### PR TITLE
docs: replace task 20 with 6 sequential sub-tasks for skill system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ crates/
 ├── llm-anthropic/    # LLMClient 的 Anthropic Claude 实现
 ├── llm-openai/       # LLMClient 的 OpenAI 兼容实现
 ├── tools/            # 标准工具库（bash, file, glob, grep, http）
+├── skill/            # Skill 系统（SkillTool、SkillToolSet、SkillLoader）
 ├── server/           # HTTP API 服务（axum），平台服务入口
 
 # Facade crate（根目录 src/lib.rs）
@@ -53,6 +54,7 @@ lattice               # 通过 feature flags 重导出所有子 crate
 |-------|-----------|
 | `runtime` | [crates/runtime/CLAUDE.md](crates/runtime/CLAUDE.md) |
 | `tools` | [crates/tools/CLAUDE.md](crates/tools/CLAUDE.md) |
+| `skill` | [crates/skill/CLAUDE.md](crates/skill/CLAUDE.md) |
 | `llm-protocol` | [crates/llm-protocol/CLAUDE.md](crates/llm-protocol/CLAUDE.md) |
 | `llm-anthropic` | [crates/llm-anthropic/CLAUDE.md](crates/llm-anthropic/CLAUDE.md) |
 | `llm-openai` | [crates/llm-openai/CLAUDE.md](crates/llm-openai/CLAUDE.md) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -105,6 +105,18 @@ pub enum EventPayload {
 
     /// 会话状态变更
     StateChange { from: String, to: String },
+
+    /// Skill 被触发执行 —— 记录在父 session 中
+    SkillInvoked {
+        skill_name: String,
+        child_session_id: SessionId,
+    },
+
+    /// Skill 执行完成 —— 记录在父 session 中
+    SkillCompleted {
+        skill_name: String,
+        child_session_id: SessionId,
+    },
 }
 
 /// 一个不可变事件
@@ -145,6 +157,32 @@ pub trait SessionStore: Send + Sync {
 
     /// Get the latest event id for a session.
     async fn latest_event_id(&self, session_id: SessionId) -> Result<Option<EventId>, StoreError>;
+
+    /// Create a child session under the given parent.
+    ///
+    /// The child session is independent — its events are stored in the
+    /// returned child store. The parent store records the relationship
+    /// for `child_sessions()` queries.
+    async fn create_child_session(
+        &self,
+        parent_session_id: SessionId,
+        skill_name: &str,
+    ) -> Result<(SessionId, Arc<dyn SessionStore>), StoreError>;
+
+    /// List all child sessions for a given parent.
+    async fn child_sessions(
+        &self,
+        parent_session_id: SessionId,
+    ) -> Result<Vec<ChildSessionInfo>, StoreError>;
+}
+
+/// Information about a child session (returned by SessionStore::child_sessions).
+#[derive(Debug, Clone)]
+pub struct ChildSessionInfo {
+    pub session_id: SessionId,
+    pub store: Arc<dyn SessionStore>,
+    pub skill_name: String,
+    pub created_at: Timestamp,
 }
 ```
 
@@ -232,24 +270,41 @@ pub struct ExecutionResult {
 **ToolExecutor trait**：
 
 ```rust
+/// Execution context passed to every tool invocation.
+pub struct ExecutionContext {
+    pub session_id: SessionId,
+    pub trigger_event_id: EventId,
+    pub store: Arc<dyn SessionStore>,
+    pub depth: u32,   // 0 = meta agent, 1 = direct skill child, etc.
+}
+pub const MAX_SKILL_DEPTH: u32 = 8;
+
 #[async_trait]
 pub trait ToolExecutor: Send + Sync {
     /// Return the tool description for LLM consumption.
     fn description(&self) -> ToolDescription;
 
-    /// Execute the tool with the given parameters.
-    async fn execute(&self, params: serde_json::Value) -> Result<ExecutionResult, ToolError>;
+    /// Execute the tool with the given parameters and execution context.
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &ExecutionContext,
+    ) -> Result<ExecutionResult, ToolError>;
 }
 ```
 
 **ToolSet**：
 
 ```rust
-pub struct ToolSet { ... }
 impl ToolSet {
     pub fn register(&mut self, tool: impl ToolExecutor + 'static) -> Result<(), ToolError> { ... }
     pub fn descriptions(&self) -> Vec<ToolDescription> { ... }
-    pub async fn execute(&self, name: &str, params: serde_json::Value) -> Result<ExecutionResult, ToolError> { ... }
+    pub async fn execute(
+        &self,
+        name: &str,
+        params: serde_json::Value,
+        ctx: &ExecutionContext,
+    ) -> Result<ExecutionResult, ToolError> { ... }
 }
 ```
 
@@ -460,6 +515,15 @@ Lattice 在此基础上做了一个重要的分层：将「工具描述」（给
 #### ToolExecutor trait（`lattice-core`）
 
 ```rust
+/// Execution context passed to every tool invocation.
+pub struct ExecutionContext {
+    pub session_id: SessionId,
+    pub trigger_event_id: EventId,
+    pub store: Arc<dyn SessionStore>,
+    pub depth: u32,
+}
+pub const MAX_SKILL_DEPTH: u32 = 8;
+
 /// A tool that can be executed by the agent.
 ///
 /// Implementations can be in-process (file read, HTTP fetch) or delegate
@@ -470,8 +534,12 @@ pub trait ToolExecutor: Send + Sync {
     /// Return the tool description for LLM consumption.
     fn description(&self) -> ToolDescription;
 
-    /// Execute the tool with the given parameters.
-    async fn execute(&self, params: serde_json::Value) -> Result<ExecutionResult, ToolError>;
+    /// Execute the tool with the given parameters and execution context.
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &ExecutionContext,
+    ) -> Result<ExecutionResult, ToolError>;
 }
 ```
 
@@ -510,6 +578,7 @@ impl ToolSet {
         &self,
         name: &str,
         params: serde_json::Value,
+        ctx: &ExecutionContext,
     ) -> Result<ExecutionResult, ToolError> { ... }
 }
 ```
@@ -538,7 +607,11 @@ impl ToolExecutor for BashTool {
         { /* Windows cmd description with dir, type, findstr examples */ }
     }
 
