### PR TITLE
docs: add per-crate CLAUDE.md files for hierarchical context loading

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,29 +28,32 @@ Lattice 是一个 Rust 编写的 **Agent 元框架**，核心思想来自 Anthro
 
 ```
 crates/
-├── core/           # 核心 trait + 类型定义（零外部依赖，纯接口）
-│                   #   ToolDescription（已有）+ ToolExecutor trait（新增）
-├── runtime/        # ControlLoop 实现（接收 ToolSet）
-├── store-memory/   # SessionStore 内存实现（开发/测试用）
-├── sandbox-local/  # Sandbox 本地子进程实现
-├── llm-protocol/   # LLM 通用协议层（消息格式转换、响应解析）
-├── llm-anthropic/  # LLMClient 的 Anthropic Claude 实现
-├── llm-openai/     # LLMClient 的 OpenAI 兼容实现
-├── tools/          # 标准工具库（bash, file, glob, grep, http）
-├── server/         # HTTP API 服务（axum），平台服务入口（第四轮）
+├── core/             # 核心 trait + 类型定义（零外部依赖，纯接口）
+├── runtime/          # ControlLoop 实现（接收 ToolSet）
+├── store-memory/     # SessionStore 内存实现（开发/测试用）
+├── sandbox-local/    # Sandbox 本地子进程实现
+├── llm-protocol/     # LLM 通用协议层（消息格式转换、响应解析）
+├── llm-anthropic/    # LLMClient 的 Anthropic Claude 实现
+├── llm-openai/       # LLMClient 的 OpenAI 兼容实现
+├── tools/            # 标准工具库（bash, file, glob, grep, http）
+├── server/           # HTTP API 服务（axum），平台服务入口
 
 # Facade crate（根目录 src/lib.rs）
-lattice                 # 通过 feature flags 重导出所有子 crate
+lattice               # 通过 feature flags 重导出所有子 crate
 ```
 
-## Feature Flag 策略
+每个 crate 都有其专属的 `CLAUDE.md` 文件，包含该 crate 的关键类型、设计决策、已知问题和依赖关系。工作在该 crate 目录时，Claude Code 会自动加载对应的上下文。
 
-- **core**：零 feature，纯接口
-- **facade `lattice`**：default = runtime + store-memory + sandbox-local；可选 llm-anthropic、llm-openai、llm-all、full
-- **server**：default = anthropic + openai；按 feature 控制编译哪些 provider/sandbox/store
-- 新增实现 crate 时必须同步更新 facade 的 feature 定义
+| Crate | CLAUDE.md |
+|-------|-----------|
+| `runtime` | [crates/runtime/CLAUDE.md](crates/runtime/CLAUDE.md) |
+| `tools` | [crates/tools/CLAUDE.md](crates/tools/CLAUDE.md) |
+| `llm-protocol` | [crates/llm-protocol/CLAUDE.md](crates/llm-protocol/CLAUDE.md) |
+| `llm-anthropic` | [crates/llm-anthropic/CLAUDE.md](crates/llm-anthropic/CLAUDE.md) |
+| `llm-openai` | [crates/llm-openai/CLAUDE.md](crates/llm-openai/CLAUDE.md) |
+| `server` | [crates/server/CLAUDE.md](crates/server/CLAUDE.md) |
 
-## 代码规范
+## 跨 crate 规范
 
 - **语言**：Rust 2021 edition
 - **异步运行时**：tokio
@@ -60,7 +63,7 @@ lattice                 # 通过 feature flags 重导出所有子 crate
 - **语言约定**：文档用中文，代码注释全部用英文（包括 `///` doc comment 和 `//` 行内注释）
 - **测试**：每个 crate 必须有单元测试，trait 实现必须有集成测试
 - **commit 信息**：`<type>(<scope>): <description>`，如 `feat(core): define SessionStore trait`
-- **模块文件**：使用 `foo.rs` 而非 `foo/mod.rs`；子模块文件与父模块同级存放（如 `api.rs` + `api/sessions.rs` + `api/types.rs`）
+- **模块文件**：使用 `foo.rs` 而非 `foo/mod.rs`；子模块文件与父模块同级存放
 
 ## 实现任务时的工作流
 

