### PR TITLE
fix(ci): export lcov in single cargo-llvm-cov test command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,6 @@ jobs:
 
       - name: Coverage
         run: |
-          cargo llvm-cov test --workspace --all-features --save-cache -- --nocapture
-          cargo llvm-cov report --lcov --output-path lcov.info --load-cache
+          cargo llvm-cov test --workspace --all-features --lcov --output-path lcov.info -- --nocapture
           curl -Os https://cli.codecov.io/latest/linux/codecov && chmod +x codecov
           ./codecov upload-file --file lcov.info


### PR DESCRIPTION
Previously used two commands (test + report) which lost coverage data between steps. Now use --lcov --output-path flags on test to directly export LCOV format in one step.