### PR TITLE
feat: add lattice facade crate with feature flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,17 @@ env:
 
 jobs:
   check:
-    name: Check
+    name: Check (${{ matrix.features || 'default' }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        features:
+          - ""                                                          # default features
+          - "--no-default-features"                                      # core only
+          - "--all-features"                                             # all features
+          - "--no-default-features --features runtime,store-memory,sandbox-local,llm-anthropic"
+          - "--no-default-features --features runtime,store-memory,sandbox-local,llm-openai"
     steps:
       - uses: actions/checkout@v4
 
@@ -30,8 +39,11 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
-      - name: Test
-        run: cargo test --all-targets --all-features
+      - name: Build (feature matrix)
+        run: cargo build --all-targets ${{ matrix.features }}
+
+      - name: Test (feature matrix)
+        run: cargo test --all-targets ${{ matrix.features }}
 
       - name: Doc check
         run: cargo doc --no-deps --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,10 +322,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "lattice-core",
- "lattice-runtime",
- "lattice-sandbox-local",
- "lattice-store-memory",
+ "lattice",
  "serde",
  "serde_json",
  "tokio",
@@ -626,6 +623,19 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "lattice"
+version = "0.1.0"
+dependencies = [
+ "lattice-core",
+ "lattice-llm-anthropic",
+ "lattice-llm-openai",
+ "lattice-llm-protocol",
+ "lattice-runtime",
+ "lattice-sandbox-local",
+ "lattice-store-memory",
 ]
 
 [[package]]
@@ -974,12 +984,7 @@ name = "real-agent"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "lattice-core",
- "lattice-llm-anthropic",
- "lattice-llm-openai",
- "lattice-runtime",
- "lattice-sandbox-local",
- "lattice-store-memory",
+ "lattice",
  "serde_json",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,45 @@
+[package]
+name = "lattice"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+description = "A Rust meta-framework for building AI agents, inspired by Anthropic's managed agents architecture."
+
+[lib]
+path = "src/lib.rs"
+
+[features]
+default = ["runtime", "store-memory", "sandbox-local"]
+
+# Core runtime
+runtime = ["dep:lattice-runtime"]
+
+# Store backends
+store-memory = ["dep:lattice-store-memory"]
+
+# Sandbox implementations
+sandbox-local = ["dep:lattice-sandbox-local"]
+
+# LLM backends
+llm-protocol = ["dep:lattice-llm-protocol"]
+llm-anthropic = ["llm-protocol", "dep:lattice-llm-anthropic"]
+llm-openai = ["llm-protocol", "dep:lattice-llm-openai"]
+llm-all = ["llm-anthropic", "llm-openai"]
+
+# Convenience
+full = ["runtime", "store-memory", "sandbox-local", "llm-all"]
+
+[dependencies]
+lattice-core = { path = "crates/core" }
+lattice-runtime = { path = "crates/runtime", optional = true }
+lattice-store-memory = { path = "crates/store-memory", optional = true }
+lattice-sandbox-local = { path = "crates/sandbox-local", optional = true }
+lattice-llm-protocol = { path = "crates/llm-protocol", optional = true }
+lattice-llm-anthropic = { path = "crates/llm-anthropic", optional = true }
+lattice-llm-openai = { path = "crates/llm-openai", optional = true }
+
 [workspace]
 resolver = "2"
 members = [

--- a/examples/hello-agent/Cargo.toml
+++ b/examples/hello-agent/Cargo.toml
@@ -7,10 +7,7 @@ authors.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-lattice-core = { path = "../../crates/core" }
-lattice-runtime = { path = "../../crates/runtime" }
-lattice-store-memory = { path = "../../crates/store-memory" }
-lattice-sandbox-local = { path = "../../crates/sandbox-local" }
+lattice = { path = "../..", default-features = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/examples/hello-agent/src/main.rs
+++ b/examples/hello-agent/src/main.rs
@@ -12,10 +12,10 @@ mod mock_llm;
 use std::sync::Arc;
 
 use anyhow::Result;
-use lattice_core::{Actor, EventFilter, EventPayload};
-use lattice_runtime::{BasicSandboxRouter, ControlLoop};
-use lattice_sandbox_local::LocalSandbox;
-use lattice_store_memory::MemoryStore;
+use lattice::core::{Actor, EventFilter, EventPayload};
+use lattice::runtime::{BasicSandboxRouter, ControlLoop};
+use lattice::sandbox_local::LocalSandbox;
+use lattice::store_memory::MemoryStore;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
         .init();
 
     // ── 1. Assemble components ─────────────────────────────────────────────
-    let store: Arc<dyn lattice_core::SessionStore> = Arc::new(MemoryStore::new());
+    let store: Arc<dyn lattice::core::SessionStore> = Arc::new(MemoryStore::new());
     let sandbox = Arc::new(LocalSandbox::new());
     let llm = Arc::new(mock_llm::MockLLMClient::hello_agent_sequence());
     let router = Arc::new(BasicSandboxRouter::new(sandbox, store.clone()));

--- a/examples/hello-agent/src/mock_llm.rs
+++ b/examples/hello-agent/src/mock_llm.rs
@@ -7,7 +7,7 @@ use std::collections::VecDeque;
 use std::sync::Mutex;
 
 use async_trait::async_trait;
-use lattice_core::{Decision, Event, LLMClient, LLMError, ToolDescription};
+use lattice::core::{Decision, Event, LLMClient, LLMError, ToolDescription};
 
 /// Mock LLM client that pops decisions from a queue in order.
 #[derive(Debug)]

--- a/examples/real-agent/Cargo.toml
+++ b/examples/real-agent/Cargo.toml
@@ -7,12 +7,7 @@ authors.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-lattice-core = { path = "../../crates/core" }
-lattice-runtime = { path = "../../crates/runtime" }
-lattice-store-memory = { path = "../../crates/store-memory" }
-lattice-sandbox-local = { path = "../../crates/sandbox-local" }
-lattice-llm-anthropic = { path = "../../crates/llm-anthropic" }
-lattice-llm-openai = { path = "../../crates/llm-openai" }
+lattice = { path = "../..", features = ["full"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/examples/real-agent/src/main.rs
+++ b/examples/real-agent/src/main.rs
@@ -18,10 +18,10 @@ use std::env;
 use std::sync::Arc;
 
 use anyhow::{bail, Context, Result};
-use lattice_core::{Actor, EventFilter, EventPayload, LLMClient, SessionStore, ToolDescription};
-use lattice_runtime::{BasicSandboxRouter, ControlLoop};
-use lattice_sandbox_local::LocalSandbox;
-use lattice_store_memory::MemoryStore;
+use lattice::core::{Actor, EventFilter, EventPayload, LLMClient, SessionStore, ToolDescription};
+use lattice::runtime::{BasicSandboxRouter, ControlLoop};
+use lattice::sandbox_local::LocalSandbox;
+use lattice::store_memory::MemoryStore;
 use tracing::info;
 
 fn main() -> Result<()> {
@@ -65,14 +65,14 @@ async fn run(task: String) -> Result<()> {
     // Create the LLM client based on provider.
     let llm: Arc<dyn LLMClient> = match provider.as_str() {
         "anthropic" => {
-            let mut client = lattice_llm_anthropic::AnthropicClient::new(&api_key, &model);
+            let mut client = lattice::llm_anthropic::AnthropicClient::new(&api_key, &model);
             if let Some(base) = api_base {
                 client = client.with_base_url(base);
             }
             Arc::new(client)
         }
         _ => {
-            let mut client = lattice_llm_openai::OpenAIClient::new(&api_key, &model);
+            let mut client = lattice::llm_openai::OpenAIClient::new(&api_key, &model);
             if let Some(base) = api_base {
                 client = client.with_base_url(base);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,44 @@
+//! # Lattice
+//!
+//! A Rust meta-framework for building AI agents, inspired by Anthropic's managed
+//! agents architecture.
+//!
+//! ## Feature Flags
+//!
+//! | Feature | Default | Description |
+//! |---------|---------|-------------|
+//! | `runtime` | ✅ | ControlLoop and BasicSandboxRouter |
+//! | `store-memory` | ✅ | In-memory SessionStore implementation |
+//! | `sandbox-local` | ✅ | Local process Sandbox implementation |
+//! | `llm-protocol` | ❌ | Common LLM protocol layer |
+//! | `llm-anthropic` | ❌ | Anthropic Claude LLM backend |
+//! | `llm-openai` | ❌ | OpenAI-compatible LLM backend |
+//! | `llm-all` | ❌ | All LLM backends |
+//! | `full` | ❌ | Everything |
+
+/// Core traits and types. Always available.
+pub use lattice_core as core;
+
+/// ControlLoop implementation.
+#[cfg(feature = "runtime")]
+pub use lattice_runtime as runtime;
+
+/// In-memory SessionStore.
+#[cfg(feature = "store-memory")]
+pub use lattice_store_memory as store_memory;
+
+/// Local process Sandbox.
+#[cfg(feature = "sandbox-local")]
+pub use lattice_sandbox_local as sandbox_local;
+
+/// Common LLM protocol layer.
+#[cfg(feature = "llm-protocol")]
+pub use lattice_llm_protocol as llm_protocol;
+
+/// Anthropic Claude LLM backend.
+#[cfg(feature = "llm-anthropic")]
+pub use lattice_llm_anthropic as llm_anthropic;
+
+/// OpenAI-compatible LLM backend.
+#[cfg(feature = "llm-openai")]
+pub use lattice_llm_openai as llm_openai;


### PR DESCRIPTION
- Upgrade root Cargo.toml from pure workspace to workspace + lib (name=lattice)
- Create src/lib.rs with conditional re-exports for all sub-crates
- Define features: default (runtime, store-memory, sandbox-local), llm-protocol, llm-anthropic, llm-openai, llm-all, full
- Update hello-agent and real-agent to depend on lattice facade crate
- Update CI to test feature matrix: default, no-default, all-features, single-provider