### PR TITLE
docs: clarify ToolDescription belongs to core/tool, not llm module

### DIFF
--- a/docs/AI_WORKFLOW.md
+++ b/docs/AI_WORKFLOW.md
@@ -141,15 +141,42 @@ Review 当前分支相对于 main 的所有改动（git diff main...HEAD）。
 
 **由 Claude Code 完成**，在 AI Review 通过后、人工 Review 之前执行。
 
-代码改完了不算完——文档必须跟着代码走。每次任务完成后，检查并更新以下文档：
+代码改完了不算完——文档必须跟着代码走。每次任务完成后，从修改的代码位置出发，**自下而上**扫描哪些文档需要更新：
 
-1. **CLAUDE.md**：如果新增了 crate、修改了 crate 结构、改变了核心原则，更新对应段落
-2. **docs/ARCHITECTURE.md**：如果引入了新的 trait、数据结构、组件交互方式，更新架构描述
-3. **docs/TECH_STACK.md**：如果引入了新的依赖（如 axum、tower-http、toml），添加选型理由
-4. **docs/ROADMAP.md**：将当前任务状态从 ⬜ 更新为 ✅
-5. **tasks/README.md**：同步任务状态
-6. **tasks/<当前任务>.md**：勾选验收标准中已完成的项
-7. **目录结构约定**（本文档最后一节）：如果文件结构有变化，保持一致
+```
+从修改的代码位置向上追溯：
+1. 修改的代码属于哪个 crate？
+   → 更新 crates/<crate>/CLAUDE.md（如该 crate 有专属 CLAUDE.md）
+2. 修改影响了哪些 trait 接口、组件交互、数据流？
+   → 更新 docs/ARCHITECTURE.md
+3. 引入了新依赖？
+   → 更新 docs/TECH_STACK.md
+4. 任务在 tasks/ 中有对应条目？
+   → 更新 tasks/README.md 和 tasks/<当前任务>.md（状态 ⬜ → ✅）
+5. 任务属于哪个里程碑？
+   → 更新 docs/ROADMAP.md
+6. 对整个项目结构或核心原则有影响？
+   → 更新根目录 CLAUDE.md（如文档索引、crate 结构图、跨 crate 规范）
+```
+
+**每个 crate 的 CLAUDE.md 更新原则**：当修改涉及该 crate 内部实现时，必须同步更新该 crate 的 CLAUDE.md。CLAUDE.md 的定位是"该 crate 内部的关键类型、设计决策、已知问题"，而非全局视角——所以它最接近代码，最需要跟着代码走。
+
+**根目录 CLAUDE.md 的更新范围**（全局视角，只写顶层结论）：
+1. 新增 crate → 更新"文档索引"和"crate 结构"两节
+2. 修改了跨 crate 规范（如新的 trait、新的接口约定）→ 更新对应段落
+3. 里程碑完成 → 更新 ROADMAP.md 状态
+
+**文档检查清单**（每次任务完成后逐项确认）：
+
+| 文档 | 触发条件 |
+|------|----------|
+| `crates/<crate>/CLAUDE.md` | 修改了该 crate 内部实现 |
+| `docs/ARCHITECTURE.md` | 新增/修改了 trait、数据结构、组件交互 |
+| `docs/TECH_STACK.md` | 新增依赖 |
+| `docs/ROADMAP.md` | 任务状态变更 |
+| `tasks/README.md` | 任务状态变更 |
+| `tasks/<任务>.md` | 验收标准完成 |
+| `CLAUDE.md`（根目录）| crate 结构变化、核心原则变化 |
 
 **原则**：
 - 文档即真相——如果文档和代码不一致，后来的人（包括 AI）会被误导
@@ -159,13 +186,13 @@ Review 当前分支相对于 main 的所有改动（git diff main...HEAD）。
 **给 Claude Code 的文档更新指令**（可附加在实现指令末尾）：
 
 ```
-实现完成后，检查并更新以下文档（如有变化）：
-- CLAUDE.md（crate 结构、核心原则）
-- docs/ARCHITECTURE.md（新 trait/组件/数据流）
-- docs/TECH_STACK.md（新依赖及选型理由）
-- docs/ROADMAP.md（任务状态 ⬜ → ✅）
-- tasks/README.md（任务状态同步）
-- tasks/<当前任务>.md（验收标准打勾）
+实现完成后，从修改的代码向上追溯，执行以下文档检查：
+1. 更新 crates/<crate>/CLAUDE.md（如果修改了该 crate 内部）
+2. 更新 docs/ARCHITECTURE.md（trait/组件/数据流变化）
+3. 更新 docs/TECH_STACK.md（新依赖）
+4. 更新 docs/ROADMAP.md（任务状态 ⬜ → ✅）
+5. 更新 tasks/README.md 和 tasks/<当前任务>.md
+6. 评估是否需要更新根目录 CLAUDE.md
 ```
 
 ### 阶段 7：人工 Review（最终审查）

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -196,14 +196,6 @@ pub enum Decision {
     ToolCall { tool: String, params: serde_json::Value },
     FinalAnswer { answer: String },
 }
