### PR TITLE
fix(ci): use codecov CLI to upload coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,4 +75,5 @@ jobs:
         run: |
           cargo llvm-cov test --workspace --all-features -- --nocapture
           cargo llvm-cov report --lcov --output-path lcov.info
-          cargo llvm-cov upload --lcov-file lcov.info
+          curl -Os https://cli.codecov.io/latest/linux/codecov && chmod +x codecov
+          ./codecov upload-process --file lcov.info --token "$CODECOV_TOKEN"


### PR DESCRIPTION
Replace unsupported cargo llvm-cov upload with curl-based codecov CLI upload.