--- a/crates/llm-anthropic/CLAUDE.md
+++ b/crates/llm-anthropic/CLAUDE.md
@@ -1,0 +1,32 @@
+# lattice-llm-anthropic
+
+## Purpose
+
+Implements `lattice_core::LLMClient` using the Anthropic Messages API. Wraps HTTP calls to the Anthropic API, serializes requests using types from `lattice-llm-protocol`, and parses responses back into Lattice decisions.
+
+## Key Types
+
+- `AnthropicClient` — the main client. Created via `AnthropicClient::new()`. Takes an HTTP client (default: reqwest) and API credentials.
+
+## Design Decisions
+
+- Uses the Anthropic Messages API (not the older Completions API).
+- API key is read from the `ANTHROPIC_API_KEY` environment variable.
+- Request timeout is hardcoded to 120s — see #34.
+- System messages: Anthropic uses a dedicated `system` role in the messages array. There is a known bug where system messages are silently remapped to the user role — see #33.
+
+## Patterns
+
+- Request building: converts `LLMRequest` from `lattice-llm-protocol` into Anthropic-specific JSON payload.
+- Response parsing: deserializes Anthropic response body, then calls `response_to_decision()` from `lattice-llm-protocol`.
+- Error handling: HTTP errors are wrapped as `LlmError::RequestFailed` variants.
+
+## Known Issues
+
+- [#33](https://github.com/hhllhhyyds/Lattice/issues/33) — AnthropicClient silently maps Role::System to user role
+- [#34](https://github.com/hhllhhyyds/Lattice/issues/34) — HTTP timeout hardcoded to 120s
+
+## Dependencies
+
+- Depends on: `lattice-core`, `lattice-llm-protocol`
+- Depended on by: `lattice-server`

--- a/crates/llm-openai/CLAUDE.md
+++ b/crates/llm-openai/CLAUDE.md
@@ -1,0 +1,33 @@
+# lattice-llm-openai
+
+## Purpose
+
+Implements `lattice_core::LLMClient` using the OpenAI Chat Completions API format. Compatible with OpenAI, local deployments (vLLM, Ollama), and third-party proxies that follow the OpenAI tool-calling schema.
+
+## Key Types
+
+- `OpenAIClient` — the main client. Created via `OpenAIClient::new()` with a base URL and API key.
+
+## Design Decisions
+
+- Uses the OpenAI Chat Completions API (`/v1/chat/completions`).
+- Tool calls use the OpenAI `function` calling schema. Multi-tool-call handling has a known bug — see #27.
+- Base URL is configurable to support local deployments and proxies.
+- Request timeout is hardcoded to 120s — see #34.
+
+## Patterns
+
+- Request building: converts `LLMRequest` from `lattice-llm-protocol` into OpenAI JSON payload.
+- Response parsing: handles both text responses and tool call responses. Tool call results are correlated via `parent_event_id` — see #28.
+- Streaming: not currently supported.
+
+## Known Issues
+
+- [#27](https://github.com/hhllhhyyds/Lattice/issues/27) — OpenAI client silently drops parallel tool calls
+- [#28](https://github.com/hhllhhyyds/Lattice/issues/28) — Tool call ID correlation is fragile, should use `parent_event_id`
+- [#34](https://github.com/hhllhhyyds/Lattice/issues/34) — HTTP timeout hardcoded to 120s
+
+## Dependencies
+
+- Depends on: `lattice-core`, `lattice-llm-protocol`
+- Depended on by: `lattice-server`

--- a/crates/llm-protocol/CLAUDE.md
+++ b/crates/llm-protocol/CLAUDE.md
@@ -1,0 +1,35 @@
+# lattice-llm-protocol
+
+## Purpose
+
+Provider-agnostic message types and conversion logic. Bridges Lattice's event-sourced architecture and the various LLM provider APIs. This is the single translation layer — LLM clients delegate to it rather than implementing conversion themselves.
+
+## Key Types
+
+- `Message` / `ContentBlock` / `Role` — universal message format used by all LLM clients
+- `events_to_messages()` — converts Lattice `Event` stream into LLM message list
+- `response_to_decision()` — parses LLM raw response into `lattice_core::Decision`
+- `LLMRequest` / `LLMResponse` — provider-agnostic request/response wrappers
+- `ToolSpec` — describes a tool for the LLM (name, description, input schema)
+
+## Design Decisions
+
+- All message conversion lives here — `AnthropicClient` and `OpenAIClient` call into this crate rather than duplicating conversion logic.
+- `Role::System` is treated specially: in most providers it maps to a system message, but AnthropicClient has a known bug where it silently maps system to user role (see #33).
+- Events are filtered before conversion: internal events (run lifecycle, error states) do not become LLM messages. Only user input and model output become conversation context.
+
+## Patterns
+
+- `convert::` module: event → message conversion
+- `parse::` module: response → decision parsing
+- `request::` / `response::` modules: wire format types
+
+## Known Issues
+
+- [#28](https://github.com/hhllhhyyds/Lattice/issues/28) — Tool call ID correlation is fragile, should use `parent_event_id`
+- [#31](https://github.com/hhllhhyyds/Lattice/issues/31) — Thinking events leak into LLM conversation as assistant messages
+
+## Dependencies
+
+- Depends on: `lattice-core`
+- Depended on by: `lattice-runtime`, `lattice-llm-anthropic`, `lattice-llm-openai`

--- a/crates/runtime/CLAUDE.md
+++ b/crates/runtime/CLAUDE.md
@@ -1,0 +1,33 @@
+# lattice-runtime
+
+## Purpose
+
+Implements the agent control loop — the central orchestrator that loads event history, calls the LLM for decisions, routes tool calls, and records results. It is stateless and recovers all state from the SessionStore.
+
+## Key Types
+
+- `ControlLoop` — the agent brain, drives the decision cycle. Receives `Arc<dyn SessionStore>`, `Arc<dyn LLMClient>`, and `Arc<ToolSet>`. Run via `.run(session_id).await`.
+
+## Design Decisions
+
+- **Stateless**: ControlLoop holds no persistent state. All state is reconstructed from `SessionStore` on each iteration.
+- **Event-sourced**: Every LLM call, tool call, and result is appended as an immutable event to the session log.
+- **ToolSet abstraction**: All tools (bash, file, glob, etc.) are behind a unified `ToolSet` interface. ControlLoop never knows whether a tool runs in-process or in a subprocess sandbox.
+- **No model-specific hardcoding**: Framework code must never contain logic branching on the LLM model name or version.
+
+## Patterns
+
+- `ControlLoop::run()` fetches all events for a session, converts them to LLM messages, calls the LLM, parses the response into decisions, executes tool calls, and appends results back to the session store.
+- Tool calls are correlated to events via `parent_event_id`.
+- All error paths emit `ToolCallError` or `RunError` events rather than returning errors up the stack.
+
+## Known Issues
+
+- [#26](https://github.com/hhllhhyyds/Lattice/issues/26) — ControlLoop reloads ALL events every iteration → O(n²) performance
+- [#31](https://github.com/hhllhhyyds/Lattice/issues/31) — Thinking events leak into LLM conversation as assistant messages
+- [#32](https://github.com/hhllhhyyds/Lattice/issues/32) — ToolError type information lost when recording ToolCallError events
+
+## Dependencies
+
+- Depends on: `lattice-core`, `lattice-llm-protocol`, `lattice-tools`
+- Depended on by: `lattice` (facade), `lattice-server`

--- a/crates/server/CLAUDE.md
+++ b/crates/server/CLAUDE.md
@@ -1,0 +1,46 @@
+# lattice-server
+
+## Purpose
+
+HTTP API server built on axum. Exposes the Lattice agent framework as a REST API with session management, event querying, and (in the future) message submission and run triggering. Supports multiple LLM providers via feature flags.
+
+## Key Types
+
+- `AppState` — global shared state: `store`, `active_runs`, `started_at`, `sessions`
+- `Router` — built via `router()` / `app()`, mounts `/health` and `/v1` route groups
+- `RunHandle` / `RunStatus` — tracks in-flight agent runs with abort support
+
+## API Routes
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/health` | Health check (status, version, uptime, enabled features) |
+| POST | `/v1/sessions` | Create a new session |
+| GET | `/v1/sessions` | List all sessions |
+| GET | `/v1/sessions/:id` | Get session details |
+| GET | `/v1/sessions/:id/events` | Get events (supports `actor`, `eventType`, `after`, `limit` filters) |
+| POST | `/v1/sessions/:id/runs` | *(planned)* Trigger an agent run |
+
+## Design Decisions
+
+- State is shared via `Arc<AppState>`. `active_runs` and `sessions` use `Arc<RwLock<...>>` for interior mutability.
+- Routes are registered under `/v1` prefix via `v1_routes()`.
+- CORS is open (`allow_origin(Any)`) for development convenience.
+- Feature-gated LLM providers: `anthropic` and `openai` features control which clients are compiled.
+
+## Patterns
+
+- All handler functions return `Result<Json<T>, AppError>`.
+- Error responses follow `{ error: { code: "...", message: "..." } }` format.
+- Feature flags: `default = anthropic + openai`; individual providers can be disabled.
+
+## Known Issues
+
+- [#29](https://github.com/hhllhhyyds/Lattice/issues/29) — Server API is read-only, missing message submission and run trigger endpoints
+- [#37](https://github.com/hhllhhyyds/Lattice/issues/37) — Server startup banner shows "UNKEN" instead of "LATTICE"
+- [#38](https://github.com/hhllhhyyds/Lattice/issues/38) — Server lacks graceful shutdown handling
+
+## Dependencies
+
+- Depends on: `lattice-core`, `lattice-runtime`, `lattice-store-memory`
+- Depended on by: (public-facing service)

--- a/crates/tools/CLAUDE.md
+++ b/crates/tools/CLAUDE.md
@@ -1,0 +1,35 @@
+# lattice-tools
+
+## Purpose
+
+Standard tool library for Lattice. Provides the `ToolSet` registry and built-in tool implementations (bash, file, glob, grep, http). All tools implement `lattice_core::ToolExecutor`.
+
+## Key Types
+
+- `ToolSet` — registry of available tools, indexed by name. Used by `ControlLoop` to route tool calls.
+- `BashTool` — executes shell commands in a subprocess sandbox. Currently holds `Arc<dyn Sandbox>` but this creates a dependency coupling issue (see #36).
+
+## Tool Layer Architecture
+
+```
+Layer 1 (core):       ToolExecutor trait (interface only)
+Layer 2 (lattice-tools): Standard tool library (BashTool, FileTool, etc.)
+Layer 3 (application): User-defined tools injected into ToolSet
+```
+
+`ControlLoop` calls `ToolSet::execute()` — it never distinguishes between in-process and sandboxed execution.
+
+## Design Decisions
+
+- Tools are registered at startup via `ToolSet::with_defaults()` or manually via `ToolSet::register()`.
+- Each tool describes itself with a `ToolDescription` (name, description, input schema) returned by `ToolExecutor::describe()`.
+- Tool execution errors are wrapped as `ToolError` and emitted as `ToolCallError` events.
+
+## Known Issues
+
+- [#36](https://github.com/hhllhhyyds/Lattice/issues/36) — BashTool holds Arc<dyn Sandbox> but lattice-tools depends on lattice-sandbox-local, creating circular coupling risk
+
+## Dependencies
+
+- Depends on: `lattice-core`
+- Depended on by: `lattice-runtime`


### PR DESCRIPTION
Introduce hierarchical CLAUDE.md files for the 6 largest crates: runtime, tools, llm-protocol, llm-anthropic, llm-openai, server.

Each file contains: purpose, key types, design decisions, known issues (linked to GitHub issues), and dependencies. The root CLAUDE.md is trimmed to project-level concerns and gains a crate index table.

This reduces token waste when an agent works on a specific crate by loading only relevant context, and keeps documentation close to the code it describes.