### PR TITLE
feat: optimize ControlLoop to fetch events only once (Issue #26)

### DIFF
--- a/crates/runtime/src/control_loop.rs
+++ b/crates/runtime/src/control_loop.rs
@@ -925,13 +925,8 @@ mod tests {
         let llm = Arc::new(TestLLM::with_sequence(decisions));
         let tools = make_tools();
 
-        let control_loop = crate::ControlLoop::with_options(
-            Arc::new(store),
-            llm,
-            tools,
-            "prompt".into(),
-            10,
-        );
+        let control_loop =
+            crate::ControlLoop::with_options(Arc::new(store), llm, tools, "prompt".into(), 10);
 
         let result = control_loop.run(session_id).await.unwrap();
         assert_eq!(result, "done");

--- a/crates/runtime/src/control_loop.rs
+++ b/crates/runtime/src/control_loop.rs
@@ -288,12 +288,23 @@ mod tests {
 
     /// Manual test double for LLMClient.
     struct TestLLM {
-        decision: Decision,
+        decisions: Arc<Mutex<Vec<Decision>>>,
+        current_index: Arc<Mutex<usize>>,
     }
 
     impl TestLLM {
         fn new(decision: Decision) -> Self {
-            Self { decision }
+            Self {
+                decisions: Arc::new(Mutex::new(vec![decision])),
+                current_index: Arc::new(Mutex::new(0)),
+            }
+        }
+
+        fn with_sequence(decisions: Vec<Decision>) -> Self {
+            Self {
+                decisions: Arc::new(Mutex::new(decisions)),
+                current_index: Arc::new(Mutex::new(0)),
+            }
         }
     }
 
@@ -305,7 +316,14 @@ mod tests {
             _available_tools: &[ToolDescription],
             _system_prompt: &str,
         ) -> Result<Decision, LLMError> {
-            Ok(self.decision.clone())
+            let mut index = self.current_index.lock().unwrap();
+            let decisions = self.decisions.lock().unwrap();
+            let decision = decisions
+                .get(*index)
+                .cloned()
+                .unwrap_or_else(|| decisions.last().unwrap().clone());
+            *index += 1;
+            Ok(decision)
         }
     }
 
@@ -690,5 +708,119 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("session not found"));
+    }
+
+    /// Test that get_events is only called once per run (performance optimization).
+    ///
+    /// This test verifies the fix for Issue #26: ControlLoop should fetch events
+    /// once at the start and maintain a local cache, rather than re-fetching on
+    /// every iteration.
+    #[tokio::test]
+    async fn test_get_events_called_only_once() {
+        let session_id = SessionId::new_v4();
+
+        // Create a store that tracks get_events call count
+        struct CallCountingStore {
+            inner: Arc<TestStore>,
+            get_events_call_count: Arc<Mutex<usize>>,
+        }
+
+        impl CallCountingStore {
+            fn with_session(session_id: SessionId) -> Self {
+                let store = TestStore::new();
+                store.insert_session(
+                    session_id,
+                    vec![Event {
+                        event_id: lattice_core::EventId::new_v4(),
+                        session_id,
+                        timestamp: chrono::Utc::now(),
+                        actor: Actor::System,
+                        payload: EventPayload::UserMessage {
+                            content: "test".into(),
+                        },
+                        parent_event_id: None,
+                    }],
+                );
+                Self {
+                    inner: Arc::new(store),
+                    get_events_call_count: Arc::new(Mutex::new(0)),
+                }
+            }
+
+            fn get_call_count(&self) -> usize {
+                *self.get_events_call_count.lock().unwrap()
+            }
+        }
+
+        #[async_trait]
+        impl lattice_core::SessionStore for CallCountingStore {
+            async fn create_session(&self) -> Result<SessionId, lattice_core::error::StoreError> {
+                self.inner.create_session().await
+            }
+
+            async fn append_event(
+                &self,
+                session_id: SessionId,
+                payload: EventPayload,
+                actor: Actor,
+                parent_event_id: Option<lattice_core::EventId>,
+            ) -> Result<lattice_core::EventId, lattice_core::error::StoreError> {
+                self.inner
+                    .append_event(session_id, payload, actor, parent_event_id)
+                    .await
+            }
+
+            async fn get_events(
+                &self,
+                session_id: SessionId,
+                filter: &EventFilter,
+            ) -> Result<Vec<Event>, lattice_core::error::StoreError> {
+                // Increment call counter
+                *self.get_events_call_count.lock().unwrap() += 1;
+                self.inner.get_events(session_id, filter).await
+            }
+
+            async fn latest_event_id(
+                &self,
+                session_id: SessionId,
+            ) -> Result<Option<lattice_core::EventId>, lattice_core::error::StoreError> {
+                self.inner.latest_event_id(session_id).await
+            }
+        }
+
+        let store = Arc::new(CallCountingStore::with_session(session_id));
+
+        // LLM will return ToolCall twice, then FinalAnswer
+        // This creates 3 iterations, which would call get_events 3 times in the old code
+        let decisions = vec![
+            Decision::ToolCall {
+                tool: "test_tool".into(),
+                params: serde_json::json!({"command": "echo first"}),
+            },
+            Decision::ToolCall {
+                tool: "test_tool".into(),
+                params: serde_json::json!({"command": "echo second"}),
+            },
+            Decision::FinalAnswer {
+                answer: "done".into(),
+            },
+        ];
+
+        let llm = Arc::new(TestLLM::with_sequence(decisions));
+        let tools = make_tools();
+
+        let control_loop =
+            crate::ControlLoop::with_options(store.clone(), llm, tools, "prompt".into(), 10);
+
+        let result = control_loop.run(session_id).await.unwrap();
+        assert_eq!(result, "done");
+
+        // Verify get_events was called only once
+        let call_count = store.get_call_count();
+        assert_eq!(
+            call_count, 1,
+            "get_events should be called only once, but was called {} times",
+            call_count
+        );
     }
 }

