### PR TITLE
feat(hello-agent): implement end-to-end example with MockLLMClient

### DIFF
--- a/examples/hello-agent/src/main.rs
+++ b/examples/hello-agent/src/main.rs
@@ -1,11 +1,18 @@
-//! Hello Agent: end-to-end validation of the Lattice framework.
+//! Hello Agent — end-to-end validation of the Lattice framework.
+//!
+//! Assembles `MemoryStore + LocalSandbox + BasicSandboxRouter + ControlLoop`
+//! and drives them with a `MockLLMClient` that returns a fixed two-step decision
+//! sequence: ToolCall (bash) → FinalAnswer.
+//!
+//! Run with:
+//!   cargo run --example hello-agent
 
 mod mock_llm;
 
 use std::sync::Arc;
 
 use anyhow::Result;
-use lattice_core::Actor;
+use lattice_core::{Actor, EventFilter, EventPayload};
 use lattice_runtime::{BasicSandboxRouter, ControlLoop};
 use lattice_sandbox_local::LocalSandbox;
 use lattice_store_memory::MemoryStore;
@@ -18,29 +25,45 @@ async fn main() -> Result<()> {
         .with_env_filter(EnvFilter::from_default_env().add_directive("info".parse()?))
         .init();
 
+    // ── 1. Assemble components ─────────────────────────────────────────────
     let store: Arc<dyn lattice_core::SessionStore> = Arc::new(MemoryStore::new());
     let sandbox = Arc::new(LocalSandbox::new());
-    let llm = Arc::new(mock_llm::MockLLMClient::new());
+    let llm = Arc::new(mock_llm::MockLLMClient::hello_agent_sequence());
     let router = Arc::new(BasicSandboxRouter::new(sandbox, store.clone()));
-    let control_loop = ControlLoop::new(store.clone(), llm, router);
 
+    let control_loop =
+        ControlLoop::with_options(store.clone(), llm, router, vec![], String::new(), 50);
+
+    // ── 2. Create session ───────────────────────────────────────────────────
     let session_id = control_loop.store().create_session().await?;
     info!(?session_id, "session created");
 
+    // ── 3. Append user message ──────────────────────────────────────────────
     control_loop
         .store()
         .append_event(
             session_id,
-            lattice_core::EventPayload::UserMessage {
-                content: "Hello, agent!".to_string(),
+            EventPayload::UserMessage {
+                content: "Run 'echo Hello from Lattice!' and tell me the output.".to_string(),
             },
             Actor::System,
             None,
         )
         .await?;
 
-    control_loop.run(session_id).await?;
+    // ── 4. Run the agent ────────────────────────────────────────────────────
+    let answer = control_loop.run(session_id).await?;
+    println!("\n=== Agent Answer ===");
+    println!("{}", answer);
 
-    info!("agent finished");
+    // ── 5. Print full event log ─────────────────────────────────────────────
+    let events = store
+        .get_events(session_id, &EventFilter::default())
+        .await?;
+    println!("\n=== Event Log ({} events) ===", events.len());
+    for event in &events {
+        println!("  [{:?}] {:?}", event.actor, event.payload);
+    }
+
     Ok(())
 }

--- a/examples/hello-agent/src/mock_llm.rs
+++ b/examples/hello-agent/src/mock_llm.rs
@@ -1,27 +1,45 @@
-//! Mock LLM client for hello-agent example.
+//! Mock LLM client that returns hardcoded decisions in sequence.
+//!
+//! Built on `Mutex<VecDeque<Decision>>` so decisions are consumed in order
+//! and the queue is transparent for inspection.
 
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::collections::VecDeque;
+use std::sync::Mutex;
 
 use async_trait::async_trait;
 use lattice_core::{Decision, Event, LLMClient, LLMError, ToolDescription};
 
-/// Mock LLM client that cycles through a hardcoded decision sequence.
+/// Mock LLM client that pops decisions from a queue in order.
+#[derive(Debug)]
 pub struct MockLLMClient {
-    step: AtomicUsize,
+    decisions: Mutex<VecDeque<Decision>>,
 }
 
 impl MockLLMClient {
+    /// Create a new MockLLMClient with the given decision sequence.
+    ///
+    /// Decisions are consumed in order on each call to `decide()`.
     #[must_use]
-    pub fn new() -> Self {
+    pub fn new(decisions: Vec<Decision>) -> Self {
         Self {
-            step: AtomicUsize::new(0),
+            decisions: Mutex::new(decisions.into()),
         }
     }
-}
 
-impl Default for MockLLMClient {
-    fn default() -> Self {
-        Self::new()
+    /// Create the standard hello-agent decision sequence:
+    /// 1. ToolCall to bash
+    /// 2. FinalAnswer
+    #[must_use]
+    pub fn hello_agent_sequence() -> Self {
+        Self::new(vec![
+            Decision::ToolCall {
+                tool: "bash".to_string(),
+                params: serde_json::json!({ "command": "echo Hello from Lattice!" }),
+            },
+            Decision::FinalAnswer {
+                answer: "命令执行成功，输出: Hello from Lattice!".to_string(),
+            },
+        ])
     }
 }
 
@@ -33,18 +51,9 @@ impl LLMClient for MockLLMClient {
         _available_tools: &[ToolDescription],
         _system_prompt: &str,
     ) -> Result<Decision, LLMError> {
-        let step = self.step.fetch_add(1, Ordering::SeqCst);
-        match step {
-            0 => Ok(Decision::ToolCall {
-                tool: "bash".to_string(),
-                params: serde_json::json!({ "command": "echo 'hello from sandbox'" }),
-            }),
-            1 => Ok(Decision::FinalAnswer {
-                answer: "Hello back from the agent!".to_string(),
-            }),
-            _ => Ok(Decision::FinalAnswer {
-                answer: "done".to_string(),
-            }),
-        }
+        let mut queue = self.decisions.lock().unwrap();
+        queue.pop_front().ok_or_else(|| {
+            LLMError::InvalidResponse("mock LLM: decision queue exhausted".to_string())
+        })
     }
 }


### PR DESCRIPTION
- Replace AtomicUsize counter with Mutex<VecDeque<Decision>> for transparent, ordered decision sequence
- Add MockLLMClient::hello_agent_sequence() with the required two-step decision: ToolCall(bash, echo Hello from Lattice!) → FinalAnswer
- Wire up MemoryStore + LocalSandbox + BasicSandboxRouter + ControlLoop
- Print final answer and full event log (5 events, correct causal chain)
- All crates pass: cargo test, cargo clippy, cargo fmt