### PR TITLE
fix: 使用 parent_event_id 关联工具结果

### DIFF
--- a/crates/llm-protocol/src/convert.rs
+++ b/crates/llm-protocol/src/convert.rs
@@ -13,10 +13,6 @@ use crate::request::ToolSpec;
 pub fn events_to_messages(events: &[Event]) -> Vec<Message> {
     let mut messages: Vec<Message> = Vec::new();
 
-    // Track the last tool call event id so we can correlate ToolResult
-    // with the correct tool_use_id.
-    let mut last_tool_call_id: Option<String> = None;
-
     for event in events {
         match &event.payload {
             EventPayload::UserMessage { content } => {
@@ -29,7 +25,6 @@ pub fn events_to_messages(events: &[Event]) -> Vec<Message> {
             }
             EventPayload::ToolCallRequested { tool, params } => {
                 let id = event.event_id.to_string();
-                last_tool_call_id = Some(id.clone());
                 messages.push(Message {
                     role: Role::Assistant,
                     content: vec![ContentBlock::ToolUse {
@@ -44,7 +39,7 @@ pub fn events_to_messages(events: &[Event]) -> Vec<Message> {
                 stderr,
                 exit_code,
             } => {
-                let tool_use_id = last_tool_call_id.clone().unwrap_or_default();
+                let tool_use_id = tool_use_id_from_parent(event);
                 let content = format_tool_result(stdout, stderr, *exit_code);
                 messages.push(Message {
                     role: Role::Tool,
@@ -56,7 +51,7 @@ pub fn events_to_messages(events: &[Event]) -> Vec<Message> {
                 });
             }
             EventPayload::ToolCallError { error } => {
-                let tool_use_id = last_tool_call_id.clone().unwrap_or_default();
+                let tool_use_id = tool_use_id_from_parent(event);
                 messages.push(Message {
                     role: Role::Tool,
                     content: vec![ContentBlock::ToolResult {
@@ -75,6 +70,13 @@ pub fn events_to_messages(events: &[Event]) -> Vec<Message> {
     }
 
     messages
+}
+
+fn tool_use_id_from_parent(event: &Event) -> String {
+    event
+        .parent_event_id
+        .map(|id| id.to_string())
+        .unwrap_or_default()
 }
 
 /// Convert Lattice tool descriptions into protocol tool specs.
@@ -110,13 +112,17 @@ mod tests {
     use uuid::Uuid;
 
     fn make_event(payload: EventPayload) -> Event {
+        make_event_with_parent(payload, None)
+    }
+
+    fn make_event_with_parent(payload: EventPayload, parent_event_id: Option<EventId>) -> Event {
         Event {
             event_id: EventId::new_v4(),
             session_id: SessionId::new_v4(),
             timestamp: Utc::now(),
             actor: Actor::System,
             payload,
-            parent_event_id: None,
+            parent_event_id,
         }
     }
 
@@ -162,11 +168,14 @@ mod tests {
                 },
                 parent_event_id: None,
             },
-            make_event(EventPayload::ToolCallResult {
-                stdout: "hi\n".into(),
-                stderr: String::new(),
-                exit_code: 0,
-            }),
+            make_event_with_parent(
+                EventPayload::ToolCallResult {
+                    stdout: "hi\n".into(),
+                    stderr: String::new(),
+                    exit_code: 0,
+                },
+                Some(tool_event_id),
+            ),
         ];
         let messages = events_to_messages(&events);
         assert_eq!(messages.len(), 2);
@@ -200,25 +209,101 @@ mod tests {
 
     #[test]
     fn test_tool_call_error_conversion() {
+        let tool_event_id = EventId::new_v4();
         let events = vec![
-            make_event(EventPayload::ToolCallRequested {
-                tool: "bash".into(),
-                params: serde_json::json!({"command": "fail"}),
-            }),
-            make_event(EventPayload::ToolCallError {
-                error: "command not found".into(),
-            }),
+            Event {
+                event_id: tool_event_id,
+                session_id: SessionId::new_v4(),
+                timestamp: Utc::now(),
+                actor: Actor::LLM,
+                payload: EventPayload::ToolCallRequested {
+                    tool: "bash".into(),
+                    params: serde_json::json!({"command": "fail"}),
+                },
+                parent_event_id: None,
+            },
+            make_event_with_parent(
+                EventPayload::ToolCallError {
+                    error: "command not found".into(),
+                },
+                Some(tool_event_id),
+            ),
         ];
         let messages = events_to_messages(&events);
         assert_eq!(messages.len(), 2);
         match &messages[1].content[0] {
             ContentBlock::ToolResult {
-                content, is_error, ..
+                tool_use_id,
+                content,
+                is_error,
             } => {
+                assert_eq!(tool_use_id, &tool_event_id.to_string());
                 assert_eq!(content, "command not found");
                 assert!(is_error);
             }
             _ => panic!("expected tool result block"),
+        }
+    }
+
+    #[test]
+    fn test_tool_results_use_parent_event_id_when_out_of_order() {
+        let first_tool_event_id = EventId::new_v4();
+        let second_tool_event_id = EventId::new_v4();
+        let session_id = SessionId::new_v4();
+        let events = vec![
+            Event {
+                event_id: first_tool_event_id,
+                session_id,
+                timestamp: Utc::now(),
+                actor: Actor::LLM,
+                payload: EventPayload::ToolCallRequested {
+                    tool: "bash".into(),
+                    params: serde_json::json!({"command": "ls"}),
+                },
+                parent_event_id: None,
+            },
+            Event {
+                event_id: second_tool_event_id,
+                session_id,
+                timestamp: Utc::now(),
+                actor: Actor::LLM,
+                payload: EventPayload::ToolCallRequested {
+                    tool: "bash".into(),
+                    params: serde_json::json!({"command": "pwd"}),
+                },
+                parent_event_id: None,
+            },
+            make_event_with_parent(
+                EventPayload::ToolCallResult {
+                    stdout: "ls output".into(),
+                    stderr: String::new(),
+                    exit_code: 0,
+                },
+                Some(first_tool_event_id),
+            ),
+            make_event_with_parent(
+                EventPayload::ToolCallResult {
+                    stdout: "pwd output".into(),
+                    stderr: String::new(),
+                    exit_code: 0,
+                },
+                Some(second_tool_event_id),
+            ),
+        ];
+
+        let messages = events_to_messages(&events);
+
+        match &messages[2].content[0] {
+            ContentBlock::ToolResult { tool_use_id, .. } => {
+                assert_eq!(tool_use_id, &first_tool_event_id.to_string());
+            }
+            _ => panic!("expected first tool result block"),
+        }
+        match &messages[3].content[0] {
+            ContentBlock::ToolResult { tool_use_id, .. } => {
+                assert_eq!(tool_use_id, &second_tool_event_id.to_string());
+            }
+            _ => panic!("expected second tool result block"),
         }
     }
 


### PR DESCRIPTION
﻿## 变更说明

修复 #28 中工具结果关联不稳定的问题。

当前 `events_to_messages()` 使用 `last_tool_call_id` 把 `ToolCallResult` / `ToolCallError` 关联到最近一次 `ToolCallRequested`。这在严格串行 ABAB 顺序下可用，但遇到乱序事件或未来并行工具调用时会把结果绑定到错误的工具调用。

本 PR 改为直接使用结果事件自身的 `parent_event_id` 生成 `tool_use_id`，与 runtime 写入事件时的关联模型保持一致。

## 主要改动

- 移除 `last_tool_call_id` 状态
- `ToolCallResult` / `ToolCallError` 通过 `parent_event_id` 关联对应工具调用
- 补充乱序工具结果回归测试，覆盖两个工具调用后再返回第一个结果的场景

## 验证

- `cargo fmt --check`
- `cargo test -p lattice-llm-protocol`
- `cargo test -p lattice-llm-openai -p lattice-llm-anthropic`
- `cargo test -p lattice-runtime`
- `cargo check --workspace --all-features`

Closes #28
