### PR TITLE
docs: enforce TDD workflow — tests first, human review, then implement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,11 @@ Lattice 是一个 Rust 编写的 **Agent 元框架**，核心思想来自 Anthro
 5. **ControlLoop 无状态**：控制循环不持有持久状态，可从 SessionStore 的事件流中随时恢复。
 6. **Feature 组合，按需裁剪**：所有非核心功能通过 Rust feature flags 控制。core crate 零 feature（纯接口），实现 crate 独立成包，facade crate `lattice` 通过 feature 重导出。消费者只编译需要的部分。
 7. **工具三层体系**：工具分三层——core 定义 `ToolExecutor` trait（Layer 1）、`lattice-tools` 提供标准工具库（Layer 2）、应用层注入自定义工具（Layer 3）。ControlLoop 通过 `ToolSet` 统一调用，不区分工具背后是沙箱执行还是进程内执行。
+8. **TDD: Tests First, Code Second.**
+   - For every task, write tests BEFORE implementation.
+   - Tests must be reviewable independently — push tests as a separate commit or PR.
+   - Wait for human approval of tests before writing implementation code.
+   - Tests define the contract. Implementation fulfills it.
 
 ## 文档索引
 
@@ -69,7 +74,14 @@ lattice               # 通过 feature flags 重导出所有子 crate
 
 1. 先读 `docs/ARCHITECTURE.md` 理解整体设计
 2. 确认要实现的组件在 `docs/ROADMAP.md` 路线图范围内
-3. 按架构文档中的 trait 定义编写代码
-4. 写测试，运行 `./scripts/check.sh` 确保 fmt + clippy + test + doc 全部通过
-5. 如有 `.env` 文件，运行 `./scripts/test-local.sh` 跑真实 LLM 集成测试
-6. 提交时遵守 commit 信息规范
+3. **TDD Phase 1（测试先行）**：先写会失败的测试（单元测试 + 集成测试），定义功能的预期行为
+   - 测试文件必须能编译但断言会失败（Red 阶段）
+   - 用 `test: add tests for #XX (<feature name>)` 提交测试
+   - **停下来等人工审查测试**
+4. **人工审查测试**：确认测试覆盖了你期望的行为、无遗漏的边界情况后再继续
+5. **TDD Phase 2（实现）**：人工批准测试后，实现最小代码让所有测试通过
+   - 用 `feat: implement #XX (<feature name>)` 提交实现
+6. 运行 `./scripts/check.sh` 确保 fmt + clippy + test + doc 全部通过
+7. 如有 `.env` 文件，运行 `./scripts/test-local.sh` 跑真实 LLM 集成测试
+8. AI 自我 review 后提交人工审查
+9. 提交时遵守 commit 信息规范

--- a/docs/AI_WORKFLOW.md
+++ b/docs/AI_WORKFLOW.md
@@ -10,6 +10,7 @@ Lattice 项目全程使用 AI 辅助编程（Claude Code）。本文档定义了
 2. **CLAUDE.md 是入口**：Claude Code 通过 CLAUDE.md 找到所有需要的上下文
 3. **小步快跑**：每次任务范围小而明确，一个 PR 解决一个问题
 4. **测试先行**：每次实现必须附带测试
+5. **TDD：测试优先于实现**：测试是规格的具体化；先让人审查测试（确认要做什么），再实现代码（确认怎么做）
 
 ## 工作流阶段
 
@@ -35,13 +36,22 @@ Lattice 项目全程使用 AI 辅助编程（Claude Code）。本文档定义了
 
 ### 阶段 3：Implement（实现）
 
-**由 Claude Code 完成**。
+**TDD Phase 1 — 写测试（先于实现）**：
 
 - 每个任务启动一个 Claude Code session
-- Claude Code 读取 CLAUDE.md → 找到相关文档 → 理解上下文 → 编写代码
+- Claude Code 读取 CLAUDE.md → 找到相关文档 → 理解上下文
+- **先写会失败的测试**，定义功能的预期行为（单元测试 + 集成测试）
+- 测试文件必须能编译，但断言会失败（Red 阶段）
 - 一个任务对应一个 feature 分支：`feat/<task-name>`
+- 提交消息格式：`test: add tests for #XX (<feature name>)`
+- **停下来，等人工审查测试**
 
-**给 Claude Code 的标准指令模板**：
+**TDD Phase 2 — 实现代码（等测试批准后）**：
+
+- 人工批准测试后，Claude Code 实现最小代码让所有测试通过
+- 提交消息格式：`feat: implement #XX (<feature name>)`
+
+**给 Claude Code 的标准指令模板（Phase 1）**：
 
 ```
 读取 CLAUDE.md 了解项目上下文。
@@ -49,11 +59,33 @@ Lattice 项目全程使用 AI 辅助编程（Claude Code）。本文档定义了
 任务：<具体任务描述>
 
 要求：
-1. 按照 docs/ARCHITECTURE.md 中的 trait 定义实现
-2. 写单元测试和集成测试
-3. 运行 `./scripts/check.sh` 确保全部通过
-4. 完成后提交到 feat/<branch-name> 分支
+1. 先写会失败的测试（单元测试 + 集成测试），定义预期行为
+2. 测试必须能编译，但断言会失败（Red）
+3. 用 "test: add tests for #XX (<feature name>)" 提交
+4. 停下来等人工审查测试
 ```
+
+**给 Claude Code 的标准指令模板（Phase 2）**：
+
+```
+人工已批准测试。现在实现最小代码让所有测试通过。
+
+要求：
+1. 实现前先跑测试确认处于 Red 状态
+2. 实现后确保所有测试通过（Green）
+3. 如需要可做重构（Refactor）
+4. 运行 `./scripts/check.sh` 确保全部通过
+5. 用 "feat: implement #XX (<feature name>)" 提交
+```
+
+### TDD 为什么重要
+
+测试是最容易理解的规格形式。人工审查测试代码时，审查的是**功能要做什么**（而非代码怎么实现）。这比混在一起的测试+实现更容易理解，也更容易发现理解偏差。
+
+- **质量**：Bug 在规格阶段捕获，而非实现后
+- **沟通**：人和 AI 通过测试共享同一份理解
+- **效率**：不会在错误理解的需求上浪费实现工作
+- **可追溯**：先写测试的 commit 证明了测试是独立于实现完成的
 
 ### 阶段 4：Test（测试验证）
 


### PR DESCRIPTION
Split every task into two explicit phases:
- Phase 1: write failing tests, submit for human review
- Phase 2: implement code once tests are approved

CLAUDE.md gains principle #8 (TDD: Tests First, Code Second) and a revised task execution flow that explicitly stops for human test review.

AI_WORKFLOW.md adds TDD to core principles, splits Implement phase into two sub-phases with separate Claude Code prompt templates, and adds a "Why TDD Matters" section explaining the rationale.