### PR TITLE
docs: task 20 split, architecture rewritten, roadmap consolidated

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,30 @@ Lattice 是一个 Rust 编写的 Agent 元框架，灵感来自 [Anthropic Manag
 
 ## 架构
 
-三个核心抽象：
+### 演进路线（详细见 [ROADMAP](docs/ROADMAP.md)）
 
-- **Session** — 不可变的事件溯源日志，Agent 的持久化记忆
-- **ControlLoop** — Agent 的大脑，负责调用 LLM 并路由决策
-- **Sandbox** — Agent 的双手，隔离的工具执行环境
+| 轮次 | 内容 | 状态 |
+|---|---|---|
+| 第一轮 | MVP：core traits + MemoryStore + LocalSandbox + ControlLoop | ✅ 已完成 |
+| 第二轮 | 真实 LLM 接入：LLM protocol + Anthropic + OpenAI | ✅ 已完成 |
+| 第三轮 | 真实 LLM 验证：端到端跑通 | ✅ 已完成 |
+| 第四轮 | HTTP API 层：REST API + SSE 实时事件流 + Docker 部署 | 🚧 进行中 |
+| 第五轮 | Skill 系统：ExecutionContext + Session Tree + SkillTool + 动态加载 | 📋 规划中 |
+| 第六轮 | 记忆与规划：RuntimeState + Planner trait + LongTermMemory | 📋 规划中 |
+
+### 核心抽象
+
+- **Session（记忆层）** — 不可变的事件溯源日志，append-only，保证可追溯性
+- **ControlLoop（执行层）** — Agent 的大脑，调用 LLM 并路由决策
+- **Sandbox（执行层）** — Agent 的双手，隔离的工具执行环境
+
+三层工具体系：
+
+- **Layer 1** — `lattice-core`：纯接口（`ToolExecutor` trait）
+- **Layer 2** — `lattice-tools`：标准工具库（Bash、File、Glob、Grep、HTTP）
+- **Layer 3** — 应用层注入：自定义工具、MCP 桥接、Skill 工具集
+
+**Skill 系统**（第五轮）遵循 [Anthropic Agent Skills](https://www.agentskills.com) 开放标准，skill 作为普通工具调用，背后运行完整子 ControlLoop，实现渐进式披露三层加载。
 
 ## 快速开始
 
@@ -74,11 +93,11 @@ curl http://localhost:3000/health
 
 ## LLM Provider 支持
 
-| Provider | 包 | 状态 |
-|----------|-----|------|
-| Anthropic Claude | `lattice-llm-anthropic` | ✅ |
-| OpenAI 兼容 | `lattice-llm-openai` | ✅ |
-| 自定义 base URL | via `LATTICE_API_BASE` | ✅ |
+| Provider         | 包                      | 状态 |
+| ---------------- | ----------------------- | ---- |
+| Anthropic Claude | `lattice-llm-anthropic` | ✅    |
+| OpenAI 兼容      | `lattice-llm-openai`    | ✅    |
+| 自定义 base URL  | via `LATTICE_API_BASE`  | ✅    |
 
 ## 文档
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,111 +12,73 @@ Lattice 的架构灵感来自 Anthropic 的 Managed Agents 博客（*Scaling Man
 ## 三个核心抽象
 
 ```
-┌──────────────────────────────────────────────┐
-│              ControlLoop (大脑)                │
-│  依赖两个 trait:                               │
-│  - SessionStore                               │
-│  - LLMClient                                  │
-│  持有 ToolSet（工具注册表）                     │
-└──────┬───────────────┬───────────────┬─────────┘
-       │               │               │
-  ┌────▼─────┐   ┌─────▼─────┐  ┌─────▼───────────┐
-  │ Session  │   │ LLMClient │  │   ToolSet       │
-  │  Store   │   │           │  │ (注册表 + 执行) │
-  │ (trait)  │   │ (trait)   │  │ (可组合实现)   │
-  └──────────┘   └───────────┘  └───────┬─────────┘
-                                        │ ToolExecutor trait
-                                  ┌─────▼─────────┐
-                                  │ BashTool      │
-                                  │ (或任意工具)  │
-                                  │  └─ Sandbox  │
-                                  └──────────────┘
+┌─────────────────────────────────────────────────────────────┐
+│                 ControlLoop（Agent 的大脑）                   │
+│  持有 ToolSet（工具注册表），唯一有权调用 LLM                 │
+│  依赖两个 trait:                                            │
+│    - SessionStore（记忆层）                                  │
+│    - LLMClient（推理层）                                    │
+└──────────┬──────────────────────────────────┬──────────────┘
+           │                                  │
+      ┌────▼──────┐                    ┌─────▼───────┐
+      │ Session   │                    │  ToolSet    │
+      │  Store    │                    │  (Layer 1-3)│
+      │ (trait)   │                    └──────┬──────┘
+      └───────────┘                            │
+                                        ┌──────▼──────┐
+                                        │ ToolExecutor │
+                                        │  (trait)    │
+                                        └──────┬──────┘
+                                               │
+                                        ┌──────▼──────────────┐
+                                        │ BashTool / FileTool  │
+                                        │ / GlobTool / MCP ... │
+                                        └─────────────────────┘
 ```
 
-### 工具三层体系
+**三层工具体系**（Layer 1-3 由 `ToolSet` 统一调用，ControlLoop 不区分沙箱执行还是进程内执行）：
 
-Lattice 的工具系统分为三层：
+- **Layer 1（`lattice-core`）**：纯接口——`ToolExecutor` trait
+- **Layer 2（`lattice-tools`）**：标准工具库——BashTool、FileTool 等
+- **Layer 3（应用层）**：用户注入——MCP 桥接、自定义工具、Skill 工具集
 
-1. **Layer 1（core）**：定义 `ToolExecutor` trait——所有工具的统一接口
-2. **Layer 2（lattice-tools）**：`ToolSet` 注册表 + 标准工具实现（BashTool）
-3. **Layer 3（应用层）**：注入自定义工具实现
+---
 
-ControlLoop 通过 `ToolSet` 统一调用工具，不区分工具背后是沙箱执行还是进程内执行。
-
-### 1. Session（会话）—— 不可变事件日志
+## 1. Session（会话）—— 不可变事件日志
 
 **定义**：Agent 运行期间产生的所有事件的不可变、仅追加、持久化序列。
 
 **不是什么**：
-- 不是 LLM 的对话历史
+- 不是 LLM 的对话历史（那是短期记忆层，规划中）
 - 不是上下文窗口
 - 不可修改、不可删除
 
-**事件结构**：
+### 事件类型
 
 ```rust
-/// 事件唯一标识
-pub type EventId = Uuid;
-
-/// 事件时间戳
-pub type Timestamp = chrono::DateTime<chrono::Utc>;
-
-/// 产生事件的角色
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "PascalCase")]
-pub enum Actor {
-    System,
-    LLM,
-    Harness,
-    Sandbox,
-}
-
 /// 事件负载
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum EventPayload {
-    /// 会话创建
     SessionCreated,
 
-    /// 用户输入任务
     UserMessage { content: String },
 
-    /// LLM 的思考过程
     Thinking { reasoning: String },
 
-    /// LLM 决定调用工具
-    ToolCallRequested {
-        tool: String,
-        params: serde_json::Value,
-    },
+    ToolCallRequested { tool: String, params: serde_json::Value },
 
-    /// 工具调用结果
-    ToolCallResult {
-        stdout: String,
-        stderr: String,
-        exit_code: i32,
-    },
+    ToolCallResult { stdout: String, stderr: String, exit_code: i32 },
 
-    /// 工具调用失败
     ToolCallError { error: String },
 
-    /// LLM 给出最终答案
     FinalAnswer { answer: String },
 
-    /// 会话状态变更
     StateChange { from: String, to: String },
 
-    /// Skill 被触发执行 —— 记录在父 session 中
-    SkillInvoked {
-        skill_name: String,
-        child_session_id: SessionId,
-    },
-
-    /// Skill 执行完成 —— 记录在父 session 中
-    SkillCompleted {
-        skill_name: String,
-        child_session_id: SessionId,
-    },
+    // — Skill 系统扩展 —
+    SkillInvoked { skill_name: String, child_session_id: SessionId },
+    SkillCompleted { skill_name: String, child_session_id: SessionId },
 }
 
 /// 一个不可变事件
@@ -131,15 +93,13 @@ pub struct Event {
 }
 ```
 
-**SessionStore trait**：
+### SessionStore trait
 
 ```rust
 #[async_trait]
 pub trait SessionStore: Send + Sync {
-    /// 创建一个新会话，返回 session_id
     async fn create_session(&self) -> Result<SessionId, StoreError>;
 
-    /// 追加事件（仅追加，不可修改）
     async fn append_event(
         &self,
         session_id: SessionId,
@@ -148,74 +108,69 @@ pub trait SessionStore: Send + Sync {
         parent_event_id: Option<EventId>,
     ) -> Result<EventId, StoreError>;
 
-    /// Retrieve events for a session, optionally filtered.
     async fn get_events(
         &self,
         session_id: SessionId,
         filter: &EventFilter,
     ) -> Result<Vec<Event>, StoreError>;
 
-    /// Get the latest event id for a session.
     async fn latest_event_id(&self, session_id: SessionId) -> Result<Option<EventId>, StoreError>;
 
-    /// Create a child session under the given parent.
-    ///
-    /// The child session is independent — its events are stored in the
-    /// returned child store. The parent store records the relationship
-    /// for `child_sessions()` queries.
+    // — Skill 系统扩展 —
     async fn create_child_session(
         &self,
         parent_session_id: SessionId,
         skill_name: &str,
     ) -> Result<(SessionId, Arc<dyn SessionStore>), StoreError>;
 
-    /// List all child sessions for a given parent.
     async fn child_sessions(
         &self,
         parent_session_id: SessionId,
     ) -> Result<Vec<ChildSessionInfo>, StoreError>;
 }
-
-/// Information about a child session (returned by SessionStore::child_sessions).
-#[derive(Debug, Clone)]
-pub struct ChildSessionInfo {
-    pub session_id: SessionId,
-    pub store: Arc<dyn SessionStore>,
-    pub skill_name: String,
-    pub created_at: Timestamp,
-}
 ```
 
-### 2. ControlLoop（控制循环）—— Agent 的大脑
+### Session Tree（Skill 系统）
+
+Session 支持树形扩展：父 session 调用 skill 时创建子 session，子 session 拥有独立的 SessionStore。父 session 的事件日志记录 `SkillInvoked`/`SkillCompleted` 事件，携带子 session ID，供可观测性查询。
+
+```
+Root SessionStore
+├── session-001 (meta agent)
+│   └── SkillInvoked → session-002 (skill: web-research, 独立 MemoryStore)
+└── session-003 (另一个 meta agent)
+```
+
+---
+
+## 2. ControlLoop（控制循环）—— Agent 的大脑
 
 **定义**：唯一有权调用 LLM 的组件。负责加载事件历史、构建提示、解析 LLM 决策、路由工具调用。
 
 **关键特性**：
 - **无状态**：不持有持久状态，所有状态从 SessionStore 恢复
-- **可崩溃恢复**：进程崩溃后，用同一个 session_id 重新创建 ControlLoop，从事件日志断点继续
-- **工具委托**：通过 ToolSet 执行工具调用，记录结果或错误事件
+- **可崩溃恢复**：用同一个 session_id 重新创建 ControlLoop，从事件日志断点继续
+- **深度感知**：通过 `depth` 字段追踪 skill 嵌套层级，防无限递归
 
-**决策循环**：
+### 决策循环
 
 ```
 loop {
     1. 从 SessionStore 加载事件历史
-    2. 从 ToolSet 获取可用工具描述，构建 LLM 提示
-    3. 调用 LLMClient.decide()
-    4. 记录决策事件
-    5. match 决策:
+    2. 从 ToolSet 获取工具描述，调用 LLM
+    3. 记录决策事件
+    4. match 决策:
        - FinalAnswer → 记录结果，退出循环
-       - Thinking → 继续循环
-       - ToolCall → 通过 ToolSet.execute(tool, params) 执行，记录结果/错误，继续循环
+       - Thinking   → 继续循环
+       - ToolCall   → 构造 ExecutionContext，ToolSet.execute()，记录结果/错误，继续循环
 }
 ```
 
-**LLMClient trait**：
+### LLMClient trait
 
 ```rust
 #[async_trait]
 pub trait LLMClient: Send + Sync {
-    /// 基于事件历史和可用工具做出决策
     async fn decide(
         &self,
         history: &[Event],
@@ -224,7 +179,6 @@ pub trait LLMClient: Send + Sync {
     ) -> Result<Decision, LLMError>;
 }
 
-/// LLM 的决策
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum Decision {
@@ -234,24 +188,40 @@ pub enum Decision {
 }
 ```
 
-### 3. Sandbox（沙箱）—— Agent 的双手
+### ExecutionContext
+
+```rust
+/// Maximum allowed skill nesting depth. A meta agent has depth=0;
+/// its direct skill children have depth=1, and so on.
+pub const MAX_SKILL_DEPTH: u32 = 8;
+
+/// Execution context passed to every tool invocation.
+pub struct ExecutionContext {
+    pub session_id: SessionId,
+    pub trigger_event_id: EventId,
+    pub store: Arc<dyn SessionStore>,
+    pub depth: u32,
+}
+```
+
+---
+
+## 3. Sandbox（沙箱）—— Agent 的双手
 
 **定义**：隔离的工具执行环境，按需创建，可替换。
 
 **关键特性**：
 - **隔离**：沙箱内的代码无法访问框架内部或凭据
-- **可替换**：崩溃了换一个新的，ControlLoop 视之为一次工具调用失败
-- **按需启动**：只在 LLM 真正需要执行工具时才创建
-- **跨平台**：LocalSandbox 根据操作系统自动选择合适的 shell
+- **可替换**：崩溃后换一个，ControlLoop 视之为一次工具调用失败
+- **跨平台**：`LocalSandbox` 根据 OS 自动选择 shell
   - Unix/Linux/macOS: `sh -c`
   - Windows: `cmd.exe /C`
 
-**Sandbox trait**：
+### Sandbox trait
 
 ```rust
 #[async_trait]
 pub trait Sandbox: Send + Sync {
-    /// 执行命令
     async fn execute(
         &self,
         command: &str,
@@ -267,24 +237,17 @@ pub struct ExecutionResult {
 }
 ```
 
-**ToolExecutor trait**：
+---
+
+## 工具系统
+
+### ToolExecutor trait（Layer 1）
 
 ```rust
-/// Execution context passed to every tool invocation.
-pub struct ExecutionContext {
-    pub session_id: SessionId,
-    pub trigger_event_id: EventId,
-    pub store: Arc<dyn SessionStore>,
-    pub depth: u32,   // 0 = meta agent, 1 = direct skill child, etc.
-}
-pub const MAX_SKILL_DEPTH: u32 = 8;
-
 #[async_trait]
 pub trait ToolExecutor: Send + Sync {
-    /// Return the tool description for LLM consumption.
     fn description(&self) -> ToolDescription;
 
-    /// Execute the tool with the given parameters and execution context.
     async fn execute(
         &self,
         params: serde_json::Value,
@@ -293,12 +256,26 @@ pub trait ToolExecutor: Send + Sync {
 }
 ```
 
-**ToolSet**：
+### ToolSet（Layer 1-3 统一入口）
 
 ```rust
+pub struct ToolSet {
+    tools: HashMap<String, Box<dyn ToolExecutor>>,
+}
+
 impl ToolSet {
+    pub fn new() -> Self { ... }
+
+    #[cfg(feature = "bash")]
+    pub fn with_defaults(sandbox: Arc<dyn Sandbox>) -> Self { ... }
+
+    /// Register a tool. Error if name conflicts.
     pub fn register(&mut self, tool: impl ToolExecutor + 'static) -> Result<(), ToolError> { ... }
+
+    /// All tool descriptions for LLM consumption.
     pub fn descriptions(&self) -> Vec<ToolDescription> { ... }
+
+    /// Route a tool call to the correct executor.
     pub async fn execute(
         &self,
         name: &str,
@@ -308,14 +285,19 @@ impl ToolSet {
 }
 ```
 
-## 数据流与生命周期
+### ToolSet 与 SandboxRouter 的关系
 
-完整的一次 Agent 任务执行：
+`ToolSet` 统一了工具描述和工具执行两个职责，取代了之前的 `Vec<ToolDescription>` + `SandboxRouter` 分离模式。
+
+`SandboxRouter` trait 和 `BasicSandboxRouter` 已被移除。ToolSet 完全替代了它们的职责——工具路由逻辑内化到 ToolSet 中，沙箱工具通过 `ToolExecutor` 实现内部持有 `Arc<dyn Sandbox>` 来委托执行。
+
+---
+
+## 数据流与生命周期
 
 ```
 1. [客户端] 创建 Session
    → SessionStore.create_session()
-   → 记录 SessionCreated 事件
 
 2. [客户端] 提交用户任务
    → SessionStore.append_event(UserMessage)
@@ -328,36 +310,34 @@ impl ToolSet {
 
 5. [ControlLoop] 从 ToolSet 获取工具描述，调用 LLM
    → LLMClient.decide(history, tools)
-   → 记录 DecisionRecorded 事件
 
 6. [LLM 决定调用工具]
    → 记录 ToolCallRequested 事件
-   → ToolSet.execute(tool, params)
+   → ToolSet.execute(tool, params, ctx)
 
-7. [ToolExecutor] 执行工具（如 BashTool → Sandbox.execute）
+7. [ToolExecutor] 执行工具
    → 记录 ToolCallResult 或 ToolCallError 事件
 
-8. [ControlLoop] 看到结果，回到步骤 4
+8. [ControlLoop] 回到步骤 4
 
 9. [LLM 给出最终答案]
    → 记录 FinalAnswer 事件
    → ControlLoop.run() 返回
-
-10. [客户端] 查询结果
-    → SessionStore.get_events(filter: FinalAnswer)
 ```
+
+---
 
 ## 崩溃恢复
 
 ```
 ControlLoop 崩溃
-  → 系统检测到
   → 用同一个 session_id 创建新的 ControlLoop
-  → ControlLoop.run() 调用 SessionStore.get_events()
-  → 发现最后一个事件是 ToolCallRequested（没有对应的 Result）
+  → SessionStore.get_events() 发现最后一个事件是 ToolCallRequested
   → LLM 看到未完成的调用，决定重试或跳过
   → 继续执行
 ```
+
+---
 
 ## 安全边界
 
@@ -365,326 +345,66 @@ ControlLoop 崩溃
 - **初始化注入**：敏感信息只在沙箱创建阶段注入（如环境变量），运行时代码无法获取注入动作本身
 - **Vault Proxy**（未来）：第三方令牌通过外部代理注入，沙箱永远接触不到原始凭据
 
+---
+
 ## Feature Flag 设计
 
 ### 设计原则
 
-1. **core 零 feature**：`lattice-core` 是纯接口层，不包含任何可选功能，所有消费者必须依赖它
-2. **实现 crate 独立成包**：每个实现（LLM 后端、存储后端、沙箱实现）是独立 crate，消费者通过 `Cargo.toml` 按需引入
-3. **Facade crate 提供便利**：`lattice` facade crate 通过 feature flags 重导出所有子 crate，方便"全家桶"使用
-4. **server 按需编译**：`lattice-server` 通过 feature 控制启用哪些 provider、存储和沙箱后端
-5. **默认最小化**：default feature 只包含最基础的功能，用户明确 opt-in 额外能力
+1. **core 零 feature**：`lattice-core` 是纯接口层，不包含任何可选功能
+2. **实现 crate 独立成包**：每个实现是独立 crate，消费者通过 `Cargo.toml` 按需引入
+3. **Facade crate 提供便利**：`lattice` facade crate 通过 feature flags 重导出所有子 crate
+4. **默认最小化**：default feature 只包含最基础的功能，用户明确 opt-in 额外能力
 
 ### Facade Crate：`lattice`
 
 ```toml
-[package]
-name = "lattice"
-
 [features]
-default = ["runtime", "store-memory", "sandbox-local"]
+default = ["runtime", "store-memory", "sandbox-local", "tools"]
 
-# 核心组件（总是可用，通过 lattice-core）
 runtime = ["dep:lattice-runtime"]
-
-# 存储后端
 store-memory = ["dep:lattice-store-memory"]
-# store-sqlite = ["dep:lattice-store-sqlite"]   # 未来
-# store-postgres = ["dep:lattice-store-postgres"] # 未来
-
-# 沙箱实现
 sandbox-local = ["dep:lattice-sandbox-local"]
-# sandbox-docker = ["dep:lattice-sandbox-docker"] # 未来
-
-# LLM 后端
+tools = ["dep:lattice-tools"]
 llm-protocol = ["dep:lattice-llm-protocol"]
 llm-anthropic = ["llm-protocol", "dep:lattice-llm-anthropic"]
 llm-openai = ["llm-protocol", "dep:lattice-llm-openai"]
 llm-all = ["llm-anthropic", "llm-openai"]
-
-# 便利组合
-full = ["runtime", "store-memory", "sandbox-local", "llm-all"]
-
-[dependencies]
-lattice-core = { path = "crates/core" }           # 始终依赖
-lattice-runtime = { path = "crates/runtime", optional = true }
-lattice-store-memory = { path = "crates/store-memory", optional = true }
-lattice-sandbox-local = { path = "crates/sandbox-local", optional = true }
-lattice-llm-protocol = { path = "crates/llm-protocol", optional = true }
-lattice-llm-anthropic = { path = "crates/llm-anthropic", optional = true }
-lattice-llm-openai = { path = "crates/llm-openai", optional = true }
+skill = ["dep:lattice-skill", "tools"]        # Skill 系统
+full = ["runtime", "store-memory", "sandbox-local", "llm-all", "tools", "skill"]
 ```
 
-`crates/server` 是独立的 `lattice-server` crate，有自己的 feature flags（default=[anthropic, openai]），受 workspace 管理。
-
-### 消费者使用示例
-
-```toml
-# 只要核心 + Anthropic
-lattice = { version = "0.1", default-features = false, features = ["runtime", "store-memory", "sandbox-local", "llm-anthropic"] }
-
-# 全家桶
-lattice = { version = "0.1", features = ["full"] }
-
-# 极简：只要接口定义（写自己的实现）
-lattice = { version = "0.1", default-features = false }
-```
-
-### Server Feature Flags
-
-```toml
-[package]
-name = "lattice-server"
-
-[features]
-default = ["anthropic", "openai"]
-
-# LLM Provider
-anthropic = ["lattice-llm-anthropic"]
-openai = ["lattice-llm-openai"]
-
-# 存储后端（未来）
-# sqlite = ["lattice-store-sqlite"]
-
-# 沙箱后端（未来）
-# docker = ["lattice-sandbox-docker"]
-```
-
-### 代码中的条件编译
-
-在 server 中按 feature 注册 provider：
-
-```rust
-pub fn register_providers(registry: &mut ProviderRegistry, config: &[ProviderConfig]) {
-    for provider in config {
-        match provider.kind {
-            #[cfg(feature = "anthropic")]
-            ProviderKind::Anthropic => { /* register */ },
-
-            #[cfg(feature = "openai")]
-            ProviderKind::OpenAI => { /* register */ },
-
-            #[allow(unreachable_patterns)]
-            _ => tracing::warn!("Provider {:?} not enabled at compile time", provider.kind),
-        }
-    }
-}
-```
-
-## 工具系统
-
-### 设计背景
-
-参考 Anthropic Managed Agents 的设计，工具（tool）的核心接口是 `execute(name, input) → output`。Brain（ControlLoop）不关心工具背后是一个沙箱容器、一个进程内函数、还是一个远程 MCP 服务器——只关心 name + input 进去，output 出来。
-
-Lattice 在此基础上做了一个重要的分层：将「工具描述」（给 LLM 看的元数据）与「工具执行」（实际运行逻辑）分离。一个 Sandbox 可以支持多个工具（如 LocalSandbox 同时支持 bash 和 python），一个工具也可以不需要 Sandbox（如 file_read 在进程内直接执行）。
-
-### 三层工具体系
+### Crate 结构
 
 ```
-┌─────────────────────────────────────────┐
-│  Layer 3: Harness-Provided Tools        │  ← 应用层注入
-│  (MCP servers, custom business tools)   │
-├─────────────────────────────────────────┤
-│  Layer 2: Standard Tool Library         │  ← 框架提供，可选启用
-│  (bash, file_read, file_write, glob,    │
-│   grep, http...)                        │
-│  - 平台感知：BashTool 根据 OS 提供      │
-│    不同的工具描述（sh/cmd）              │
-├─────────────────────────────────────────┤
-│  Layer 1: Tool Infrastructure           │  ← core 层，纯接口
-│  (ToolDescription, ToolExecutor trait,  │
-│   ToolSet)                              │
-└─────────────────────────────────────────┘
+crates/
+├── core/             # 纯接口：SessionStore, LLMClient, Sandbox, ToolExecutor, ExecutionContext
+├── runtime/          # ControlLoop 实现
+├── store-memory/     # MemoryStore 实现
+├── sandbox-local/   # LocalSandbox 实现（跨平台 shell）
+├── tools/           # ToolSet + 标准工具（BashTool 等）
+├── skill/           # Skill 系统（SkillDefinition, SkillTool, SkillLoader）  # 规划中
+├── llm-protocol/    # LLM 通用协议层
+├── llm-anthropic/   # Anthropic Claude 后端
+├── llm-openai/      # OpenAI 兼容后端
+└── server/          # HTTP API 服务（axum）
 ```
 
-**Layer 1：Tool Infrastructure（`lattice-core`）**
+---
 
-纯接口定义，零实现。包括已有的 `ToolDescription` 和新增的 `ToolExecutor` trait。
+## 未来扩展
 
-**Layer 2：Standard Tool Library（`lattice-tools`）**
+- **MCP 桥接工具**：实现 `ToolExecutor`，内部通过 MCP 协议调用外部 MCP 服务器。作为 Layer 3 工具由应用层注入。
+- **沙箱工厂（SandboxFactory）**：按需创建沙箱（如 Docker 容器），引入 factory 模式。
+- **凭据隔离**：资源绑定（token 注入沙箱初始化）和 Vault Proxy 两种模式。
+- **工具权限控制**：参考 Claude Code 的 permission 模型，按工具名配置 allow/deny 规则。
+- **RuntimeState**（第六轮）：运行时结构化状态，供规划执行器快速读写，独立于 append-only 事件日志。
+- **Planner trait**（第六轮）：将步骤决策从 LLM 中枢分离，支持小模型规划器或 FSM 规则引擎。
+- **LongTermMemory**（第六轮）：跨会话记忆，支持向量检索或 SQLite FTS5 全文检索。
 
-框架自带的常用工具实现。每个工具是独立的 struct，实现 `ToolExecutor`。通过 feature flags 按需编译，默认只包含 bash。
+---
 
-**Layer 3：Harness-Provided Tools（应用层）**
-
-框架消费者自行注册的工具——MCP 桥接、业务专用工具等。通过相同的 `ToolExecutor` trait 和 `ToolSet::add()` 接口注入，与内置工具同等公民。
-
-### 核心接口
-
-#### ToolExecutor trait（`lattice-core`）
-
-```rust
-/// Execution context passed to every tool invocation.
-pub struct ExecutionContext {
-    pub session_id: SessionId,
-    pub trigger_event_id: EventId,
-    pub store: Arc<dyn SessionStore>,
-    pub depth: u32,
-}
-pub const MAX_SKILL_DEPTH: u32 = 8;
-
-/// A tool that can be executed by the agent.
-///
-/// Implementations can be in-process (file read, HTTP fetch) or delegate
-/// to a Sandbox (bash, python). The ControlLoop treats all tools identically
-/// through this trait.
-#[async_trait]
-pub trait ToolExecutor: Send + Sync {
-    /// Return the tool description for LLM consumption.
-    fn description(&self) -> ToolDescription;
-
-    /// Execute the tool with the given parameters and execution context.
-    async fn execute(
-        &self,
-        params: serde_json::Value,
-        ctx: &ExecutionContext,
-    ) -> Result<ExecutionResult, ToolError>;
-}
-```
-
-#### ToolSet（`lattice-tools`）
-
-```rust
-/// A collection of tools available to the agent.
-///
-/// ToolSet serves two roles:
-/// 1. Provide tool descriptions to the LLM (via `descriptions()`)
-/// 2. Route tool calls to the correct executor (via `execute()`)
-pub struct ToolSet {
-    tools: HashMap<String, Box<dyn ToolExecutor>>,
-}
-
-impl ToolSet {
-    pub fn new() -> Self { ... }
-
-    /// Build a ToolSet with all default tools enabled by feature flags.
-    /// Currently includes BashTool (if the `bash` feature is enabled).
-    #[cfg(feature = "bash")]
-    pub fn with_defaults(sandbox: Arc<dyn Sandbox>) -> Self {
-        let mut set = Self::new();
-        set.register(BashTool::new(sandbox)).unwrap();
-        set
-    }
-
-    /// Register a tool. Returns error if a tool with the same name already exists.
-    pub fn register(&mut self, tool: impl ToolExecutor + 'static) -> Result<(), ToolError> { ... }
-
-    /// List all tool descriptions (passed to LLMClient::decide).
-    pub fn descriptions(&self) -> Vec<ToolDescription> { ... }
-
-    /// Look up and execute a tool by name.
-    pub async fn execute(
-        &self,
-        name: &str,
-        params: serde_json::Value,
-        ctx: &ExecutionContext,
-    ) -> Result<ExecutionResult, ToolError> { ... }
-}
-```
-
-### 两类工具执行模式
-
-工具按执行方式分为两类，但对 ControlLoop 来说完全透明：
-
-**沙箱工具（Sandbox-backed）**：需要隔离执行环境的工具。`ToolExecutor::execute()` 内部持有 `Arc<dyn Sandbox>` 引用，委托给沙箱执行。
-
-```rust
-/// Bash tool — delegates to a Sandbox for isolated execution.
-/// Platform-aware: provides different tool descriptions based on OS.
-pub struct BashTool {
-    sandbox: Arc<dyn Sandbox>,
-}
-
-#[async_trait]
-impl ToolExecutor for BashTool {
-    fn description(&self) -> ToolDescription {
-        // Platform-specific: "sh" on Unix, "cmd" on Windows
-        #[cfg(unix)]
-        { /* Unix shell description with ls, cat, grep examples */ }
-        
-        #[cfg(windows)]
-        { /* Windows cmd description with dir, type, findstr examples */ }
-    }
-
-    async fn execute(
-        &self,
-        params: serde_json::Value,
-        _ctx: &ExecutionContext,
-    ) -> Result<ExecutionResult, ToolError> {
-        let command = params
-            .get("command")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| ToolError::InvalidParams(
-                "missing or invalid 'command' field (expected string)".to_string(),
-            ))?;
-        self.sandbox
-            .execute(command, params.clone())
-            .await
-            .map_err(|e| ToolError::ExecutionFailed(e.to_string()))
-    }
-}
-```
-
-### 平台感知工具
-
-标准工具库中的某些工具（如 BashTool）是平台感知的，会根据编译目标平台提供不同的工具描述：
-
-- **Unix/Linux/macOS**：工具名为 `"sh"`，描述中包含 Unix 命令示例（ls, cat, grep, find）
-- **Windows**：工具名为 `"cmd"`，描述中包含 Windows 命令示例（dir, type, findstr, where）
-
-这确保 LLM 能够生成适合当前平台的命令。平台检测在编译时通过 `#[cfg(unix)]` 和 `#[cfg(windows)]` 完成，零运行时开销。
-
-**进程内工具（In-process）**：不需要沙箱的轻量工具，直接在框架进程内执行。
-
-```rust
-/// File read tool — reads files in-process, no sandbox needed.
-pub struct FileReadTool {
-    allowed_paths: Vec<PathBuf>,
-}
-
-#[async_trait]
-impl ToolExecutor for FileReadTool {
-    fn description(&self) -> ToolDescription { /* file_read tool schema */ }
-
-    async fn execute(
-        &self,
-        params: serde_json::Value,
-        _ctx: &ExecutionContext,
-    ) -> Result<ExecutionResult, ToolError> {
-        let path = params["path"]
-            .as_str()
-            .ok_or_else(|| ToolError::InvalidParams("missing 'path' field".to_string()))?;
-        let content = tokio::fs::read_to_string(path).await
-            .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
-        Ok(ExecutionResult {
-            stdout: content,
-            stderr: String::new(),
-            exit_code: 0,
-        })
-    }
-}
-```
-
-> **注意**：FileReadTool 及其他进程内工具（glob、grep、http）尚未实现，此处为设计示例。目前已实现的标准工具仅有 BashTool。
-
-### ToolSet 与 SandboxRouter 的关系
-
-`ToolSet` 统一了工具描述和工具执行两个职责，取代了之前的 `Vec<ToolDescription>` + `SandboxRouter` 分离模式。
-
-`SandboxRouter` trait 和 `BasicSandboxRouter` 已被移除。ToolSet 完全替代了它们的职责——工具路由逻辑内化到 ToolSet 中，沙箱工具通过 `ToolExecutor` 实现内部持有 `Arc<dyn Sandbox>` 来委托执行。ControlLoop 持有 `Arc<ToolSet>`：
-
-```rust
-let tools = Arc::new(ToolSet::with_defaults(sandbox));
-let control_loop = ControlLoop::new(store, llm, tools);
-
-// Register custom tools:
-let mut tools = ToolSet::with_defaults(sandbox);
-tools.register(MyCustomTool::new()).unwrap();
-let control_loop = ControlLoop::new(store, llm, Arc::new(tools));
-```
-
-### 测试覆盖率
+## 测试覆盖率
 
 使用 `cargo-llvm-cov` 检测代码覆盖率。覆盖率指标按 crate 维度统计（line coverage、branch coverage），作为 CI 的一部分运行，不阻断合并。
 
@@ -692,53 +412,3 @@ let control_loop = ControlLoop::new(store, llm, Arc::new(tools));
 - **CI 上传**：通过 Codecov action 上传至 codecov.io
 - **报告格式**：LCOV（`--lcov`），生成 lcov.info
 - **原则**：新增代码应附带测试，保持覆盖率不下降
-
-## Crate 结构
-
-```
-crates/
-├── core/           # SessionStore, LLMClient, Sandbox, ToolExecutor traits + core types
-├── tools/          # lattice-tools: 标准工具库
-│   ├── set.rs      #   ToolSet 注册表
-│   └── bash.rs     #   BashTool（沙箱工具）
-├── runtime/        # ControlLoop（接收 Arc<ToolSet>）
-├── store-memory/   # SessionStore 内存实现
-├── sandbox-local/  # Sandbox 本地子进程实现
-├── llm-protocol/   # LLM 通用协议层（消息格式转换、响应解析）
-├── llm-anthropic/  # Anthropic Claude 后端
-├── llm-openai/     # OpenAI 兼容后端
-└── server/         # HTTP API 服务（axum）
-```
-
-#### Feature Flags
-
-```toml
-# crates/tools/Cargo.toml
-[package]
-name = "lattice-tools"
-
-[features]
-default = ["bash"]
-bash = ["lattice-sandbox-local"]
-
-[dependencies]
-lattice-core = { path = "../core" }
-lattice-sandbox-local = { path = "../sandbox-local", optional = true }
-```
-
-Facade crate 同步更新：
-
-```toml
-# 根 Cargo.toml (lattice facade)
-[features]
-default = ["runtime", "store-memory", "sandbox-local", "tools"]
-tools = ["dep:lattice-tools"]
-full = ["runtime", "store-memory", "sandbox-local", "llm-all", "tools"]
-```
-
-### 未来扩展
-
-- **MCP 桥接工具**：实现 `ToolExecutor`，内部通过 MCP 协议调用外部 MCP 服务器。作为 Layer 3 工具由应用层注入。
-- **沙箱工厂（SandboxFactory）**：当工具需要按需创建沙箱时（如 Docker 容器），引入 factory 模式，实现 Anthropic 提出的 `provision({resources})` 语义。
-- **凭据隔离**：参考 Anthropic 的两种模式——资源绑定（token 注入沙箱初始化）和 Vault Proxy（工具通过代理访问凭据）。框架层面预留接口，不在工具实现中硬编码凭据处理。
-- **工具权限控制**：参考 Claude Code 的 permission 模型，支持按工具名配置 allow/deny 规则。

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -51,6 +51,35 @@
 | 18 | [配置管理与多 Provider 支持](../tasks/18-config-provider.md) | `feat/config-provider` | ⬜ |
 | 19 | [Docker 化独立部署](../tasks/19-docker-deploy.md) | `feat/docker-deploy` | ⬜ |
 
+## 第五轮：Skill 系统（规划中）
+
+**目标**：实现 Lattice 的 skill 系统，使 meta agent 能够将复杂子任务委托给专门的 skill agent 执行。skill 在父 agent 视角是普通 tool 调用，背后运行完整的子 ControlLoop，支持多轮 LLM 决策、独立工具集和独立 session 树节点。
+
+**设计原则**：遵循 [Anthropic Agent Skills 开放标准](https://www.agentskills.com)，以 SKILL.md 为唯一事实来源，实现渐进式披露（Progressive Disclosure）三层加载机制。
+
+| # | 任务 | 分支名 |
+|---|------|--------|
+| 20-1 | core 层扩展：ExecutionContext + EventPayload + ToolError | `feat/skill-execution-context` |
+| 20-2 | SessionStore 树形扩展 + MemoryStore 子 session | `feat/skill-session-tree` |
+| 20-3 | ToolSet + 已有工具适配新签名 | `feat/skill-tool-execute-ctx` |
+| 20-4 | ControlLoop 构造 ExecutionContext + builder | `feat/skill-control-loop` |
+| 20-5 | lattice-skill crate | `feat/skill-crate` |
+| 20-6 | skill feature + 示例 skill 目录 + meta-agent example | `feat/skill-facade` |
+
+### 渐进式披露三层加载
+
+```
+Level 1：SkillLoader 启动时加载所有 skill 的 name + description（≈30-50 tokens/skill）
+         ↓ 意图匹配
+Level 2：加载 SKILL.md 正文作为 system prompt
+         ↓ 执行中按需
+Level 3：子 agent 按需读取 references/、scripts/ 中的文件
+```
+
+### Session Tree
+
+父 session 调用 skill 时创建子 session，子 session 拥有独立 SessionStore。父 session 记录 `SkillInvoked`/`SkillCompleted` 事件，携带子 session ID。
+
 ### API 端点预览
 
 ```
@@ -66,6 +95,153 @@ GET    /v1/providers                    → 列出可用 LLM provider
 ```
 
 ## 📋 后续规划
+
+### 第六轮：记忆与规划
+
+**目标**：为 Lattice 添加运行时状态管理、显式规划执行层，以及长期记忆接口，补全 Agent 的"记忆-规划-执行"闭环。
+
+#### 运行时状态管理器（RuntimeState）
+
+**问题**：现有的 `SessionStore` 是 append-only 事件日志，适合持久化和可追溯性，但不适合运行时快速读写。规划执行器如果从事件日志重建状态，每次迭代都要 O(n) 扫描，性能差且不稳定。
+
+**解决方案**：引入轻量 `RuntimeState` trait，作为 ControlLoop 的伴随状态：
+
+```rust
+/// Runtime state for an agent session — structured, in-memory, fast read/write.
+/// Unlike SessionStore (append-only log), RuntimeState supports get/patch/reset.
+#[async_trait]
+pub trait RuntimeState: Send + Sync {
+    /// Get a field value by key.
+    async fn get(&self, key: &str) -> Result<Option<serde_json::Value>, RuntimeStateError>;
+
+    /// Set or overwrite a field.
+    async fn set(&self, key: &str, value: serde_json::Value) -> Result<(), RuntimeStateError>;
+
+    /// Delete a field.
+    async fn remove(&self, key: &str) -> Result<(), RuntimeStateError>;
+
+    /// Snapshot the entire state for persistence or replay.
+    async fn snapshot(&self) -> Result<RuntimeStateSnapshot, RuntimeStateError>;
+
+    /// Restore from a snapshot.
+    async fn restore(&self, snapshot: &RuntimeStateSnapshot) -> Result<(), RuntimeStateError>;
+}
+```
+
+**标准字段约定**（convention，不强制）：
+
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| `step` | i32 | 当前步骤序号 |
+| `tool_results` | Map | 工具执行结果缓存 `{ "bash": "output", ... }` |
+| `retries` | i32 | 当前步骤重试次数 |
+| `max_retries` | i32 | 最大重试次数 |
+| `plan` | Array | 当前执行计划（子步骤列表） |
+
+**与 SessionStore 的关系**：
+- `SessionStore`：持久化、可追溯、append-only——事件的账本
+- `RuntimeState`：临时、可读写、运行时内存——规划器的快速寄存器
+
+#### 规划执行器（Planner trait）
+
+**问题**：当前 ControlLoop 中，LLM 同时扮演"推理者"和"规划者"两个角色。当任务步骤固定时（如"先查数据库再发邮件再写日志"），用满血大模型做规划是 token 浪费，且规划结果不稳定。
+
+**解决方案**：引入 `Planner` trait，将规划决策从 LLM 中枢中分离出来：
+
+```rust
+/// A planner decides the next step given current state and goals.
+/// Unlike LLMClient (general reasoning), a Planner is specialized for
+/// step sequencing and action selection.
+#[async_trait]
+pub trait Planner: Send + Sync {
+    /// Given the current runtime state and LLM output, decide the next action.
+    async fn plan(
+        &self,
+        state: &dyn RuntimeState,
+        llm_output: &str,  // LLM 中枢的高层结论，不是全量上下文
+        available_tools: &[ToolDescription],
+    ) -> Result<Plan, PlannerError>;
+}
+
+/// A concrete planning decision.
+#[derive(Debug, Clone)]
+pub struct Plan {
+    /// Machine-readable next action.
+    pub action: PlanAction,
+    /// Plain-text reasoning for audit log.
+    pub reasoning: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum PlanAction {
+    /// Call a specific tool with parameters.
+    ToolCall { tool: String, params: serde_json::Value },
+    /// Halt execution and return answer.
+    FinalAnswer { answer: String },
+    /// Retry the current step (increment retry counter).
+    Retry,
+    /// Update runtime state without calling a tool.
+    UpdateState { patch: serde_json::Value },
+    /// Ask the LLM for clarification on a ambiguous goal.
+    AskForClarification { question: String },
+}
+```
+
+**两种实现路径**：
+
+| 类型 | 适用场景 | 实现方式 |
+|---|---|---|
+| `SmallModelPlanner` | 复杂但非固定的业务流程 | 单独小模型（如 Qwen2.5-7B）+ 强制 JSON Schema 输出，token 成本低 |
+| `FsmPlanner` | 步骤固定的流水线任务 | 纯 Rust FSM/状态机，零 LLM 调用，极致稳定 |
+
+**与 LLM 中枢的关系**：
+- LLM 中枢（`LLMClient`）：动脑，处理通用推理和最终答案
+- 规划执行器（`Planner`）：动手，执行步骤决策，输出结构化动作
+- 两者串联：LLM 高层结论 → Planner 拆解步骤 → 工具执行
+
+#### 长期记忆
+
+**问题**：append-only 事件日志会随时间无限增长，长会话的上下文窗口迟早爆炸。同时，Agent 需要从历史任务中学习（相似任务复用经验）。
+
+**解决方案**：定义 `LongTermMemory` trait，支持事件历史摘要和检索：
+
+```rust
+/// Long-term memory store for cross-session learning and context management.
+/// Backed by a vector store (Pinecone/Milvus) or a simple full-text index.
+#[async_trait]
+pub trait LongTermMemory: Send + Sync {
+    /// Store a memory entry with optional embedding for retrieval.
+    async fn store(&self, entry: MemoryEntry) -> Result<(), MemoryError>;
+
+    /// Retrieve memories relevant to the given query.
+    async fn retrieve(&self, query: &str, top_k: usize) -> Result<Vec<MemoryEntry>, MemoryError>;
+
+    /// Summarize and archive a session's event log into a compact memory entry.
+    async fn archive_session(&self, session_id: SessionId) -> Result<MemoryEntry, MemoryError>;
+}
+
+#[derive(Debug, Clone)]
+pub struct MemoryEntry {
+    pub id: Uuid,
+    pub content: String,          // 摘要文本
+    pub embedding: Option<Vec<f32>>, // 向量嵌入（可选，无向量库时可不填）
+    pub tags: Vec<String>,        // 标签：["bug-fix", "auth", "migration"]
+    pub session_id: Option<SessionId>,
+    pub created_at: Timestamp,
+}
+```
+
+**存储后端**：
+- 轻量：SQLite FTS5 全文检索，无需外部服务
+- 生产：Pinecone / Milvus / Qdrant 向量数据库
+- 两者可叠加：SQLite 做标签+全文检索，向量库做语义检索
+
+**使用场景**：
+- 新会话开始时，检索相关历史经验注入上下文
+- 上下文窗口接近上限时，自动摘要归档旧事件
+- 团队共享知识库：把成功的 skill 执行结果归档复用
+
+---
 
 ### Docker 沙箱
 - 实现 Sandbox trait 的 Docker 容器版本
@@ -87,11 +263,3 @@ GET    /v1/providers                    → 列出可用 LLM provider
 ### 凭据管理
 - Vault Proxy 模式：沙箱外注入凭据
 - 初始化注入模式：沙箱创建时一次性注入
-
-### Skill 系统
-- 任务 20-1：`lattice-core` 新增 `ExecutionContext`、`MAX_SKILL_DEPTH`、`ToolError::MaxDepthExceeded`、`EventPayload` 新增变体
-- 任务 20-2：`SessionStore` 新增 `create_child_session` / `child_sessions`，`MemoryStore` 实现子 session
-- 任务 20-3：`ToolSet::execute` + 已有工具适配新签名
-- 任务 20-4：`ControlLoop` 加 `depth` 字段和 builder，构造 `ExecutionContext`
-- 任务 20-5：新建 `lattice-skill` crate（SkillDefinition、SkillToolSet、SkillTool、SkillLoader）
-- 任务 20-6：接入 facade + 示例 skill 目录 + meta-agent example


### PR DESCRIPTION
- Split monolithic tasks/20-skill-system.md into 6 sequential sub-tasks (20-1 through 20-6) with distinct branches, covering ExecutionContext, SessionTree, ToolExecutor signature, ControlLoop builder, lattice-skill crate, and facade integration
- Created skill-sys GitHub label and 6 linked issues (hhllhhyyds/Lattice#51-56)
- Rewrote docs/ARCHITECTURE.md: 3 core abstractions, Session Tree section, ExecutionContext definition, unified Layer 1-3 tool diagram
- Rewrote docs/ROADMAP.md: formal "第五轮: Skill 系统" section with progressive disclosure mechanism, "第六轮: 记忆与规划" with RuntimeState/Planner/LongTermMemory
- Updated README.md: added "演进路线" table showing all 6 rounds with status