### PR TITLE
feat(store-memory): implement MemoryStore with 5 test cases

### DIFF
--- a/crates/core/src/event.rs
+++ b/crates/core/src/event.rs
@@ -72,5 +72,3 @@ pub struct Event {
     /// Parent event (for correlation).
     pub parent_event_id: Option<EventId>,
 }
-
-

--- a/crates/store-memory/src/memory_store.rs
+++ b/crates/store-memory/src/memory_store.rs
@@ -1,4 +1,8 @@
 //! In-memory implementation of SessionStore.
+//!
+//! Uses `Arc<RwLock<HashMap<SessionId, Vec<Event>>>>` to support
+//! concurrent access. Data is not persisted — process restarts
+//! will lose all sessions.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -11,11 +15,15 @@ use lattice_core::{
 use tokio::sync::RwLock;
 
 /// In-memory session store for development and testing.
+///
+/// Not suitable for production — data is lost on process restart.
 pub struct MemoryStore {
+    /// Session id -> event log.
     sessions: Arc<RwLock<HashMap<SessionId, Vec<Event>>>>,
 }
 
 impl MemoryStore {
+    /// Create a new empty MemoryStore.
     #[must_use]
     pub fn new() -> Self {
         Self {
@@ -32,6 +40,7 @@ impl Default for MemoryStore {
 
 #[async_trait]
 impl SessionStore for MemoryStore {
+    /// Creates a new session and records a `SessionCreated` event.
     async fn create_session(&self) -> Result<SessionId, StoreError> {
         let session_id = SessionId::new_v4();
         let event = Event {
@@ -47,6 +56,7 @@ impl SessionStore for MemoryStore {
         Ok(session_id)
     }
 
+    /// Appends an immutable event to the session's event log.
     async fn append_event(
         &self,
         session_id: SessionId,
@@ -71,6 +81,7 @@ impl SessionStore for MemoryStore {
         Ok(event_id)
     }
 
+    /// Retrieves events for a session, applying optional filters.
     async fn get_events(
         &self,
         session_id: SessionId,
@@ -90,6 +101,7 @@ impl SessionStore for MemoryStore {
         Ok(result)
     }
 
+    /// Returns the event id of the most recent event, if any.
     async fn latest_event_id(&self, session_id: SessionId) -> Result<Option<EventId>, StoreError> {
         let sessions = self.sessions.read().await;
         let events = sessions
@@ -102,6 +114,7 @@ impl SessionStore for MemoryStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lattice_core::EventPayload;
 
     #[tokio::test]
     async fn test_create_session() {
@@ -129,5 +142,109 @@ mod tests {
             .unwrap();
         let events = store.get_events(id, &EventFilter::default()).await.unwrap();
         assert_eq!(events.len(), 2);
+        assert!(matches!(
+            events[1].payload,
+            EventPayload::UserMessage { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_filter_by_actor() {
+        let store = MemoryStore::new();
+        let id = store.create_session().await.unwrap();
+        store
+            .append_event(
+                id,
+                EventPayload::UserMessage {
+                    content: "user".to_string(),
+                },
+                Actor::System,
+                None,
+            )
+            .await
+            .unwrap();
+        store
+            .append_event(
+                id,
+                EventPayload::Thinking {
+                    reasoning: "thinking".to_string(),
+                },
+                Actor::LLM,
+                None,
+            )
+            .await
+            .unwrap();
+        store
+            .append_event(
+                id,
+                EventPayload::FinalAnswer {
+                    answer: "answer".to_string(),
+                },
+                Actor::LLM,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let llm_events = store
+            .get_events(
+                id,
+                &EventFilter {
+                    actor: Some(Actor::LLM),
+                    payload_type: None,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(llm_events.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_read_write() {
+        let store = MemoryStore::new();
+        let id = store.create_session().await.unwrap();
+
+        // Spawn multiple writers and readers concurrently.
+        let sessions_clone = store.sessions.clone();
+        let handle = tokio::spawn(async move {
+            for _ in 0..10 {
+                let sessions = sessions_clone.read().await;
+                let _count = sessions.get(&id).map(|e| e.len());
+                drop(sessions);
+                tokio::task::yield_now().await;
+            }
+        });
+
+        for i in 0..5 {
+            store
+                .append_event(
+                    id,
+                    EventPayload::UserMessage {
+                        content: format!("msg {i}"),
+                    },
+                    Actor::System,
+                    None,
+                )
+                .await
+                .unwrap();
+        }
+
+        handle.await.unwrap();
+
+        let events = store.get_events(id, &EventFilter::default()).await.unwrap();
+        // 1 session created + 5 appended
+        assert_eq!(events.len(), 6);
+    }
+
+    #[tokio::test]
+    async fn test_session_not_found() {
+        let store = MemoryStore::new();
+        let fake_id = SessionId::new_v4();
+        let result = store.get_events(fake_id, &EventFilter::default()).await;
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            StoreError::SessionNotFound(_)
+        ));
     }
 }


### PR DESCRIPTION
Implement SessionStore trait with Arc<RwLock<HashMap<...>> backed in-memory storage. Add doc comments to all pub items and tests for: create, append+retrieve, actor filtering, concurrent read/write, and session-not-found error handling.