### PR TITLE
fix(ci): use --save-cache / --load-cache to persist coverage data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Coverage
         run: |
-          cargo llvm-cov test --workspace --all-features -- --nocapture
-          cargo llvm-cov report --lcov --output-path lcov.info
+          cargo llvm-cov test --workspace --all-features --save-cache -- --nocapture
+          cargo llvm-cov report --lcov --output-path lcov.info --load-cache
           curl -Os https://cli.codecov.io/latest/linux/codecov && chmod +x codecov
-          ./codecov upload-process --file lcov.info
+          ./codecov upload-file --file lcov.info


### PR DESCRIPTION
cargo-llvm-cov test and report must run as separate commands, so coverage data must be persisted via --save-cache and reloaded via --load-cache.