-
-/// 工具描述（注入给 LLM）
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ToolDescription {
-    pub name: String,
-    pub description: String,
-    pub parameters_schema: serde_json::Value,
-}
 ```
 
 ### 3. Sandbox（沙箱）—— Agent 的双手
@@ -468,15 +460,15 @@ Lattice 在此基础上做了一个重要的分层：将「工具描述」（给
 /// A tool that can be executed by the agent.
 ///
 /// Implementations can be in-process (file read, HTTP fetch) or delegate
-/// to a Sandbox (bash, python). The ControlLoop does not distinguish
-/// between the two — it only calls `execute()`.
+/// to a Sandbox (bash, python). The ControlLoop treats all tools identically
+/// through this trait.
 #[async_trait]
 pub trait ToolExecutor: Send + Sync {
     /// Return the tool description for LLM consumption.
     fn description(&self) -> ToolDescription;
 
     /// Execute the tool with the given parameters.
-    async fn execute(&self, params: serde_json::Value) -> Result<ExecutionResult, SandboxError>;
+    async fn execute(&self, params: serde_json::Value) -> Result<ExecutionResult, ToolError>;
 }
 ```
 
@@ -488,9 +480,6 @@ pub trait ToolExecutor: Send + Sync {
 /// ToolSet serves two roles:
 /// 1. Provide tool descriptions to the LLM (via `descriptions()`)
 /// 2. Route tool calls to the correct executor (via `execute()`)
-///
-/// This replaces the previous pattern of separate `Vec<ToolDescription>` +
-/// `SandboxRouter` with a unified abstraction.
 pub struct ToolSet {
     tools: HashMap<String, Box<dyn ToolExecutor>>,
 }
@@ -499,22 +488,16 @@ impl ToolSet {
     pub fn new() -> Self { ... }
 
     /// Build a ToolSet with all default tools enabled by feature flags.
+    /// Currently includes BashTool (if the `bash` feature is enabled).
+    #[cfg(feature = "bash")]
     pub fn with_defaults(sandbox: Arc<dyn Sandbox>) -> Self {
         let mut set = Self::new();
-        #[cfg(feature = "bash")]
-        set.add(BashTool::new(sandbox));
-        #[cfg(feature = "file")]
-        {
-            set.add(FileReadTool::new());
-            set.add(FileWriteTool::new());
-            set.add(GlobTool::new());
-            set.add(GrepTool::new());
-        }
+        set.register(BashTool::new(sandbox)).unwrap();
         set
     }
 
-    /// Register a tool. Panics if a tool with the same name already exists.
-    pub fn add(&mut self, tool: impl ToolExecutor + 'static) { ... }
+    /// Register a tool. Returns error if a tool with the same name already exists.
+    pub fn register(&mut self, tool: impl ToolExecutor + 'static) -> Result<(), ToolError> { ... }
 
     /// List all tool descriptions (passed to LLMClient::decide).
     pub fn descriptions(&self) -> Vec<ToolDescription> { ... }
@@ -524,7 +507,7 @@ impl ToolSet {
         &self,
         name: &str,
         params: serde_json::Value,
-    ) -> Result<ExecutionResult, SandboxError> { ... }
+    ) -> Result<ExecutionResult, ToolError> { ... }
 }
 ```
 
@@ -545,13 +528,16 @@ impl ToolExecutor for BashTool {
     fn description(&self) -> ToolDescription { /* bash tool schema */ }
 
     async fn execute(&self, params: serde_json::Value) -> Result<ExecutionResult, ToolError> {
-        let command = params["command"].as_str().ok_or(ToolError::InvalidParams(
-            "missing 'command' field".to_string(),
-        ))?;
+        let command = params
+            .get("command")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ToolError::InvalidParams(
+                "missing or invalid 'command' field (expected string)".to_string(),
+            ))?;
         self.sandbox
             .execute(command, params.clone())
             .await
-            .map_err(ToolError::ExecutionFailed)
+            .map_err(|e| ToolError::ExecutionFailed(e.to_string()))
     }
 }
 ```
@@ -583,6 +569,8 @@ impl ToolExecutor for FileReadTool {
 }
 ```
 
+> **注意**：FileReadTool 及其他进程内工具（glob、grep、http）尚未实现，此处为设计示例。目前已实现的标准工具仅有 BashTool。
+
 ### ToolSet 与 SandboxRouter 的关系
 
 `ToolSet` 统一了工具描述和工具执行两个职责，取代了之前的 `Vec<ToolDescription>` + `SandboxRouter` 分离模式。
@@ -596,6 +584,11 @@ let control_loop = ControlLoop::with_options(store, llm, router, vec![], prompt,
 // After:
 let tools = Arc::new(ToolSet::with_defaults(sandbox));
 let control_loop = ControlLoop::new(store, llm, tools);
+
+// Register custom tools:
+let mut tools = ToolSet::with_defaults(sandbox);
+tools.register(MyCustomTool::new()).unwrap();
+let control_loop = ControlLoop::new(store, llm, Arc::new(tools));
 ```
 
 ### 测试覆盖率
@@ -611,15 +604,17 @@ let control_loop = ControlLoop::new(store, llm, tools);
 
 ```
 crates/
-├── core/           # ToolDescription（已有）+ ToolExecutor trait（新增）
-├── tools/          # lattice-tools: 标准工具库（新 crate）
-│   ├── bash.rs     #   BashTool（沙箱工具）
-│   ├── file.rs     #   FileReadTool, FileWriteTool（进程内工具）
-│   ├── glob.rs     #   GlobTool（进程内工具）
-│   ├── grep.rs     #   GrepTool（进程内工具）
-│   └── http.rs     #   HttpTool（进程内工具，可选 reqwest）
-├── runtime/        # ControlLoop 改为接收 ToolSet
-└── server/         # 构建 ToolSet::with_defaults() 传入 ControlLoop
+├── core/           # SessionStore, LLMClient, Sandbox, ToolExecutor traits + core types
+├── tools/          # lattice-tools: 标准工具库
+│   ├── set.rs      #   ToolSet 注册表
+│   └── bash.rs     #   BashTool（沙箱工具）
+├── runtime/        # ControlLoop（接收 Arc<ToolSet>）
+├── store-memory/   # SessionStore 内存实现
+├── sandbox-local/  # Sandbox 本地子进程实现
+├── llm-protocol/   # LLM 通用协议层（消息格式转换、响应解析）
+├── llm-anthropic/  # Anthropic Claude 后端
+├── llm-openai/     # OpenAI 兼容后端
+└── server/         # HTTP API 服务（axum）
 ```
 
 #### Feature Flags
@@ -631,17 +626,11 @@ name = "lattice-tools"
 
 [features]
 default = ["bash"]
-bash = ["dep:lattice-sandbox-local"]
-file = []
-glob = ["dep:glob"]
-grep = ["dep:grep"]
-http = ["dep:reqwest"]
-full = ["bash", "file", "glob", "grep", "http"]
+bash = ["lattice-sandbox-local"]
 
 [dependencies]
 lattice-core = { path = "../core" }
 lattice-sandbox-local = { path = "../sandbox-local", optional = true }
-# ...
 ```
 
 Facade crate 同步更新：
@@ -649,9 +638,9 @@ Facade crate 同步更新：
 ```toml
 # 根 Cargo.toml (lattice facade)
 [features]
+default = ["runtime", "store-memory", "sandbox-local", "tools"]
 tools = ["dep:lattice-tools"]
-tools-full = ["tools", "lattice-tools/full"]
-full = ["runtime", "store-memory", "sandbox-local", "llm-all", "tools-full"]
+full = ["runtime", "store-memory", "sandbox-local", "llm-all", "tools"]
 ```
 
 ### 未来扩展


### PR DESCRIPTION
- Remove ToolDescription struct from LLMClient trait section in ARCHITECTURE.md (it is defined in crates/core/src/tool.rs, belongs to Layer 1 tool infrastructure)
- Update core/ crate structure comment to list all major traits
- Rewrite section 6 of AI_WORKFLOW.md with bottom-up doc scanning logic: crate CLAUDE.md → ARCHITECTURE.md → TECH_STACK.md → ROADMAP.md → root CLAUDE.md
- Add trigger-condition table so AI knows when each doc needs updating