### PR TITLE
ci: use --workspace flag for build and test steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,13 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
       - name: Build (feature matrix)
-        run: cargo build --all-targets ${{ matrix.features }}
+        run: cargo build --workspace ${{ matrix.features }}
 
       - name: Test (feature matrix)
-        run: cargo test --all-targets ${{ matrix.features }}
+        run: cargo test --workspace ${{ matrix.features }}
 
       - name: Doc check
         run: cargo doc --no-deps --all-features


### PR DESCRIPTION
The --workspace flag is needed to test all workspace members, not just the root lattice crate. Previously --all-targets only tested the facade crate itself (which has no tests), missing all sub-crate tests.