--- a/crates/runtime/src/control_loop.rs
+++ b/crates/runtime/src/control_loop.rs
@@ -851,7 +851,8 @@ mod tests {
             async fn latest_event_id(
                 &self,
                 session_id: SessionId,
-            ) -> Result<Option<lattice_core::EventId>, lattice_core::error::StoreError> {
+            ) -> Result<Option<lattice_core::EventId>, lattice_core::error::StoreError>
+            {
                 self.inner.latest_event_id(session_id).await
             }
         }

--- a/crates/runtime/src/control_loop.rs
+++ b/crates/runtime/src/control_loop.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use lattice_core::{
-    Actor, Decision, EventFilter, EventPayload, LLMClient, SessionId, SessionStore,
+    Actor, Decision, Event, EventFilter, EventPayload, LLMClient, SessionId, SessionStore,
 };
 use tracing::{info, instrument, warn};
 
@@ -77,13 +77,14 @@ impl ControlLoop {
     pub async fn run(&self, session_id: SessionId) -> anyhow::Result<String> {
         info!(?session_id, "control loop started");
 
-        for _ in 0..self.max_iterations {
-            let events = self
-                .store
-                .get_events(session_id, &EventFilter::default())
-                .await
-                .map_err(|e| anyhow::anyhow!("{e}"))?;
+        // Fetch events once at the start (performance optimization for Issue #26)
+        let mut events = self
+            .store
+            .get_events(session_id, &EventFilter::default())
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
 
+        for _ in 0..self.max_iterations {
             let available_tools = self.tools.descriptions();
             let decision = self
                 .llm
@@ -94,15 +95,28 @@ impl ControlLoop {
             match decision {
                 Decision::Thinking { reasoning } => {
                     info!(?reasoning, "LLM thinking");
-                    self.store
+                    let event_id = self
+                        .store
                         .append_event(
                             session_id,
-                            EventPayload::Thinking { reasoning },
+                            EventPayload::Thinking {
+                                reasoning: reasoning.clone(),
+                            },
                             Actor::LLM,
                             events.last().map(|e| e.event_id),
                         )
                         .await
                         .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+                    // Update local event list
+                    events.push(Event {
+                        event_id,
+                        session_id,
+                        timestamp: chrono::Utc::now(),
+                        actor: Actor::LLM,
+                        payload: EventPayload::Thinking { reasoning },
+                        parent_event_id: events.last().map(|e| e.event_id),
+                    });
                 }
                 Decision::ToolCall { tool, params } => {
                     info!(?tool, "LLM requested tool call");
@@ -121,17 +135,31 @@ impl ControlLoop {
                         .await
                         .map_err(|e| anyhow::anyhow!("{e}"))?;
 
+                    // Update local event list
+                    events.push(Event {
+                        event_id: req_event_id,
+                        session_id,
+                        timestamp: chrono::Utc::now(),
+                        actor: Actor::LLM,
+                        payload: EventPayload::ToolCallRequested {
+                            tool: tool.clone(),
+                            params: params.clone(),
+                        },
+                        parent_event_id: parent_id,
+                    });
+
                     info!("executing tool: {}", tool);
                     // Execute the tool and record the result (or error) directly.
                     match self.tools.execute(&tool, params).await {
                         Ok(result) => {
                             info!("tool execution succeeded: exit_code={}", result.exit_code);
-                            self.store
+                            let result_event_id = self
+                                .store
                                 .append_event(
                                     session_id,
                                     EventPayload::ToolCallResult {
-                                        stdout: result.stdout,
-                                        stderr: result.stderr,
+                                        stdout: result.stdout.clone(),
+                                        stderr: result.stderr.clone(),
                                         exit_code: result.exit_code,
                                     },
                                     Actor::Sandbox,
@@ -139,27 +167,54 @@ impl ControlLoop {
                                 )
                                 .await
                                 .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+                            // Update local event list
+                            events.push(Event {
+                                event_id: result_event_id,
+                                session_id,
+                                timestamp: chrono::Utc::now(),
+                                actor: Actor::Sandbox,
+                                payload: EventPayload::ToolCallResult {
+                                    stdout: result.stdout,
+                                    stderr: result.stderr,
+                                    exit_code: result.exit_code,
+                                },
+                                parent_event_id: Some(req_event_id),
+                            });
                         }
                         Err(e) => {
                             warn!("tool execution failed: {}", e);
-                            self.store
+                            let error_str = e.to_string();
+                            let error_event_id = self
+                                .store
                                 .append_event(
                                     session_id,
                                     EventPayload::ToolCallError {
-                                        error: e.to_string(),
+                                        error: error_str.clone(),
                                     },
                                     Actor::Sandbox,
                                     Some(req_event_id),
                                 )
                                 .await
                                 .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+                            // Update local event list
+                            events.push(Event {
+                                event_id: error_event_id,
+                                session_id,
+                                timestamp: chrono::Utc::now(),
+                                actor: Actor::Sandbox,
+                                payload: EventPayload::ToolCallError { error: error_str },
+                                parent_event_id: Some(req_event_id),
+                            });
                         }
                     }
                     info!("tool call completed, continuing loop");
                 }
                 Decision::FinalAnswer { answer } => {
                     info!(?answer, "LLM final answer");
-                    self.store
+                    let event_id = self
+                        .store
                         .append_event(
                             session_id,
                             EventPayload::FinalAnswer {
@@ -170,6 +225,19 @@ impl ControlLoop {
                         )
                         .await
                         .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+                    // Update local event list (for consistency, though we return immediately)
+                    events.push(Event {
+                        event_id,
+                        session_id,
+                        timestamp: chrono::Utc::now(),
+                        actor: Actor::LLM,
+                        payload: EventPayload::FinalAnswer {
+                            answer: answer.clone(),
+                        },
+                        parent_event_id: events.last().map(|e| e.event_id),
+                    });
+
                     info!(?session_id, "control loop finished");
                     return Ok(answer);
                 }

--- a/crates/runtime/src/control_loop.rs
+++ b/crates/runtime/src/control_loop.rs
@@ -892,4 +892,48 @@ mod tests {
             call_count
         );
     }
+
+    /// Test that Thinking decision path is covered.
+    #[tokio::test]
+    async fn test_thinking_decision_coverage() {
+        let session_id = SessionId::new_v4();
+        let store = TestStore::new();
+        store.insert_session(
+            session_id,
+            vec![Event {
+                event_id: lattice_core::EventId::new_v4(),
+                session_id,
+                timestamp: chrono::Utc::now(),
+                actor: Actor::System,
+                payload: EventPayload::UserMessage {
+                    content: "test".into(),
+                },
+                parent_event_id: None,
+            }],
+        );
+
+        // LLM returns Thinking, then FinalAnswer
+        let decisions = vec![
+            Decision::Thinking {
+                reasoning: "let me think".into(),
+            },
+            Decision::FinalAnswer {
+                answer: "done".into(),
+            },
+        ];
+
+        let llm = Arc::new(TestLLM::with_sequence(decisions));
+        let tools = make_tools();
+
+        let control_loop = crate::ControlLoop::with_options(
+            Arc::new(store),
+            llm,
+            tools,
+            "prompt".into(),
+            10,
+        );
+
+        let result = control_loop.run(session_id).await.unwrap();
+        assert_eq!(result, "done");
+    }
 }

--- a/tasks/06.1-fix-control-loop-performance.md
+++ b/tasks/06.1-fix-control-loop-performance.md
@@ -1,0 +1,199 @@
+# 任务 06.1：修复 ControlLoop O(N²) 性能问题
+
+## 目标
+
+修复 `ControlLoop::run()` 中每次迭代都重新获取所有事件的性能问题，将数据库查询从 O(N) 降低到 O(1)。
+
+## 父任务
+
+任务 06：实现 ControlLoop + BasicSandboxRouter
+
+## 问题描述
+
+当前实现在主循环中每次迭代都调用 `store.get_events()`，导致：
+- 第 1 次迭代：获取 1 个事件
+- 第 2 次迭代：获取 3 个事件
+- 第 N 次迭代：获取 2N+1 个事件
+- 总复杂度：O(N²)
+
+对于 MemoryStore，这意味着大量的 Vec 克隆。对于未来的持久化存储（SQLite/Postgres），这会变成真实的 I/O 开销。
+
+## 解决方案（Option B）
+
+采用 Issue #26 中提出的 Option B：在内存中维护事件列表。
+
+**核心思想**：
+- ControlLoop 在运行期间是唯一的写入者
+- 可以在本地维护事件列表
+- 每次 append_event 后，同时更新本地列表和数据库
+
+## 具体实现
+
+### 修改前（当前代码）
+
+```rust
+pub async fn run(&self, session_id: SessionId) -> anyhow::Result<String> {
+    for _ in 0..self.max_iterations {
+        // ❌ 每次都重新获取所有事件
+        let events = self.store.get_events(session_id, &EventFilter::default()).await?;
+        
+        let decision = self.llm.decide(&events, ...).await?;
+        
+        match decision {
+            Decision::Thinking { reasoning } => {
+                self.store.append_event(...).await?;
+            }
+            // ...
+        }
+    }
+}
+```
+
+### 修改后
+
+```rust
+pub async fn run(&self, session_id: SessionId) -> anyhow::Result<String> {
+    // ✅ 只在开始时获取一次
+    let mut events = self.store.get_events(session_id, &EventFilter::default()).await?;
+    
+    for _ in 0..self.max_iterations {
+        let decision = self.llm.decide(&events, ...).await?;
+        
+        match decision {
+            Decision::Thinking { reasoning } => {
+                // 写入数据库
+                let event_id = self.store.append_event(...).await?;
+                // ✅ 同时更新本地列表
+                events.push(Event { event_id, ... });
+            }
+            // ...
+        }
+    }
+}
+```
+
+## 实现步骤
+
+### 1. 将 `get_events` 移到循环外
+
+```rust
+// 在 for 循环之前
+let mut events = self
+    .store
+    .get_events(session_id, &EventFilter::default())
+    .await
+    .map_err(|e| anyhow::anyhow!("{e}"))?;
+```
+
+### 2. 修改 Decision::Thinking 分支
+
+```rust
+Decision::Thinking { reasoning } => {
+    info!(?reasoning, "LLM thinking");
+    let event_id = self
+        .store
+        .append_event(
+            session_id,
+            EventPayload::Thinking { reasoning: reasoning.clone() },
+            Actor::LLM,
+            events.last().map(|e| e.event_id),
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    
+    // 添加到本地列表
+    events.push(Event {
+        event_id,
+        session_id,
+        payload: EventPayload::Thinking { reasoning },
+        actor: Actor::LLM,
+        parent_event_id: events.last().map(|e| e.event_id),
+        timestamp: chrono::Utc::now(),
+    });
+}
+```
+
+### 3. 修改 Decision::ToolCall 分支
+
+需要在三个地方添加事件到本地列表：
+- ToolCallRequested
+- ToolCallResult
+- ToolCallError
+
+### 4. 修改 Decision::FinalAnswer 分支
+
+添加 FinalAnswer 事件到本地列表（虽然之后就返回了，但为了一致性）
+
+## 注意事项
+
+1. **Event 结构体构造**：需要查看 `Event` 的字段，确保正确构造
+2. **timestamp**：使用 `chrono::Utc::now()` 或从 store 返回
+3. **event_id**：`append_event` 需要返回新创建的 event_id
+4. **parent_event_id**：注意在 ToolCallResult/Error 中使用 `req_event_id`
+
+## 测试策略
+
+### 单元测试
+
+在 `crates/runtime/src/control_loop.rs` 的测试中：
+
+1. **验证只调用一次 get_events**：
+   - 使用 mock store 记录调用次数
+   - 运行多次迭代
+   - 断言 `get_events` 只被调用 1 次
+
+2. **验证事件正确追加**：
+   - 运行包含多次工具调用的会话
+   - 验证所有事件都被正确保存到 store
+
+### 集成测试
+
+运行现有的集成测试，确保行为不变：
+- `cargo test -p lattice-runtime`
+- `cargo test --workspace`
+
+## 性能验证
+
+### 理论改进
+
+假设 50 次迭代：
+- 修改前：50 次数据库查询，获取 ~2,500 个事件
+- 修改后：1 次数据库查询，获取 ~100 个事件
+- 改进：减少 96% 的数据库访问
+
+### 实际测量（可选）
+
+可以添加性能测试来验证改进：
+
+```rust
+#[tokio::test]
+async fn test_performance_improvement() {
+    // 创建一个会话，执行 20 次工具调用
+    // 测量执行时间
+    // 验证性能提升
+}
+```
+
+## 验收标准
+
+- [ ] `get_events` 只在循环开始前调用一次
+- [ ] 所有 `append_event` 后都更新本地 events 列表
+- [ ] 所有现有测试通过：`cargo test -p lattice-runtime`
+- [ ] 所有工作区测试通过：`cargo test --workspace`
+- [ ] Clippy 零警告：`cargo clippy -p lattice-runtime`
+- [ ] 代码格式正确：`cargo fmt --check`
+- [ ] 添加注释说明性能优化的原因
+
+## 相关 Issue
+
+- Closes #26
+
+## 依赖
+
+无（独立任务）
+
+## 预计影响
+
+- 文件修改：`crates/runtime/src/control_loop.rs`
+- 可能需要修改：`lattice_core::SessionStore::append_event` 的返回类型（如果当前不返回 event_id）
+- 测试修改：可能需要更新 mock store


### PR DESCRIPTION
## Summary

Fix Issue #26: ControlLoop now fetches events once at the start of `run()` and maintains a local cache, instead of re-fetching on every iteration.

## Problem

Previously, `ControlLoop::run()` called `store.get_events()` inside the main loop, causing O(N²) performance:
- Iteration 1: fetch 1 event
- Iteration 2: fetch 3 events
- Iteration N: fetch 2N+1 events

For 50 iterations, this resulted in ~2,500 event fetches instead of ~100.

## Solution (Option B from Issue #26)

- Move `get_events()` call outside the loop
- Maintain mutable `events` Vec throughout the loop
- After each `append_event()`, push the new Event to local cache
- Applied to all three decision branches: Thinking, ToolCall, FinalAnswer

## Performance Improvement

- **Before**: O(N) get_events calls per run (N = iterations)
- **After**: O(1) get_events call per run
- **For 50 iterations**: reduces from ~2,500 event fetches to ~100 (96% improvement)

## Testing

- ✅ New test: `test_get_events_called_only_once` verifies optimization
- ✅ All 9 runtime tests pass
- ✅ All workspace tests pass
- ✅ Clippy: zero warnings
- ✅ Format check: pass

## Changes

- `crates/runtime/src/control_loop.rs`:
  - Add `Event` import
  - Move `get_events` outside loop
  - Add local cache updates in 3 decision branches
  - Enhance `TestLLM` to support multiple decisions
- `tasks/06.1-fix-control-loop-performance.md`: Task documentation

## Related

Closes #26

🤖 Generated with Claude Code