-    async fn execute(&self, params: serde_json::Value) -> Result<ExecutionResult, ToolError> {
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        _ctx: &ExecutionContext,
+    ) -> Result<ExecutionResult, ToolError> {
         let command = params
             .get("command")
             .and_then(|v| v.as_str())
@@ -574,7 +647,11 @@ pub struct FileReadTool {
 impl ToolExecutor for FileReadTool {
     fn description(&self) -> ToolDescription { /* file_read tool schema */ }
 
-    async fn execute(&self, params: serde_json::Value) -> Result<ExecutionResult, ToolError> {
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        _ctx: &ExecutionContext,
+    ) -> Result<ExecutionResult, ToolError> {
         let path = params["path"]
             .as_str()
             .ok_or_else(|| ToolError::InvalidParams("missing 'path' field".to_string()))?;

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -87,3 +87,11 @@ GET    /v1/providers                    → 列出可用 LLM provider
 ### 凭据管理
 - Vault Proxy 模式：沙箱外注入凭据
 - 初始化注入模式：沙箱创建时一次性注入
+
+### Skill 系统
+- 任务 20-1：`lattice-core` 新增 `ExecutionContext`、`MAX_SKILL_DEPTH`、`ToolError::MaxDepthExceeded`、`EventPayload` 新增变体
+- 任务 20-2：`SessionStore` 新增 `create_child_session` / `child_sessions`，`MemoryStore` 实现子 session
+- 任务 20-3：`ToolSet::execute` + 已有工具适配新签名
+- 任务 20-4：`ControlLoop` 加 `depth` 字段和 builder，构造 `ExecutionContext`
+- 任务 20-5：新建 `lattice-skill` crate（SkillDefinition、SkillToolSet、SkillTool、SkillLoader）
+- 任务 20-6：接入 facade + 示例 skill 目录 + meta-agent example

--- a/tasks/15-tool-system.md
+++ b/tasks/15-tool-system.md
@@ -52,34 +52,44 @@ pub trait ToolExecutor: Send + Sync {
     /// Return the tool description for LLM consumption.
     fn description(&self) -> ToolDescription;
 
-    /// Execute the tool with the given parameters.
-    async fn execute(&self, params: serde_json::Value) -> Result<ExecutionResult, ToolError>;
+    /// Execute the tool with the given parameters and execution context.
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &ExecutionContext,
+    ) -> Result<ExecutionResult, ToolError>;
 }
-```
 
-**新增错误类型**：`crates/core/src/error.rs`
+/// Maximum allowed skill nesting depth (0 = meta agent, 1 = direct skill child, etc.).
+pub const MAX_SKILL_DEPTH: u32 = 8;
 
-```rust
+/// Execution context passed to every tool invocation.
+pub struct ExecutionContext {
+    pub session_id: SessionId,
+    pub trigger_event_id: EventId,
+    pub store: Arc<dyn SessionStore>,
+    pub depth: u32,
+}
+
 /// Error from a tool executor.
 #[derive(Debug, Clone, Error)]
+#[error(transparent)]
 pub enum ToolError {
-    /// Tool not found in the registry.
     #[error("tool not found: {0}")]
     NotFound(String),
 
-    /// Invalid parameters provided to the tool.
     #[error("invalid parameters: {0}")]
     InvalidParams(String),
 
-    /// Tool execution failed.
     #[error("execution failed: {0}")]
     ExecutionFailed(String),
 
-    /// Execution timed out.
     #[error("timeout after {timeout_secs}s")]
     Timeout { timeout_secs: u64 },
 
-    /// Generic tool error.
+    #[error("max skill depth {0} exceeded")]
+    MaxDepthExceeded(u32),
+
     #[error("tool error: {0}")]
     Other(String),
 }
@@ -142,6 +152,7 @@ impl ToolSet {
         &self,
         name: &str,
         params: serde_json::Value,
+        ctx: &ExecutionContext,
     ) -> Result<ExecutionResult, ToolError> { ... }
 
     /// Check if a tool is registered.
@@ -189,7 +200,11 @@ impl ToolExecutor for BashTool {
         }
     }
 
-    async fn execute(&self, params: serde_json::Value) -> Result<ExecutionResult, ToolError> {
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        _ctx: &ExecutionContext,
+    ) -> Result<ExecutionResult, ToolError> {
         let command = params.get("command")
             .and_then(|v| v.as_str())
             .ok_or_else(|| ToolError::InvalidParams("missing 'command' field".into()))?;

--- a/tasks/20-1-execution-context.md
+++ b/tasks/20-1-execution-context.md
@@ -1,0 +1,191 @@
+# 任务 20-1：core 层扩展 — ExecutionContext + EventPayload + ToolError
+
+## 目标
+
+在 `lattice-core` 中引入 skill 系统所需的全部基础设施类型：
+`ExecutionContext`、`MAX_SKILL_DEPTH`、`ToolError::MaxDepthExceeded`、`EventPayload` 新增变体。
+
+**这是 skill 系统的第一阶段**，所有后续阶段都依赖本次新增的类型。
+
+## 分支
+
+`feat/skill-execution-context`
+
+## 依赖
+
+- 任务 15（工具系统：ToolExecutor + ToolSet）
+- 任务 3（core 类型和 trait）
+
+---
+
+## 新增类型
+
+### 1. `ExecutionContext`（`crates/core/src/tool.rs`）
+
+在文件末尾添加：
+
+```rust
+/// Maximum allowed skill nesting depth.
+///
+/// A meta agent has depth=0; its direct skill children have depth=1, and so on.
+/// When depth reaches MAX_SKILL_DEPTH, tool execution must fail with
+/// `ToolError::MaxDepthExceeded` to prevent infinite recursion.
+pub const MAX_SKILL_DEPTH: u32 = 8;
+
+/// Execution context passed to every tool invocation by the ControlLoop.
+///
+/// Allows tools to inspect the calling session, record correlated events,
+/// and enforce depth limits for skill nesting.
+#[derive(Debug, Clone)]
+pub struct ExecutionContext {
+    /// The session this tool call belongs to.
+    pub session_id: SessionId,
+    /// The event id of the `ToolCallRequested` event that triggered this execution.
+    pub trigger_event_id: EventId,
+    /// The session store for reading/writing events.
+    pub store: Arc<dyn SessionStore>,
+    /// Nesting depth: 0 for the top-level meta agent, 1 for direct skill children, etc.
+    pub depth: u32,
+}
+```
+
+**注意**：`Arc<dyn SessionStore>` 已通过 `crates/core/src/lib.rs` 的 re-export 可用。
+如果出现循环依赖，在 `lib.rs` 中添加显式 `use crate::session::{SessionStore, ChildSessionInfo};`。
+
+### 2. `ToolError::MaxDepthExceeded`（`crates/core/src/error.rs`）
+
+在 `ToolError` 枚举中添加变体：
+
+```rust
+/// Maximum skill nesting depth exceeded.
+#[error("max skill depth {0} exceeded")]
+MaxDepthExceeded(u32),
+```
+
+### 3. `EventPayload` 新增变体（`crates/core/src/event.rs`）
+
+在 `EventPayload` 枚举中添加：
+
+```rust
+/// A skill was invoked — recorded in the parent session.
+SkillInvoked {
+    skill_name: String,
+    child_session_id: SessionId,
+},
+
+/// A skill completed — recorded in the parent session.
+SkillCompleted {
+    skill_name: String,
+    child_session_id: SessionId,
+},
+```
+
+### 4. `ToolExecutor` 签名变更（`crates/core/src/tool.rs`）
+
+`execute` 方法签名从：
+
+```rust
+async fn execute(&self, params: serde_json::Value) -> Result<ExecutionResult, ToolError>;
+```
+
+变更为：
+
+```rust
+async fn execute(
+    &self,
+    params: serde_json::Value,
+    ctx: &ExecutionContext,
+) -> Result<ExecutionResult, ToolError>;
+```
+
+### 5. 更新 `crates/core/src/lib.rs`
+
+确保 re-exports 包含新增类型：
+
+```rust
+pub use session::{SessionStore, ChildSessionInfo};
+pub use tool::{ExecutionContext, MAX_SKILL_DEPTH, ToolExecutor};
+pub use error::ToolError;
+```
+
+---
+
+## 测试要求
+
+### 单元测试（`crates/core/src/tool.rs`）
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn execution_context_clone() {
+        let ctx = ExecutionContext {
+            session_id: SessionId::new_v4(),
+            trigger_event_id: EventId::new_v4(),
+            store: Arc::new(MockStore),
+            depth: 3,
+        };
+        let cloned = ctx.clone();
+        assert_eq!(cloned.depth, 3);
+    }
+
+    #[test]
+    fn max_skill_depth_value() {
+        assert_eq!(MAX_SKILL_DEPTH, 8);
+    }
+}
+```
+
+### 单元测试（`crates/core/src/error.rs`）
+
+```rust
+#[test]
+fn test_max_depth_exceeded_display() {
+    let err = ToolError::MaxDepthExceeded(8);
+    assert!(err.to_string().contains("max skill depth"));
+    assert!(err.to_string().contains("8"));
+}
+```
+
+### 单元测试（`crates/core/src/event.rs`）
+
+```rust
+#[test]
+fn test_skill_invoked_serde_roundtrip() {
+    let child = SessionId::new_v4();
+    let payload = EventPayload::SkillInvoked {
+        skill_name: "web-research".into(),
+        child_session_id: child,
+    };
+    let json = serde_json::to_string(&payload).unwrap();
+    let parsed: EventPayload = serde_json::from_str(&json).unwrap();
+    assert_eq!(payload, parsed);
+}
+
+#[test]
+fn test_skill_completed_serde_roundtrip() {
+    let child = SessionId::new_v4();
+    let payload = EventPayload::SkillCompleted {
+        skill_name: "web-research".into(),
+        child_session_id: child,
+    };
+    let json = serde_json::to_string(&payload).unwrap();
+    let parsed: EventPayload = serde_json::from_str(&json).unwrap();
+    assert_eq!(payload, parsed);
+}
+```
+
+---
+
+## 验收标准
+
+- [ ] `MAX_SKILL_DEPTH = 8` 定义在 `lattice-core`
+- [ ] `ExecutionContext` 有完整 doc comment，包含所有字段说明
+- [ ] `ToolError::MaxDepthExceeded` 新增，显示格式为 `"max skill depth 8 exceeded"`
+- [ ] `EventPayload` 新增 `SkillInvoked` 和 `SkillCompleted` 变体，serde 序列化格式为 `"skillInvoked"` / `"skillCompleted"`
+- [ ] `ToolExecutor::execute` 签名含 `ctx: &ExecutionContext`
+- [ ] 所有新增类型在 `lattice-core` 的 `lib.rs` 中 re-export
+- [ ] 上述三个测试文件中的测试全部通过
+- [ ] `cargo fmt --all -- --check` 和 `cargo clippy --all-targets -- -D warnings` 通过

--- a/tasks/20-2-session-tree.md
+++ b/tasks/20-2-session-tree.md
@@ -1,0 +1,187 @@
+# 任务 20-2：SessionStore 树形扩展 + MemoryStore 子 session
+
+## 目标
+
+扩展 `SessionStore` trait 支持创建子 session，构建 session tree。`MemoryStore` 实现子 session 支持。
+
+## 分支
+
+`feat/skill-session-tree`
+
+## 依赖
+
+- 任务 20-1（core 层扩展：EventPayload 新增变体）
+
+---
+
+## SessionStore trait 扩展
+
+### `crates/core/src/session.rs`
+
+在 `SessionStore` trait 中新增两个方法：
+
+```rust
+/// Create a child session under the given parent.
+///
+/// The child session is independent — its events are stored in the
+/// returned child store. The parent store records the relationship
+/// for `child_sessions()` queries.
+async fn create_child_session(
+    &self,
+    parent_session_id: SessionId,
+    skill_name: &str,
+) -> Result<(SessionId, Arc<dyn SessionStore>), StoreError>;
+
+/// List all child sessions for a given parent.
+async fn child_sessions(
+    &self,
+    parent_session_id: SessionId,
+) -> Result<Vec<ChildSessionInfo>, StoreError>;
+```
+
+新增 `ChildSessionInfo` 结构体：
+
+```rust
+/// Information about a child session (returned by SessionStore::child_sessions).
+#[derive(Debug, Clone)]
+pub struct ChildSessionInfo {
+    pub session_id: SessionId,
+    pub store: Arc<dyn SessionStore>,
+    pub skill_name: String,
+    pub created_at: Timestamp,
+}
+```
+
+### `crates/core/src/lib.rs`
+
+确保 re-export：
+
+```rust
+pub use session::{SessionStore, ChildSessionInfo};
+```
+
+---
+
+## MemoryStore 实现
+
+### `crates/store-memory/src/memory_store.rs`
+
+**重构内部结构**：
+
+将原来的 `sessions: Arc<RwLock<HashMap<SessionId, Vec<Event>>>>` 包装为 `Inner` 结构体：
+
+```rust
+/// Internal state of MemoryStore.
+struct Inner {
+    sessions: HashMap<SessionId, Vec<Event>>,
+    /// Tree relationship: parent_session_id → list of child sessions
+    children: HashMap<SessionId, Vec<ChildSessionInfo>>,
+}
+
+pub struct MemoryStore {
+    inner: Arc<RwLock<Inner>>,
+}
+```
+
+**`create_child_session` 实现要点**：
+
+1. 验证 `parent_session_id` 存在
+2. 创建独立的子 `MemoryStore`（new）
+3. 在子 store 中调用 `create_session()` 创建根 session
+4. 在父 store 的 `children` 中记录 `ChildSessionInfo`
+5. 返回 `(child_session_id, Arc::new(child_store))`
+
+**`child_sessions` 实现要点**：
+
+从 `inner.children` 中查找父 session 对应的 `Vec<ChildSessionInfo>`，不存在时返回空 Vec。
+
+**注意**：`MemoryStore` 内部调用 `create_session()` 时需要访问自己的 `inner`，而非通过 trait 接口（避免异步锁冲突）。子 store 使用独立的 `inner` 实例，保证父子 session 完全隔离。
+
+---
+
+## 测试要求
+
+### 单元测试（`crates/store-memory/src/memory_store.rs`）
+
+```rust
+#[tokio::test]
+async fn create_child_session_returns_independent_store() {
+    let store = MemoryStore::new();
+    let parent_id = store.create_session().await.unwrap();
+
+    let (child_id, child_store) = store
+        .create_child_session(parent_id, "web-research")
+        .await
+        .unwrap();
+
+    // Child session id is different from parent
+    assert_ne!(child_id, parent_id);
+
+    // Events in child store are NOT visible in parent store
+    child_store
+        .append_event(
+            child_id,
+            EventPayload::UserMessage { content: "child msg".into() },
+            Actor::Harness,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let parent_events = store.get_events(parent_id, &EventFilter::default()).await.unwrap();
+    assert!(parent_events.iter().all(|e| !matches!(e.payload, EventPayload::UserMessage { .. })));
+}
+
+#[tokio::test]
+async fn child_sessions_returns_correct_info() {
+    let store = MemoryStore::new();
+    let parent_id = store.create_session().await.unwrap();
+
+    let (id1, _) = store.create_child_session(parent_id, "skill-a").await.unwrap();
+    let (id2, _) = store.create_child_session(parent_id, "skill-b").await.unwrap();
+
+    let children = store.child_sessions(parent_id).await.unwrap();
+    assert_eq!(children.len(), 2);
+    let names: Vec<_> = children.iter().map(|c| c.skill_name.as_str()).collect();
+    assert!(names.contains(&"skill-a"));
+    assert!(names.contains(&"skill-b"));
+}
+
+#[tokio::test]
+async fn multiple_children_accumulated() {
+    let store = MemoryStore::new();
+    let parent_id = store.create_session().await.unwrap();
+
+    for i in 0..5 {
+        store
+            .create_child_session(parent_id, format!("skill-{i}"))
+            .await
+            .unwrap();
+    }
+
+    let children = store.child_sessions(parent_id).await.unwrap();
+    assert_eq!(children.len(), 5);
+}
+
+#[tokio::test]
+async fn child_sessions_parent_not_found() {
+    let store = MemoryStore::new();
+    let fake = SessionId::new_v4();
+    let result = store.child_sessions(fake).await;
+    // Should return empty vec, not error (parent just has no children)
+    assert!(result.is_ok());
+    assert!(result.unwrap().is_empty());
+}
+```
+
+---
+
+## 验收标准
+
+- [ ] `SessionStore` trait 新增 `create_child_session` / `child_sessions` 方法
+- [ ] `ChildSessionInfo` 定义在 `lattice-core`
+- [ ] `MemoryStore` 实现两个新方法
+- [ ] 子 session 事件完全隔离（子 store 的事件不在父 store 中可见）
+- [ ] `child_sessions` 对不存在的父 session 返回空 Vec（而非错误）
+- [ ] 以上测试全部通过
+- [ ] `cargo fmt` + `cargo clippy` 通过

--- a/tasks/20-3-tool-execute-ctx.md
+++ b/tasks/20-3-tool-execute-ctx.md
@@ -1,0 +1,112 @@
+# 任务 20-3：ToolSet + 已有工具适配新签名
+
+## 目标
+
+更新 `ToolSet::execute` 签名，适配 `ToolExecutor::execute` 新增的 `ctx` 参数。所有已有工具（BashTool 及后续的 FileTool、GlobTool 等）的 `execute` 方法签名同步更新，行为保持不变。
+
+## 分支
+
+`feat/skill-tool-execute-ctx`
+
+## 依赖
+
+- 任务 20-1（core 层扩展：ExecutionContext + ToolExecutor 新签名）
+
+---
+
+## 修改内容
+
+### 1. `ToolSet::execute`（`crates/tools/src/set.rs`）
+
+```rust
+/// Look up and execute a tool by name.
+#[instrument(skip(self))]
+pub async fn execute(
+    &self,
+    name: &str,
+    params: serde_json::Value,
+    ctx: &ExecutionContext,
+) -> Result<lattice_core::ExecutionResult, ToolError> {
+    let executor = self
+        .tools
+        .get(name)
+        .ok_or_else(|| ToolError::NotFound(name.to_string()))?;
+    executor.execute(params, ctx).await
+}
+```
+
+测试中的 mock 工具也需要同步更新签名：
+
+```rust
+async fn execute(
+    &self,
+    _params: serde_json::Value,
+    _ctx: &ExecutionContext,
+) -> Result<ExecutionResult, ToolError> {
+    self.result.clone()
+}
+```
+
+### 2. `BashTool::execute`（`crates/tools/src/bash.rs`）
+
+```rust
+async fn execute(
+    &self,
+    params: serde_json::Value,
+    _ctx: &ExecutionContext,  // BashTool 当前不使用 ctx，直接忽略
+) -> Result<ExecutionResult, ToolError> {
+    // 实现保持不变，仅添加 ctx 参数
+}
+```
+
+### 3. 更新测试中的 mock 工具
+
+`crates/tools/src/set.rs` 中的 `MockTool`：
+
+```rust
+async fn execute(
+    &self,
+    _params: serde_json::Value,
+    _ctx: &ExecutionContext,
+) -> Result<ExecutionResult, ToolError> {
+    self.result.clone()
+}
+```
+
+`crates/runtime/src/control_loop.rs` 中的 `NoopTool`（如果存在）：
+
+```rust
+async fn execute(
+    &self,
+    _params: serde_json::Value,
+    _ctx: &ExecutionContext,
+) -> Result<ExecutionResult, ToolError> {
+    Ok(ExecutionResult { stdout: "ok".into(), stderr: String::new(), exit_code: 0 })
+}
+```
+
+---
+
+## 测试要求
+
+### 单元测试
+
+**`lattice-tools`**：
+
+- `ToolSet::execute` 正确透传 `ExecutionContext` 给工具
+- `BashTool::execute` 忽略 ctx，行为与之前完全一致
+
+**`lattice-runtime`**：
+
+- `NoopTool` 测试 mock 工具更新签名后仍正常工作
+- `ControlLoop` 中的所有内联 mock 工具签名同步更新
+
+---
+
+## 验收标准
+
+- [ ] `ToolSet::execute` 签名含 `ctx: &ExecutionContext`
+- [ ] `BashTool::execute` 签名同步更新，行为不变
+- [ ] `crates/tools/src/set.rs` 中所有测试通过（mock 工具签名已更新）
+- [ ] `crates/runtime/src/control_loop.rs` 中所有内联 mock 工具签名已更新，测试通过
+- [ ] `cargo fmt` + `cargo clippy` 通过

--- a/tasks/20-4-control-loop-ctx.md
+++ b/tasks/20-4-control-loop-ctx.md
@@ -1,0 +1,241 @@
+# 任务 20-4：ControlLoop 构造 ExecutionContext
+
+## 目标
+
+更新 `ControlLoop`，引入 `depth` 字段和 builder pattern，在 dispatch 工具调用时构造并透传 `ExecutionContext`。
+
+## 分支
+
+`feat/skill-control-loop`
+
+## 依赖
+
+- 任务 20-1（ExecutionContext 定义）
+- 任务 20-3（ToolSet::execute 新签名）
+
+---
+
+## 修改内容
+
+### `crates/runtime/src/control_loop.rs`
+
+**结构体新增字段**：
+
+```rust
+pub struct ControlLoop {
+    store: Arc<dyn SessionStore>,
+    llm: Arc<dyn LLMClient>,
+    tools: Arc<ToolSet>,
+    system_prompt: String,
+    max_iterations: usize,
+    depth: u32,  // 新增，默认 0
+}
+```
+
+**`new()` 默认 depth=0**：
+
+```rust
+pub fn new(
+    store: Arc<dyn SessionStore>,
+    llm: Arc<dyn LLMClient>,
+    tools: Arc<ToolSet>,
+) -> Self {
+    Self {
+        store,
+        llm,
+        tools,
+        system_prompt: "You are a helpful agent.".to_string(),
+        max_iterations: DEFAULT_MAX_ITERATIONS,
+        depth: 0,
+    }
+}
+```
+
+**新增 builder 方法**：
+
+```rust
+/// Set the skill nesting depth (used when spawning child ControlLoop instances).
+pub fn depth(mut self, depth: u32) -> Self {
+    self.depth = depth;
+    self
+}
+
+impl ControlLoop {
+    /// Fluent builder for ControlLoop.
+    pub fn builder() -> ControlLoopBuilder {
+        ControlLoopBuilder::new()
+    }
+}
+
+pub struct ControlLoopBuilder {
+    store: Option<Arc<dyn SessionStore>>,
+    llm: Option<Arc<dyn LLMClient>>,
+    tools: Option<Arc<ToolSet>>,
+    system_prompt: Option<String>,
+    max_iterations: Option<usize>,
+    depth: Option<u32>,
+}
+
+impl ControlLoopBuilder {
+    pub fn new() -> Self { Self {
+        store: None, llm: None, tools: None,
+        system_prompt: None, max_iterations: None, depth: None,
+    } }
+
+    pub fn store(mut self, store: Arc<dyn SessionStore>) -> Self {
+        self.store = Some(store); self
+    }
+    pub fn llm(mut self, llm: Arc<dyn LLMClient>) -> Self {
+        self.llm = Some(llm); self
+    }
+    pub fn tools(mut self, tools: Arc<ToolSet>) -> Self {
+        self.tools = Some(tools); self
+    }
+    pub fn system_prompt(mut self, prompt: &str) -> Self {
+        self.system_prompt = Some(prompt.to_string()); self
+    }
+    pub fn depth(mut self, depth: u32) -> Self {
+        self.depth = Some(depth); self
+    }
+
+    pub fn build(self) -> ControlLoop {
+        ControlLoop {
+            store: self.store.expect("store required"),
+            llm: self.llm.expect("llm required"),
+            tools: self.tools.expect("tools required"),
+            system_prompt: self.system_prompt.unwrap_or_else(|| "You are a helpful agent.".to_string()),
+            max_iterations: self.max_iterations.unwrap_or(DEFAULT_MAX_ITERATIONS),
+            depth: self.depth.unwrap_or(0),
+        }
+    }
+}
+```
+
+**dispatch 工具时构造 ctx**：
+
+在 `Decision::ToolCall` 分支中：
+
+```rust
+let ctx = ExecutionContext {
+    session_id,
+    trigger_event_id: req_event_id,
+    store: self.store.clone(),
+    depth: self.depth,
+};
+
+match self.tools.execute(&tool, params, &ctx).await {
+    Ok(result) => { /* record ToolCallResult */ }
+    Err(e)     => { /* record ToolCallError  */ }
+}
+```
+
+---
+
+## 测试要求
+
+### 单元测试（`crates/runtime/src/control_loop.rs`）
+
+```rust
+#[test]
+fn builder_default_depth_is_zero() {
+    let builder = ControlLoopBuilder::new();
+    assert_eq!(builder.depth, None);
+    let loop_ = builder
+        .store(Arc::new(TestStore::new()))
+        .llm(Arc::new(TestLLM::new(Decision::FinalAnswer { answer: "x".into() })))
+        .tools(Arc::new(ToolSet::new()))
+        .build();
+    assert_eq!(loop_.depth, 0);
+}
+
+#[test]
+fn builder_depth_override() {
+    let loop_ = ControlLoopBuilder::new()
+        .store(Arc::new(TestStore::new()))
+        .llm(Arc::new(TestLLM::new(Decision::FinalAnswer { answer: "x".into() })))
+        .tools(Arc::new(ToolSet::new()))
+        .depth(3)
+        .build();
+    assert_eq!(loop_.depth, 3);
+}
+
+#[tokio::test]
+async fn execution_context_passed_to_tool() {
+    // Struct to capture the ctx passed to a tool
+    static CAPTURED_CTX: std::sync::OnceLock<ExecutionContext> = std::sync::OnceLock::new();
+
+    struct CapturingTool;
+    #[async_trait]
+    impl ToolExecutor for CapturingTool {
+        fn description(&self) -> ToolDescription {
+            ToolDescription {
+                name: "capture".into(),
+                description: "captures ctx".into(),
+                parameters_schema: serde_json::json!({}),
+            }
+        }
+        async fn execute(
+            &self,
+            _params: serde_json::Value,
+            ctx: &ExecutionContext,
+        ) -> Result<ExecutionResult, ToolError> {
+            let _ = CAPTURED_CTX.set(ctx.clone());
+            Ok(ExecutionResult { stdout: "ok".into(), stderr: String::new(), exit_code: 0 })
+        }
+    }
+
+    let session_id = SessionId::new_v4();
+    let store = Arc::new(TestStore::new());
+    store.insert_session(session_id, vec![Event {
+        event_id: EventId::new_v4(),
+        session_id,
+        timestamp: chrono::Utc::now(),
+        actor: Actor::System,
+        payload: EventPayload::SessionCreated,
+        parent_event_id: None,
+    }]);
+
+    struct TwoStepLLM(Arc<Mutex<bool>>);
+    #[async_trait]
+    impl LLMClient for TwoStepLLM {
+        async fn decide(&self, _h: &[Event], _t: &[ToolDescription], _s: &str)
+            -> Result<Decision, LLMError>
+        {
+            let mut called = self.0.lock().unwrap();
+            if !*called {
+                *called = true;
+                Ok(Decision::ToolCall { tool: "capture".into(), params: serde_json::json!({}) })
+            } else {
+                Ok(Decision::FinalAnswer { answer: "done".into() })
+            }
+        }
+    }
+
+    let mut tools = ToolSet::new();
+    tools.register(CapturingTool).unwrap();
+
+    let loop_ = ControlLoop::builder()
+        .store(store.clone())
+        .llm(Arc::new(TwoStepLLM::new()))
+        .tools(Arc::new(tools))
+        .depth(5)
+        .build();
+
+    loop_.run(session_id).await.unwrap();
+
+    let ctx = CAPTURED_CTX.get().expect("ctx was captured");
+    assert_eq!(ctx.depth, 5);
+    assert_eq!(ctx.session_id, session_id);
+}
+```
+
+---
+
+## 验收标准
+
+- [ ] `ControlLoop` 新增 `depth` 字段（默认 0）
+- [ ] `ControlLoopBuilder` 实现，支持 `depth()` builder 方法
+- [ ] `ControlLoop::builder()` 可用
+- [ ] dispatch 时 `ExecutionContext` 构造正确，`depth` 字段透传
+- [ ] 上述单元测试全部通过
+- [ ] `cargo fmt` + `cargo clippy` 通过

--- a/tasks/20-5-skill-crate.md
+++ b/tasks/20-5-skill-crate.md
@@ -1,0 +1,489 @@
+# 任务 20-5：lattice-skill crate — SkillDefinition + SkillTool + SkillToolSet + SkillLoader
+
+## 目标
+
+新建 `lattice-skill` crate，实现 Skill 系统的核心逻辑：skill 定义解析、skill 工具集管理、skill 工具执行器、skill 动态加载器。
+
+**设计原则**：遵循 [Anthropic Agent Skills 开放标准](https://www.agentskills.com)，以 SKILL.md 为唯一事实来源。
+
+## 分支
+
+`feat/skill-crate`
+
+## 依赖
+
+- 任务 20-1（ExecutionContext + ToolExecutor 新签名）
+- 任务 20-2（SessionStore 子 session 方法）
+- 任务 20-4（ControlLoop builder + depth）
+
+---
+
+## crate 结构
+
+```
+crates/skill/
+├── Cargo.toml
+└── src/
+    ├── lib.rs            # re-exports
+    ├── definition.rs     # SkillDefinition（从 SKILL.md frontmatter 解析）
+    ├── tool_set.rs       # SkillToolSet（继承 + 排除 + 覆盖）
+    ├── tool.rs           # SkillTool（实现 ToolExecutor）
+    └── loader.rs         # 动态加载：扫描目录，解析 SKILL.md，注册 skill
+```
+
+---
+
+## 模块设计
+
+### `src/definition.rs` — SkillDefinition
+
+从 SKILL.md YAML frontmatter 解析。标准字段遵循 Anthropic Agent Skills 开放标准，Lattice 扩展在 `x-lattice` 命名空间下。
+
+```rust
+//! Skill definition — parsed from SKILL.md YAML frontmatter.
+
+use indexmap::IndexMap;
+use serde::Deserialize;
+
+/// Parsed from SKILL.md YAML frontmatter.
+/// Standard fields follow the Anthropic Agent Skills open standard.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SkillDefinition {
+    /// Skill identifier. Max 64 chars. Kebab-case recommended (standard).
+    pub name: String,
+    /// Human-readable description for LLM tool selection. Max 1024 chars (standard).
+    pub description: String,
+    /// Compatible agent platforms (standard, optional).
+    pub compatibility: Option<String>,
+    /// Pre-approved tools this skill is allowed to use (standard, optional).
+    #[serde(rename = "allowed-tools")]
+    pub allowed_tools: Option<Vec<String>>,
+    /// Metadata block (author, version, tags, etc.) (standard, optional).
+    pub metadata: Option<SkillMetadata>,
+    /// Lattice-specific extensions under x-lattice namespace.
+    #[serde(rename = "x-lattice")]
+    pub lattice: Option<LatticeExtension>,
+}
+
+/// Standard metadata fields.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SkillMetadata {
+    pub author: Option<String>,
+    pub version: Option<String>,
+    pub tags: Option<Vec<String>>,
+    #[serde(rename = "short-description")]
+    pub short_description: Option<String>,
+}
+
+/// Lattice-specific extensions (x-lattice namespace).
+#[derive(Debug, Clone, Deserialize)]
+pub struct LatticeExtension {
+    pub params: Option<IndexMap<String, ParamSchema>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ParamSchema {
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub description: Option<String>,
+    pub required: Option<bool>,
+    pub default: Option<serde_json::Value>,
+}
+
+impl SkillDefinition {
+    /// Validate the definition after parsing.
+    pub fn validate(&self) -> Result<(), SkillValidationError> {
+        if self.name.is_empty() {
+            return Err(SkillValidationError::MissingField("name".into()));
+        }
+        if self.name.len() > 64 {
+            return Err(SkillValidationError::FieldTooLong { field: "name".into(), max: 64, actual: self.name.len() });
+        }
+        if self.description.len() > 1024 {
+            return Err(SkillValidationError::FieldTooLong { field: "description".into(), max: 1024, actual: self.description.len() });
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SkillValidationError {
+    #[error("missing required field: {0}")]
+    MissingField(String),
+    #[error("field '{field}' exceeds max length {max} (got {actual})")]
+    FieldTooLong { field: String, max: usize, actual: usize },
+}
+```
+
+### `src/tool_set.rs` — SkillToolSet
+
+Skill 的工具集：继承父工具集 + 添加自有工具 + 排除父工具，三者优先级正确。
+
+```rust
+//! Skill tool set — inherits, excludes, and overrides parent tools.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use lattice_core::{ExecutionContext, ExecutionResult, ToolDescription, ToolError, ToolExecutor};
+use lattice_tools::ToolSet;
+
+/// Skill tool set supporting three operations on the parent ToolSet:
+///
+/// - **Inherit**: all parent tools are visible unless excluded
+/// - **Exclude**: specific parent tools can be hidden
+/// - **Override/Own**: skill-defined tools take precedence over parent tools
+pub struct SkillToolSet {
+    inherited: Arc<ToolSet>,
+    own: ToolSet,
+    excluded: HashSet<String>,
+}
+
+impl SkillToolSet {
+    pub fn build(
+        parent: Arc<ToolSet>,
+        own_tools: Vec<Box<dyn ToolExecutor>>,
+        exclude: Vec<String>,
+    ) -> Self {
+        let excluded: HashSet<_> = exclude.into_iter().collect();
+        let mut own = ToolSet::new();
+        for tool in own_tools {
+            own.register_boxed(tool).expect("skill own tool name conflict");
+        }
+        Self { inherited: parent, own, excluded }
+    }
+
+    /// All tool descriptions visible to this skill.
+    pub fn descriptions(&self) -> Vec<ToolDescription> {
+        let mut all: Vec<_> = self.inherited.descriptions()
+            .into_iter()
+            .filter(|d| !self.excluded.contains(&d.name))
+            .collect();
+        all.extend(self.own.descriptions());
+        all
+    }
+
+    pub async fn execute(
+        &self,
+        name: &str,
+        params: serde_json::Value,
+        ctx: &ExecutionContext,
+    ) -> Result<ExecutionResult, ToolError> {
+        if self.own.contains(name) {
+            self.own.execute(name, params, ctx).await
+        } else if !self.excluded.contains(name) {
+            self.inherited.execute(name, params, ctx).await
+        } else {
+            Err(ToolError::NotFound(name.to_string()))
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.own.len() + self.inherited.len() - self.excluded.len()
+    }
+}
+```
+
+### `src/tool.rs` — SkillTool
+
+实现 `ToolExecutor` trait。负责子 session 创建、子 ControlLoop 执行、结果回传。
+
+```rust
+//! Skill tool — delegates to a child ControlLoop with a separate session.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use lattice_core::{
+    Actor, EventFilter, EventPayload, ExecutionContext, ExecutionResult,
+    LLMClient, MAX_SKILL_DEPTH, SessionId, SessionStore, ToolDescription, ToolError, ToolExecutor,
+};
+
+use super::definition::SkillDefinition;
+use super::tool_set::SkillToolSet;
+
+/// A tool that wraps a skill — executes it as a child ControlLoop.
+pub struct SkillTool {
+    definition: SkillDefinition,
+    /// Markdown body of SKILL.md — used as system prompt for the skill agent.
+    system_prompt: String,
+    parent_tools: Arc<lattice_tools::ToolSet>,
+    llm: Arc<dyn LLMClient>,
+}
+
+impl SkillTool {
+    pub fn new(
+        definition: SkillDefinition,
+        system_prompt: String,
+        parent_tools: Arc<lattice_tools::ToolSet>,
+        llm: Arc<dyn LLMClient>,
+    ) -> Self {
+        Self { definition, system_prompt, parent_tools, llm }
+    }
+
+    fn tool_name(&self) -> String {
+        format!("skill:{}", self.definition.name)
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for SkillTool {
+    fn description(&self) -> ToolDescription {
+        ToolDescription {
+            name: self.tool_name(),
+            description: self.definition.description.clone(),
+            parameters_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "input": {
+                        "type": "string",
+                        "description": "Input to pass to the skill agent",
+                    }
+                },
+                "required": ["input"]
+            }),
+        }
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &ExecutionContext,
+    ) -> Result<ExecutionResult, ToolError> {
+        // 1. Depth check
+        if ctx.depth >= MAX_SKILL_DEPTH {
+            return Err(ToolError::MaxDepthExceeded(MAX_SKILL_DEPTH));
+        }
+
+        // 2. Create child session
+        let skill_name = &self.definition.name;
+        let (child_session_id, child_store) = ctx
+            .store
+            .create_child_session(ctx.session_id, skill_name)
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
+
+        // 3. Record SkillInvoked in parent session
+        ctx.store
+            .append_event(
+                ctx.session_id,
+                EventPayload::SkillInvoked { skill_name: skill_name.clone(), child_session_id },
+                Actor::Harness,
+                Some(ctx.trigger_event_id),
+            )
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
+
+        // 4. Inject initial user message into child session
+        let input = params.get("input").and_then(|v| v.as_str()).unwrap_or("").to_string();
+        child_store
+            .append_event(child_session_id, EventPayload::UserMessage { content: input }, Actor::Harness, None)
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
+
+        // 5. Build skill tool set
+        let excluded = self.definition.allowed_tools
+            .as_ref()
+            .map(|v| v.iter().cloned().collect::<HashSet<_>>())
+            .unwrap_or_default();
+        let skill_tool_set = SkillToolSet::build(self.parent_tools.clone(), vec![], excluded.into_iter().collect());
+
+        // 6. Spawn child ControlLoop with depth + 1
+        let child_loop = crate::ControlLoop::builder()
+            .store(child_store.clone())
+            .llm(self.llm.clone())
+            .tools(Arc::new(skill_tool_set))
+            .system_prompt(&self.system_prompt)
+            .depth(ctx.depth + 1)
+            .build();
+
+        child_loop.run(child_session_id)
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
+
+        // 7. Extract FinalAnswer from child session
+        let events = child_store
+            .get_events(child_session_id, &EventFilter::default())
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
+        let answer = events.iter()
+            .find_map(|e| match &e.payload {
+                EventPayload::FinalAnswer { answer } => Some(answer.clone()),
+                _ => None,
+            })
+            .ok_or_else(|| ToolError::ExecutionFailed("skill produced no FinalAnswer".into()))?;
+
+        // 8. Record SkillCompleted in parent session
+        ctx.store
+            .append_event(
+                ctx.session_id,
+                EventPayload::SkillCompleted { skill_name: skill_name.clone(), child_session_id },
+                Actor::Harness,
+                Some(ctx.trigger_event_id),
+            )
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
+
+        Ok(ExecutionResult { stdout: answer, stderr: String::new(), exit_code: 0 })
+    }
+}
+```
+
+### `src/loader.rs` — SkillLoader
+
+动态加载 skills/ 目录下的所有 skill。单个失败仅 warn，不影响其他。
+
+```rust
+//! Skill loader — scans a directory and loads all SKILL.md definitions.
+
+use std::path::PathBuf;
+
+use lattice_core::{LLMClient, ToolExecutor};
+use lattice_tools::ToolSet;
+
+use super::definition::SkillDefinition;
+use super::tool::SkillTool;
+
+/// Loads skills from a directory on the filesystem.
+///
+/// Each subdirectory of `skills_dir` is one skill; SKILL.md is the only required file.
+/// Follows the Anthropic Agent Skills directory structure.
+pub struct SkillLoader { skills_dir: PathBuf }
+
+impl SkillLoader {
+    pub fn new(skills_dir: impl Into<PathBuf>) -> Self {
+        Self { skills_dir: skills_dir.into() }
+    }
+
+    /// Scan `skills_dir`, load every subdirectory containing a SKILL.md.
+    /// One failed skill does not abort loading others — failures are logged at WARN level.
+    pub async fn load_all(
+        &self,
+        parent_tools: Arc<ToolSet>,
+        llm: Arc<dyn LLMClient>,
+    ) -> Vec<SkillTool> {
+        let mut skills = vec![];
+        let mut entries = match tokio::fs::read_dir(&self.skills_dir).await {
+            Ok(e) => e,
+            Err(e) => { tracing::warn!("skills directory not found: {:?}: {}", self.skills_dir, e); return skills; }
+        };
+        while let Some(entry) = entries.next_entry().await.expect("read_dir ok") {
+            let path = entry.path();
+            if path.is_dir() {
+                match self.load_one(&path, parent_tools.clone(), llm.clone()).await {
+                    Ok(skill) => skills.push(skill),
+                    Err(e) => tracing::warn!("skipping skill at {:?}: {}", path, e),
+                }
+            }
+        }
+        skills
+    }
+
+    async fn load_one(
+        &self,
+        dir: &PathBuf,
+        parent_tools: Arc<ToolSet>,
+        llm: Arc<dyn LLMClient>,
+    ) -> Result<SkillTool, SkillLoadError> {
+        let skill_md_path = dir.join("SKILL.md");
+        let raw = tokio::fs::read_to_string(&skill_md_path)
+            .await
+            .map_err(|_| SkillLoadError::MissingSkillMd(skill_md_path.clone()))?;
+
+        let (frontmatter, body) = parse_skill_md(&raw)
+            .ok_or_else(|| SkillLoadError::MissingFrontmatter(skill_md_path.clone()))?;
+
+        let definition: SkillDefinition = serde_yaml::from_str(frontmatter)
+            .map_err(SkillLoadError::YamlParse)?;
+
+        definition.validate().map_err(SkillLoadError::Validation)?;
+
+        let system_prompt = body.trim().to_string();
+        Ok(SkillTool::new(definition, system_prompt, parent_tools, llm))
+    }
+}
+
+/// Split "---\nfrontmatter\n---\nbody" into (frontmatter, body).
+pub fn parse_skill_md(raw: &str) -> Option<(&str, &str)> {
+    let rest = raw.strip_prefix("---\n")?;
+    let end = rest.find("\n---\n")?;
+    Some((&rest[..end], &rest[end + 5..]))
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SkillLoadError {
+    #[error("SKILL.md not found at {0:?}")]
+    MissingSkillMd(PathBuf),
+    #[error("SKILL.md missing YAML frontmatter at {0:?}")]
+    MissingFrontmatter(PathBuf),
+    #[error("validation error: {0}")]
+    Validation(#[from] super::definition::SkillValidationError),
+    #[error("yaml parse error: {0}")]
+    YamlParse(#[from] serde_yaml::Error),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+```
+
+### `Cargo.toml`
+
+```toml
+[package]
+name = "lattice-skill"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+lattice-core    = { path = "../core" }
+lattice-tools   = { path = "../tools" }
+lattice-runtime = { path = "../runtime" }
+async-trait  = { workspace = true }
+serde        = { workspace = true, features = ["derive"] }
+serde_json   = { workspace = true }
+serde_yaml   = { workspace = true }
+indexmap     = { workspace = true, features = ["serde"] }
+tokio        = { workspace = true, features = ["fs"] }
+thiserror    = { workspace = true }
+tracing      = { workspace = true }
+```
+
+---
+
+## 测试要求
+
+### 单元测试
+
+**`lattice-skill`**：
+
+- `SkillDefinition::validate()`：name 为空报错；name 超 64 字符报错；description 超 1024 字符报错；正常值通过
+- `SkillToolSet`：
+  - own 工具优先于继承工具（同名时）
+  - excluded 工具返回 NotFound
+  - `descriptions()` 正确排除 excluded 工具
+- `SkillTool::execute`：`depth >= MAX_SKILL_DEPTH` 返回 `MaxDepthExceeded`
+- `SkillLoader`：
+  - 缺少 SKILL.md → `MissingSkillMd`
+  - 缺少 frontmatter → `MissingFrontmatter`
+  - 单 skill 失败不影响其他 skill
+- `parse_skill_md`：
+  - 正确拆分 `"---\nYAML\n---\nMD"` → `("YAML", "MD")`
+  - 缺少 `---` → `None`
+
+### 集成测试
+
+- meta agent 调用 skill，父 session 有 `SkillInvoked` + `SkillCompleted` 事件，子 session 有完整事件链
+- skill 深度超限返回 `MaxDepthExceeded`，父 agent 收到 `ToolCallError` 事件，整体不崩溃
+
+---
+
+## 验收标准
+
+- [ ] `lattice-skill` crate 编译通过，包含 `SkillDefinition`（含验证）、`SkillToolSet`（继承/exclude/覆盖）、`SkillTool`（实现 ToolExecutor）、`SkillLoader`（扫描 + 解析 SKILL.md）
+- [ ] `SkillTool::execute`：depth 检查 → 子 session 创建 → 子 ControlLoop 执行 → 结果回传 → 父子 session 事件记录
+- [ ] `SkillLoader` 单 skill 失败仅 warn 不 panic
+- [ ] `MAX_SKILL_DEPTH = 8`，超限返回 `ToolError::MaxDepthExceeded`
+- [ ] 所有上述单元测试通过
+- [ ] `cargo fmt` + `cargo clippy` + `cargo test -p lattice-skill` 通过

--- a/tasks/20-6-skill-facade.md
+++ b/tasks/20-6-skill-facade.md
@@ -1,0 +1,249 @@
+# 任务 20-6：skill feature + 示例 skill 目录 + meta-agent example
+
+## 目标
+
+将 lattice-skill 接入 facade crate，添加示例 skill 目录，创建 meta-agent example，实现端到端验证。
+
+## 分支
+
+`feat/skill-facade`
+
+## 依赖
+
+- 任务 20-5（lattice-skill crate）
+
+---
+
+## 修改内容
+
+### 1. 更新 workspace members（`Cargo.toml` 根目录）
+
+```toml
+members = [
+    # ... 已有的 ...
+    "crates/skill",
+]
+```
+
+### 2. 更新 Facade crate（`src/lib.rs` + `Cargo.toml` 根目录）
+
+**`Cargo.toml`** 新增：
+
+```toml
+[features]
+skill = ["dep:lattice-skill", "tools"]
+full  = ["runtime", "store-memory", "sandbox-local", "llm-all", "tools", "skill"]
+
+[dependencies]
+lattice-skill = { path = "crates/skill", optional = true }
+```
+
+**`src/lib.rs`** 新增：
+
+```rust
+/// Skill system — skill loading, SkillTool, and SkillToolSet.
+#[cfg(feature = "skill")]
+pub use lattice_skill as skill;
+```
+
+### 3. 添加示例 skill 目录
+
+```
+skills/
+└── web-research/
+    ├── SKILL.md                # 完整示例（见下方）
+    ├── scripts/                # 空占位符
+    ├── references/            # 空占位符
+    └── assets/                # 空占位符
+```
+
+**`skills/web-research/SKILL.md`**：
+
+```markdown
+---
+name: web-research
+description: >-
+  Deep research on a topic using web search and content synthesis.
+  Use when the user asks to research, investigate, or compile information
+  on any subject. Returns structured findings with sources.
+compatibility: Requires internet access
+allowed-tools: bash http_fetch
+metadata:
+  author: lattice
+  version: "1.0.0"
+  short-description: Web research and synthesis specialist
+---
+
+# Web Research
+
+You are a research specialist. Perform thorough research on the given topic.
+
+## Input Requirements
+
+- A research query from the user.
+- If `depth` parameter is set, perform that many search iterations (1-5).
+
+## Execution Steps
+
+### Step 1: Initial Search
+Use available search tools to find relevant sources for the query.
+Aim for at least 5 distinct sources.
+
+### Step 2: Deep Dive
+For each promising source, extract key facts, data points, and quotes.
+Cross-reference claims across multiple sources.
+
+### Step 3: Synthesis
+Compile findings into a structured summary with:
+- Key findings (bullet points)
+- Sources consulted (with URLs)
+- Confidence level (high/medium/low)
+
+## Output Format
+Return a FinalAnswer with the structured summary.
+Be concise but complete. Focus on accuracy over breadth.
+```
+
+### 4. 新建 `examples/meta-agent`
+
+```
+examples/meta-agent/
+├── Cargo.toml
+└── src/
+    └── main.rs
+```
+
+**`Cargo.toml`**：
+
+```toml
+[package]
+name = "meta-agent"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+lattice = { path = "../..", features = ["runtime", "store-memory", "sandbox-local", "llm-anthropic", "tools", "skill"] }
+tokio = { workspace = true }
+anyhow = { workspace = true }
+tracing-subscriber = { workspace = true }
+```
+
+**`src/main.rs`**：
+
+```rust
+//! Meta agent example — demonstrates skill delegation with mock LLM.
+//!
+//! Uses MockLLMClient to simulate:
+//!   1. Meta agent decides to call "skill:web-research"
+//!   2. Skill agent returns a FinalAnswer
+//!   3. Meta agent returns the skill result as its own FinalAnswer
+
+use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use lattice::prelude::*;
+use lattice::skill::{SkillLoader, SkillTool};
+use lattice::core::{Decision, Event, EventFilter, ExecutionResult, LLMClient, LLMError, ToolDescription};
+
+// ── Mock LLM ──────────────────────────────────────────────────────────────
+
+struct MetaLLM;
+#[async_trait] impl LLMClient for MetaLLM {
+    async fn decide(&self, _h: &[Event], _t: &[ToolDescription], _s: &str)
+        -> Result<Decision, LLMError>
+    {
+        // Meta agent: decide to call the skill tool
+        Ok(Decision::ToolCall {
+            tool: "skill:web-research".into(),
+            params: serde_json::json!({ "input": "latest Rust async runtime research" }),
+        })
+    }
+}
+
+struct SkillLLM(Arc<Mutex<usize>>);
+impl SkillLLM {
+    fn new() -> Self { Self(Arc::new(Mutex::new(0))) }
+}
+#[async_trait] impl LLMClient for SkillLLM {
+    async fn decide(&self, _h: &[Event], _t: &[ToolDescription], _s: &str)
+        -> Result<Decision, LLMError>
+    {
+        let mut step = self.0.lock().unwrap();
+        *step += 1;
+        if *step == 1 {
+            Ok(Decision::Thinking { reasoning: "researching...".into() })
+        } else {
+            Ok(Decision::FinalAnswer {
+                answer: "Rust async runtimes (Tokio, async-std, Smol) continue to evolve...".into(),
+            })
+        }
+    }
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let store = Arc::new(MemoryStore::new());
+    let session_id = store.create_session().await?;
+    store.append_event(
+        session_id,
+        EventPayload::UserMessage { content: "Research Rust async runtimes".into() },
+        Actor::Harness,
+        None,
+    ).await?;
+
+    // Use MockLLM or real LLM based on environment
+    let llm: Arc<dyn LLMClient> = if std::env::var("ANTHROPIC_API_KEY").is_ok() {
+        Arc::new(lattice::llm_anthropic::AnthropicClient::from_env()?)
+    } else {
+        Arc::new(MetaLLM)
+    };
+
+    // Build parent tools (empty for this example, skills add themselves)
+    let mut tools = ToolSet::new();
+
+    // Load skills if the directory exists
+    if std::path::Path::new("skills/").exists() {
+        let loader = SkillLoader::new("skills/");
+        let skills = loader.load_all(Arc::new(tools.clone()), llm.clone()).await;
+        for skill in skills {
+            tools.register(skill)?;
+        }
+    }
+
+    let control_loop = ControlLoop::builder()
+        .store(store.clone())
+        .llm(llm)
+        .tools(Arc::new(tools))
+        .system_prompt("You are a meta agent. Use skills to delegate complex subtasks.")
+        .build();
+
+    let answer = control_loop.run(session_id).await?;
+    println!("Final answer: {}", answer);
+
+    // Inspect session tree
+    let children = store.child_sessions(session_id).await?;
+    println!("\nSession tree: {} child session(s)", children.len());
+    for child in &children {
+        println!("  Skill '{}': {}", child.skill_name, child.session_id);
+    }
+
+    Ok(())
+}
+```
+
+---
+
+## 验收标准
+
+- [ ] workspace members 包含 `crates/skill`
+- [ ] facade `skill` feature 正确导出 `lattice-skill`
+- [ ] `skills/web-research/SKILL.md` 存在且符合规范
+- [ ] `examples/meta-agent` 编译通过
+- [ ] `cargo build --example meta-agent` 成功
+- [ ] `cargo fmt` + `cargo clippy` 通过

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -2,15 +2,15 @@
 
 ## 第一轮：MVP ✅
 
-| #   | 任务                                                   | 分支名                | 状态 |
-| --- | ------------------------------------------------------ | --------------------- | ---- |
-| 1   | [初始化 workspace + crate 骨架](01-init-workspace.md)  | `feat/init-workspace` | ✅    |
-| 2   | [搭建 CI/CD](02-setup-ci.md)                           | `feat/setup-ci`       | ✅    |
-| 3   | [实现 core 类型和 trait](03-core-traits.md)            | `feat/core-traits`    | ✅    |
-| 4   | [实现 MemoryStore](04-store-memory.md)                 | `feat/store-memory`   | ✅    |
-| 5   | [实现 LocalSandbox](05-sandbox-local.md)               | `feat/sandbox-local`  | ✅    |
-| 6   | [实现 ControlLoop](06-runtime.md)                      | `feat/runtime`        | ✅    |
-| 7   | [实现 hello-agent example](07-hello-agent.md)          | `feat/hello-agent`    | ✅    |
+| #   | 任务                                                  | 分支名                | 状态 |
+| --- | ----------------------------------------------------- | --------------------- | ---- |
+| 1   | [初始化 workspace + crate 骨架](01-init-workspace.md) | `feat/init-workspace` | ✅    |
+| 2   | [搭建 CI/CD](02-setup-ci.md)                          | `feat/setup-ci`       | ✅    |
+| 3   | [实现 core 类型和 trait](03-core-traits.md)           | `feat/core-traits`    | ✅    |
+| 4   | [实现 MemoryStore](04-store-memory.md)                | `feat/store-memory`   | ✅    |
+| 5   | [实现 LocalSandbox](05-sandbox-local.md)              | `feat/sandbox-local`  | ✅    |
+| 6   | [实现 ControlLoop](06-runtime.md)                     | `feat/runtime`        | ✅    |
+| 7   | [实现 hello-agent example](07-hello-agent.md)         | `feat/hello-agent`    | ✅    |
 
 ## 第二轮：真实 LLM 接入 ✅
 
@@ -30,16 +30,31 @@
 
 **目标**：从库升级为可独立部署的平台服务
 
-| #   | 任务                                                  | 分支名                 | 状态 |
-| --- | ----------------------------------------------------- | ---------------------- | ---- |
-| 12  | [Facade crate + Feature Flags](12-facade-features.md) | `feat/facade-features` | ✅    |
-| 13  | [Server crate 骨架 + 基础路由](13-server-skeleton.md) | `feat/server-skeleton` | ✅    |
-| 14  | [会话管理 API](14-session-api.md)                     | `feat/session-api`     | ✅    |
-| 15  | [工具系统：ToolExecutor + ToolSet + 标准工具库](15-tool-system.md) | `feat/tool-system` | ✅ |
-| 16  | [任务提交与 Agent 执行 API](16-agent-run-api.md)      | `feat/agent-run-api`   | ⬜    |
-| 17  | [SSE 实时事件流](17-sse-stream.md)                    | `feat/sse-stream`      | ⬜    |
-| 18  | [配置管理与多 Provider 支持](18-config-provider.md)   | `feat/config-provider` | ⬜    |
-| 19  | [Docker 化独立部署](19-docker-deploy.md)              | `feat/docker-deploy`   | ⬜    |
+| #   | 任务                                                                                     | 分支名                 | 状态 |
+| --- | ---------------------------------------------------------------------------------------- | ---------------------- | ---- |
+| 12  | [Facade crate + Feature Flags](12-facade-features.md)                                    | `feat/facade-features` | ✅    |
+| 13  | [Server crate 骨架 + 基础路由](13-server-skeleton.md)                                    | `feat/server-skeleton` | ✅    |
+| 14  | [会话管理 API](14-session-api.md)                                                        | `feat/session-api`     | ✅    |
+| 15  | [工具系统：ToolExecutor + ToolSet + 标准工具库](15-tool-system.md)                       | `feat/tool-system`     | ✅    |
+| 16  | [任务提交与 Agent 执行 API](16-agent-run-api.md)                                         | `feat/agent-run-api`   | ⬜    |
+| 17  | [SSE 实时事件流](17-sse-stream.md)                                                       | `feat/sse-stream`      | ⬜    |
+| 18  | [配置管理与多 Provider 支持](18-config-provider.md)                                      | `feat/config-provider` | ⬜    |
+| 19  | [Docker 化独立部署](19-docker-deploy.md)                                                 | `feat/docker-deploy`   | ⬜    |
+
+## 第五轮：Skill 系统 🚧
+
+**目标**：实现 Lattice 的 skill 系统，使 meta agent 能将复杂子任务委托给专门的 skill agent 执行。skill 在父 agent 视角是普通 tool 调用，背后运行完整的子 ControlLoop，支持多轮 LLM 决策、独立工具集和独立 session 树节点。
+
+**设计原则**：遵循 [Anthropic Agent Skills 开放标准](https://www.agentskills.com)，以 SKILL.md 为唯一事实来源，实现渐进式披露三层加载。
+
+| #    | 任务                                                           | 分支名                    | 状态 |
+|------|---------------------------------------------------------------|---------------------------|------|
+| 20-1 | [core 层扩展：ExecutionContext + EventPayload + ToolError](20-1-execution-context.md) | `feat/skill-execution-context` | ⬜ |
+| 20-2 | [SessionStore 树形扩展 + MemoryStore 子 session](20-2-session-tree.md)               | `feat/skill-session-tree`      | ⬜ |
+| 20-3 | [ToolSet + 已有工具适配新签名](20-3-tool-execute-ctx.md)                              | `feat/skill-tool-execute-ctx` | ⬜ |
+| 20-4 | [ControlLoop 构造 ExecutionContext + builder](20-4-control-loop-ctx.md)               | `feat/skill-control-loop`      | ⬜ |
+| 20-5 | [lattice-skill crate：SkillDefinition + SkillTool + SkillToolSet + SkillLoader](20-5-skill-crate.md) | `feat/skill-crate`    | ⬜ |
+| 20-6 | [skill feature + 示例 skill 目录 + meta-agent example](20-6-skill-facade.md)         | `feat/skill-facade`           | ⬜ |
 
 ## 后续规划（待拆解）
 


### PR DESCRIPTION
Split the monolithic tasks/20-skill-system.md into 6 focused sub-tasks:

- 20-1: ExecutionContext + MAX_SKILL_DEPTH + EventPayload variants + ToolError variant
- 20-2: SessionStore tree extension (create_child_session / child_sessions)
- 20-3: ToolSet + BashTool adapter to new ctx-bearing execute signature
- 20-4: ControlLoop depth field + builder + ExecutionContext construction
- 20-5: lattice-skill crate (SkillDefinition, SkillToolSet, SkillTool, SkillLoader)
- 20-6: skill feature + example skill directory + meta-agent example

Also updated:
- docs/ARCHITECTURE.md: EventPayload, SessionStore, ToolExecutor signature sync
- docs/ROADMAP.md: skill section expanded to 6 sub-tasks
- CLAUDE.md: crate structure + skill crate entry
- tasks/15-tool-system.md: execute signature includes ctx: &ExecutionContext
- tasks/README.md: added Fifth Round: Skill System with 6 sub-tasks