### PR TITLE
fix: Server API 接入真实 ControlLoop 执行

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,6 +796,7 @@ name = "lattice-server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "chrono",
  "http-body-util",
@@ -807,6 +808,7 @@ dependencies = [
  "lattice-runtime",
  "lattice-sandbox-local",
  "lattice-store-memory",
+ "lattice-tools",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -18,6 +18,7 @@ lattice-core = { path = "../core" }
 lattice-runtime = { path = "../runtime" }
 lattice-store-memory = { path = "../store-memory" }
 lattice-sandbox-local = { path = "../sandbox-local" }
+lattice-tools = { path = "../tools" }
 lattice-llm-protocol = { path = "../llm-protocol", optional = true }
 lattice-llm-anthropic = { path = "../llm-anthropic", optional = true }
 lattice-llm-openai = { path = "../llm-openai", optional = true }
@@ -33,6 +34,7 @@ chrono = { workspace = true }
 anyhow = { workspace = true }
 
 [dev-dependencies]
+async-trait = { workspace = true }
 axum = { workspace = true }
 hyper = { workspace = true }
 tower = { workspace = true }

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -44,6 +44,7 @@ pub fn v1_routes() -> Router<Arc<AppState>> {
             "/sessions/{id}/messages",
             post(submit_message).get(get_messages),
         )
+        .route("/sessions/{id}/run", post(trigger_run))
         .route("/sessions/{id}/status", get(get_status))
 }
 
@@ -243,7 +244,7 @@ async fn session_status_from_index(
 ) -> SessionStatus {
     let runs = active_runs.read().await;
     match runs.get(&session_id) {
-        Some(handle) => match handle.status {
+        Some(handle) => match &handle.status {
             crate::RunStatus::Running => SessionStatus::Running,
             crate::RunStatus::Completed => SessionStatus::Completed,
             crate::RunStatus::Failed(_) => SessionStatus::Failed,
@@ -262,12 +263,12 @@ async fn run_status_and_info(
     let runs = active_runs.read().await;
     match runs.get(&session_id) {
         Some(handle) => {
-            let status = match handle.status {
+            let status = match &handle.status {
                 crate::RunStatus::Running => SessionStatus::Running,
                 crate::RunStatus::Completed => SessionStatus::Completed,
                 crate::RunStatus::Failed(_) => SessionStatus::Failed,
             };
-            let run_status = match handle.status {
+            let run_status = match &handle.status {
                 crate::RunStatus::Running => RunStatus::Running,
                 crate::RunStatus::Completed => RunStatus::Completed,
                 crate::RunStatus::Failed(_) => RunStatus::Failed,
@@ -308,12 +309,20 @@ async fn submit_message(
     // Check for concurrent run.
     {
         let runs = state.active_runs.read().await;
-        if runs.contains_key(&session_id) {
+        if matches!(
+            runs.get(&session_id).map(|handle| &handle.status),
+            Some(crate::RunStatus::Running)
+        ) {
             return Err(AppError::Conflict(
                 "Session already has a running task".into(),
             ));
         }
     }
+
+    let llm = state
+        .llm_factory
+        .create(req.provider.as_deref(), req.model.as_deref())
+        .map_err(AppError::InvalidRequest)?;
 
     // Append UserMessage event.
     state
@@ -332,25 +341,84 @@ async fn submit_message(
     // Register a RunHandle (for now, just mark as running).
     let run_id = uuid::Uuid::new_v4().to_string();
     let started_at = chrono::Utc::now();
+    let system_prompt = req.system_prompt.unwrap_or_else(|| {
+        "You are a helpful agent. You can execute shell commands using the available shell tool. \
+         After getting tool results, provide a clear final answer to the user."
+            .to_string()
+    });
+    let max_iterations = req.max_iterations.unwrap_or(50);
+    crate::spawn_control_loop_run(
+        Arc::clone(&state),
+        session_id,
+        run_id.clone(),
+        started_at,
+        llm,
+        system_prompt,
+        max_iterations,
+    )
+    .await;
 
+    let response = SubmitMessageResponse {
+        session_id,
+        run_id,
+        status: "running",
+        message: "Agent task started",
+    };
+
+    Ok((axum::http::StatusCode::ACCEPTED, Json(response)))
+}
+
+/// POST /v1/sessions/:id/run — trigger agent execution for existing session events.
+async fn trigger_run(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<SessionId>,
+    Json(req): Json<RunRequest>,
+) -> Result<(axum::http::StatusCode, Json<SubmitMessageResponse>), AppError> {
+    // Verify session exists.
     {
-        let mut runs = state.active_runs.write().await;
-        let join_handle = tokio::spawn(async {
-            // TODO: Actually run ControlLoop here.
-            // For now, just sleep briefly to simulate work.
-            tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-        });
-
-        runs.insert(
-            session_id,
-            crate::RunHandle {
-                session_id,
-                status: crate::RunStatus::Running,
-                started_at,
-                abort_handle: join_handle.abort_handle(),
-            },
-        );
+        let sessions = state.sessions.read().await;
+        if !sessions.iter().any(|s| s.session_id == session_id) {
+            return Err(AppError::SessionNotFound(session_id));
+        }
     }
+
+    // Check for concurrent run.
+    {
+        let runs = state.active_runs.read().await;
+        if matches!(
+            runs.get(&session_id).map(|handle| &handle.status),
+            Some(crate::RunStatus::Running)
+        ) {
+            return Err(AppError::Conflict(
+                "Session already has a running task".into(),
+            ));
+        }
+    }
+
+    let llm = state
+        .llm_factory
+        .create(req.provider.as_deref(), req.model.as_deref())
+        .map_err(AppError::InvalidRequest)?;
+
+    let run_id = uuid::Uuid::new_v4().to_string();
+    let started_at = chrono::Utc::now();
+    let system_prompt = req.system_prompt.unwrap_or_else(|| {
+        "You are a helpful agent. You can execute shell commands using the available shell tool. \
+         After getting tool results, provide a clear final answer to the user."
+            .to_string()
+    });
+    let max_iterations = req.max_iterations.unwrap_or(50);
+
+    crate::spawn_control_loop_run(
+        Arc::clone(&state),
+        session_id,
+        run_id.clone(),
+        started_at,
+        llm,
+        system_prompt,
+        max_iterations,
+    )
+    .await;
 
     let response = SubmitMessageResponse {
         session_id,
@@ -452,17 +520,12 @@ async fn get_status(
     let (run_status, run_started_at, run_completed_at) = {
         let runs = state.active_runs.read().await;
         if let Some(handle) = runs.get(&session_id) {
-            let status = match handle.status {
+            let status = match &handle.status {
                 crate::RunStatus::Running => "running",
                 crate::RunStatus::Completed => "completed",
                 crate::RunStatus::Failed(_) => "failed",
             };
-            let completed_at = match handle.status {
-                crate::RunStatus::Completed | crate::RunStatus::Failed(_) => {
-                    Some(chrono::Utc::now())
-                }
-                _ => None,
-            };
+            let completed_at = handle.completed_at;
             (status, Some(handle.started_at), completed_at)
         } else {
             ("idle", None, None)

--- a/crates/server/src/api/types.rs
+++ b/crates/server/src/api/types.rs
@@ -138,17 +138,27 @@ pub struct SubmitMessageRequest {
     #[serde(default)]
     pub content: String,
     /// Optional LLM provider (e.g., "anthropic", "openai").
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[allow(dead_code)] // TODO: use in LLM client factory
     pub provider: Option<String>,
     /// Optional model name (e.g., "gpt-4o", "claude-3-5-sonnet-20241022").
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[allow(dead_code)] // TODO: use in LLM client factory
     pub model: Option<String>,
     /// Optional system prompt override.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[allow(dead_code)] // TODO: use in ControlLoop
     pub system_prompt: Option<String>,
+    /// Optional maximum number of ControlLoop iterations.
+    pub max_iterations: Option<usize>,
+}
+
+/// Request to trigger agent execution for an existing session.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RunRequest {
+    /// Optional LLM provider (e.g., "anthropic", "openai").
+    pub provider: Option<String>,
+    /// Optional model name.
+    pub model: Option<String>,
+    /// Optional system prompt override.
+    pub system_prompt: Option<String>,
+    /// Optional maximum number of ControlLoop iterations.
+    pub max_iterations: Option<usize>,
 }
 
 /// Response after submitting a message (202 Accepted).

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -7,11 +7,16 @@ mod api;
 mod error;
 
 use std::collections::HashMap;
+use std::env;
 use std::sync::Arc;
 
 use axum::{extract::State, http::StatusCode, response::IntoResponse, routing::get, Json, Router};
 use chrono::{DateTime, Utc};
 pub use lattice_core::SessionId;
+use lattice_core::{LLMClient, Sandbox};
+use lattice_runtime::ControlLoop;
+use lattice_sandbox_local::LocalSandbox;
+use lattice_tools::ToolSet;
 use serde::Serialize;
 use tokio::sync::RwLock;
 use tower_http::cors::{Any, CorsLayer};
@@ -24,6 +29,10 @@ pub use crate::error::AppError;
 pub struct AppState {
     /// Session store (currently MemoryStore, swappable via trait).
     pub store: Arc<dyn lattice_core::SessionStore>,
+    /// Factory for creating LLM clients per submitted run.
+    pub llm_factory: Arc<dyn LlmClientFactory>,
+    /// Tool registry used by agent runs.
+    pub tools: Arc<ToolSet>,
     /// Active ControlLoop task handles.
     pub active_runs: Arc<RwLock<HashMap<SessionId, RunHandle>>>,
     /// Server start time (for uptime reporting).
@@ -45,12 +54,16 @@ pub struct SessionInfo {
 
 /// Handle for an in-flight agent run.
 pub struct RunHandle {
+    /// Unique ID for this run.
+    pub run_id: String,
     /// Session ID for this run.
     pub session_id: SessionId,
     /// Current status of the run.
     pub status: RunStatus,
     /// When the run started.
     pub started_at: DateTime<Utc>,
+    /// When the run finished.
+    pub completed_at: Option<DateTime<Utc>>,
     /// Handle used to abort the run task.
     pub abort_handle: tokio::task::AbortHandle,
 }
@@ -63,6 +76,146 @@ pub enum RunStatus {
     Completed,
     /// Run failed with an error message.
     Failed(String),
+}
+
+/// Factory for creating LLM clients for a run.
+pub trait LlmClientFactory: Send + Sync {
+    /// Create a client for the requested provider/model.
+    fn create(
+        &self,
+        provider: Option<&str>,
+        model: Option<&str>,
+    ) -> Result<Arc<dyn LLMClient>, String>;
+}
+
+/// Environment-backed LLM factory used by the production server.
+pub struct EnvLlmClientFactory;
+
+impl LlmClientFactory for EnvLlmClientFactory {
+    fn create(
+        &self,
+        provider: Option<&str>,
+        model: Option<&str>,
+    ) -> Result<Arc<dyn LLMClient>, String> {
+        create_llm_client(provider, model)
+    }
+}
+
+/// Create an LLM client from request overrides and environment variables.
+pub fn create_llm_client(
+    provider: Option<&str>,
+    model: Option<&str>,
+) -> Result<Arc<dyn LLMClient>, String> {
+    let provider = provider
+        .map(str::to_owned)
+        .or_else(|| env::var("LATTICE_LLM_PROVIDER").ok())
+        .unwrap_or_else(|| "openai".to_string());
+
+    match provider.as_str() {
+        "anthropic" => create_anthropic_client(model),
+        "openai" | "openai-compatible" => create_openai_client(model),
+        other => Err(format!(
+            "unsupported LLM provider '{other}' (expected 'anthropic' or 'openai')"
+        )),
+    }
+}
+
+#[cfg(feature = "anthropic")]
+fn create_anthropic_client(model: Option<&str>) -> Result<Arc<dyn LLMClient>, String> {
+    let api_key = env::var("ANTHROPIC_API_KEY")
+        .or_else(|_| env::var("LATTICE_API_KEY"))
+        .map_err(|_| "ANTHROPIC_API_KEY or LATTICE_API_KEY must be set".to_string())?;
+    let model = model
+        .map(str::to_owned)
+        .or_else(|| env::var("LATTICE_MODEL").ok())
+        .unwrap_or_else(|| "claude-sonnet-4-20250514".to_string());
+
+    let mut client = lattice_llm_anthropic::AnthropicClient::new(api_key, model);
+    if let Ok(base_url) = env::var("ANTHROPIC_API_BASE").or_else(|_| env::var("LATTICE_API_BASE")) {
+        client = client.with_base_url(base_url);
+    }
+    Ok(Arc::new(client))
+}
+
+#[cfg(not(feature = "anthropic"))]
+fn create_anthropic_client(_model: Option<&str>) -> Result<Arc<dyn LLMClient>, String> {
+    Err("anthropic provider is not enabled in this build".to_string())
+}
+
+#[cfg(feature = "openai")]
+fn create_openai_client(model: Option<&str>) -> Result<Arc<dyn LLMClient>, String> {
+    let api_key = env::var("OPENAI_API_KEY")
+        .or_else(|_| env::var("LATTICE_API_KEY"))
+        .map_err(|_| "OPENAI_API_KEY or LATTICE_API_KEY must be set".to_string())?;
+    let model = model
+        .map(str::to_owned)
+        .or_else(|| env::var("LATTICE_MODEL").ok())
+        .unwrap_or_else(|| "gpt-4o".to_string());
+
+    let mut client = lattice_llm_openai::OpenAIClient::new(api_key, model);
+    if let Ok(base_url) = env::var("OPENAI_API_BASE").or_else(|_| env::var("LATTICE_API_BASE")) {
+        client = client.with_base_url(base_url);
+    }
+    Ok(Arc::new(client))
+}
+
+#[cfg(not(feature = "openai"))]
+fn create_openai_client(_model: Option<&str>) -> Result<Arc<dyn LLMClient>, String> {
+    Err("openai provider is not enabled in this build".to_string())
+}
+
+/// Spawn a real ControlLoop run and update active run state on completion.
+pub async fn spawn_control_loop_run(
+    state: Arc<AppState>,
+    session_id: SessionId,
+    run_id: String,
+    started_at: DateTime<Utc>,
+    llm: Arc<dyn LLMClient>,
+    system_prompt: String,
+    max_iterations: usize,
+) -> tokio::task::AbortHandle {
+    let store = Arc::clone(&state.store);
+    let tools = Arc::clone(&state.tools);
+    let active_runs = Arc::clone(&state.active_runs);
+    let run_id_for_task = run_id.clone();
+    let (start_tx, start_rx) = tokio::sync::oneshot::channel();
+
+    let join_handle = tokio::spawn(async move {
+        let _ = start_rx.await;
+        let control_loop =
+            ControlLoop::with_options(store, llm, tools, system_prompt, max_iterations);
+        let status = match control_loop.run(session_id).await {
+            Ok(_) => RunStatus::Completed,
+            Err(err) => RunStatus::Failed(err.to_string()),
+        };
+
+        let mut runs = active_runs.write().await;
+        if let Some(handle) = runs.get_mut(&session_id) {
+            if handle.run_id == run_id_for_task {
+                handle.status = status;
+                handle.completed_at = Some(Utc::now());
+            }
+        }
+    });
+
+    let abort_handle = join_handle.abort_handle();
+    {
+        let mut runs = state.active_runs.write().await;
+        runs.insert(
+            session_id,
+            RunHandle {
+                run_id,
+                session_id,
+                status: RunStatus::Running,
+                started_at,
+                completed_at: None,
+                abort_handle: abort_handle.clone(),
+            },
+        );
+    }
+    let _ = start_tx.send(());
+
+    abort_handle
 }
 
 /// Health check response body.
@@ -119,8 +272,24 @@ fn app(state: AppState) -> Router {
 
 /// Creates a new AppState with the given session store.
 pub fn new_state(store: Arc<dyn lattice_core::SessionStore>) -> AppState {
+    let sandbox: Arc<dyn Sandbox> = Arc::new(LocalSandbox::new());
+    new_state_with_components(
+        store,
+        Arc::new(EnvLlmClientFactory),
+        Arc::new(ToolSet::with_defaults(sandbox)),
+    )
+}
+
+/// Creates a new AppState with injectable runtime components.
+pub fn new_state_with_components(
+    store: Arc<dyn lattice_core::SessionStore>,
+    llm_factory: Arc<dyn LlmClientFactory>,
+    tools: Arc<ToolSet>,
+) -> AppState {
     AppState {
         store,
+        llm_factory,
+        tools,
         active_runs: Arc::new(RwLock::new(HashMap::new())),
         started_at: Utc::now(),
         sessions: Arc::new(RwLock::new(Vec::new())),
@@ -135,13 +304,50 @@ pub fn router(state: AppState) -> Router {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
+    use lattice_core::{Decision, Event, LLMError, ToolDescription};
+    use std::sync::Mutex;
     use tower::ServiceExt;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn make_app() -> Router {
         let store = Arc::new(lattice_store_memory::MemoryStore::new());
         router(new_state(store))
+    }
+
+    struct TestLlm {
+        result: Result<Decision, LLMError>,
+    }
+
+    #[async_trait]
+    impl LLMClient for TestLlm {
+        async fn decide(
+            &self,
+            _history: &[Event],
+            _available_tools: &[ToolDescription],
+            _system_prompt: &str,
+        ) -> Result<Decision, LLMError> {
+            self.result.clone()
+        }
+    }
+
+    struct TestFactory;
+
+    impl LlmClientFactory for TestFactory {
+        fn create(
+            &self,
+            _provider: Option<&str>,
+            _model: Option<&str>,
+        ) -> Result<Arc<dyn LLMClient>, String> {
+            Ok(Arc::new(TestLlm {
+                result: Ok(Decision::FinalAnswer {
+                    answer: "done".into(),
+                }),
+            }))
+        }
     }
 
     #[tokio::test]
@@ -198,6 +404,156 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn create_llm_client_rejects_unknown_provider() {
+        let err = match create_llm_client(Some("unknown"), Some("model")) {
+            Ok(_) => panic!("expected unknown provider to fail"),
+            Err(err) => err,
+        };
+        assert!(err.contains("unsupported LLM provider"));
+    }
+
+    #[test]
+    #[cfg(feature = "openai")]
+    fn create_llm_client_uses_openai_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::set_var("OPENAI_API_KEY", "sk-test");
+            std::env::remove_var("LATTICE_API_KEY");
+            std::env::remove_var("OPENAI_API_BASE");
+            std::env::remove_var("LATTICE_API_BASE");
+        }
+
+        let client = create_llm_client(Some("openai"), Some("gpt-4o"));
+        assert!(client.is_ok());
+
+        unsafe {
+            std::env::remove_var("OPENAI_API_KEY");
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "anthropic")]
+    fn create_llm_client_uses_anthropic_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::set_var("ANTHROPIC_API_KEY", "sk-ant-test");
+            std::env::remove_var("LATTICE_API_KEY");
+            std::env::remove_var("ANTHROPIC_API_BASE");
+            std::env::remove_var("LATTICE_API_BASE");
+        }
+
+        let client = create_llm_client(Some("anthropic"), Some("claude-sonnet-4-20250514"));
+        assert!(client.is_ok());
+
+        unsafe {
+            std::env::remove_var("ANTHROPIC_API_KEY");
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "openai")]
+    fn create_llm_client_reports_missing_openai_key() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var("OPENAI_API_KEY");
+            std::env::remove_var("LATTICE_API_KEY");
+        }
+
+        let err = match create_llm_client(Some("openai"), Some("gpt-4o")) {
+            Ok(_) => panic!("expected missing API key to fail"),
+            Err(err) => err,
+        };
+        assert!(err.contains("OPENAI_API_KEY"));
+    }
+
+    #[tokio::test]
+    async fn injected_state_components_are_used() {
+        let store = Arc::new(lattice_store_memory::MemoryStore::new());
+        let state =
+            new_state_with_components(store, Arc::new(TestFactory), Arc::new(ToolSet::new()));
+
+        assert_eq!(state.tools.len(), 0);
+        let client = state.llm_factory.create(None, None).unwrap();
+        let decision = client.decide(&[], &[], "").await.unwrap();
+        match decision {
+            Decision::FinalAnswer { answer } => assert_eq!(answer, "done"),
+            _ => panic!("expected final answer"),
+        }
+    }
+
+    #[tokio::test]
+    async fn spawned_control_loop_updates_completed_status() {
+        let store: Arc<dyn lattice_core::SessionStore> =
+            Arc::new(lattice_store_memory::MemoryStore::new());
+        let session_id = store.create_session().await.unwrap();
+        let state = Arc::new(new_state_with_components(
+            Arc::clone(&store),
+            Arc::new(TestFactory),
+            Arc::new(ToolSet::new()),
+        ));
+        let run_id = "run-complete".to_string();
+        let started_at = Utc::now();
+        let llm: Arc<dyn LLMClient> = Arc::new(TestLlm {
+            result: Ok(Decision::FinalAnswer {
+                answer: "done".into(),
+            }),
+        });
+
+        spawn_control_loop_run(
+            Arc::clone(&state),
+            session_id,
+            run_id.clone(),
+            started_at,
+            llm,
+            "prompt".into(),
+            5,
+        )
+        .await;
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        let runs = state.active_runs.read().await;
+        let handle = runs.get(&session_id).unwrap();
+        assert_eq!(handle.run_id, run_id);
+        assert!(matches!(handle.status, RunStatus::Completed));
+        assert!(handle.completed_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn spawned_control_loop_updates_failed_status() {
+        let store: Arc<dyn lattice_core::SessionStore> =
+            Arc::new(lattice_store_memory::MemoryStore::new());
+        let session_id = store.create_session().await.unwrap();
+        let state = Arc::new(new_state_with_components(
+            Arc::clone(&store),
+            Arc::new(TestFactory),
+            Arc::new(ToolSet::new()),
+        ));
+        let llm: Arc<dyn LLMClient> = Arc::new(TestLlm {
+            result: Err(LLMError::RequestFailed("boom".into())),
+        });
+
+        spawn_control_loop_run(
+            Arc::clone(&state),
+            session_id,
+            "run-fail".into(),
+            Utc::now(),
+            llm,
+            "prompt".into(),
+            5,
+        )
+        .await;
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        let runs = state.active_runs.read().await;
+        let handle = runs.get(&session_id).unwrap();
+        match &handle.status {
+            RunStatus::Failed(message) => assert!(message.contains("boom")),
+            _ => panic!("expected failed run"),
+        }
+        assert!(handle.completed_at.is_some());
     }
 
     #[tokio::test]

--- a/crates/server/tests/agent_run_api_tests.rs
+++ b/crates/server/tests/agent_run_api_tests.rs
@@ -5,17 +5,58 @@
 //! - GET /v1/sessions/:id/messages — get conversation history
 //! - GET /v1/sessions/:id/status — query execution status
 
+use async_trait::async_trait;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
-use lattice_core::SessionStore;
-use lattice_server::{new_state, router};
+use lattice_core::{Decision, Event, LLMClient, LLMError, SessionStore, ToolDescription};
+use lattice_server::{new_state, new_state_with_components, router, LlmClientFactory};
 use std::sync::Arc;
+use std::time::Duration;
 use tower::ServiceExt;
 
 /// Helper to create a test app with MemoryStore.
 fn make_app() -> axum::Router {
     let store = Arc::new(lattice_store_memory::MemoryStore::new());
-    router(new_state(store))
+    router(new_state_with_components(
+        store,
+        Arc::new(FakeLlmFactory),
+        Arc::new(lattice_tools::ToolSet::new()),
+    ))
+}
+
+struct FakeLlmFactory;
+
+impl LlmClientFactory for FakeLlmFactory {
+    fn create(
+        &self,
+        _provider: Option<&str>,
+        _model: Option<&str>,
+    ) -> Result<Arc<dyn LLMClient>, String> {
+        Ok(Arc::new(FakeLlm {
+            answer: "test answer".to_string(),
+            delay: Duration::from_millis(150),
+        }))
+    }
+}
+
+struct FakeLlm {
+    answer: String,
+    delay: Duration,
+}
+
+#[async_trait]
+impl LLMClient for FakeLlm {
+    async fn decide(
+        &self,
+        _history: &[Event],
+        _available_tools: &[ToolDescription],
+        _system_prompt: &str,
+    ) -> Result<Decision, LLMError> {
+        tokio::time::sleep(self.delay).await;
+        Ok(Decision::FinalAnswer {
+            answer: self.answer.clone(),
+        })
+    }
 }
 
 /// Helper to create a session and return its ID.
@@ -205,6 +246,105 @@ async fn post_message_with_system_prompt() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::ACCEPTED);
+}
+
+#[tokio::test]
+async fn post_run_triggers_control_loop_for_existing_session() {
+    let app = make_app();
+    let session_id = create_test_session(&app).await;
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/sessions/{}/run", session_id))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"maxIterations":5}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let body = axum::body::to_bytes(response.into_body(), 1024)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["sessionId"], session_id);
+    assert!(json["runId"].is_string());
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(250)).await;
+
+    let status_response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/v1/sessions/{}/status", session_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(status_response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(status_response.into_body(), 1024)
+        .await
+        .unwrap();
+    let status_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(status_json["runStatus"], "completed");
+}
+
+#[tokio::test]
+async fn post_run_session_not_found_returns_404() {
+    let app = make_app();
+    let fake_id = "00000000-0000-0000-0000-000000000000";
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/sessions/{}/run", fake_id))
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn post_run_concurrent_run_returns_409() {
+    let app = make_app();
+    let session_id = create_test_session(&app).await;
+
+    let first = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/sessions/{}/run", session_id))
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(first.status(), StatusCode::ACCEPTED);
+
+    let second = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/sessions/{}/run", session_id))
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(second.status(), StatusCode::CONFLICT);
 }
 
 // --- GET /v1/sessions/:id/messages tests ---
@@ -445,7 +585,7 @@ async fn get_messages_with_final_answer() {
 
     // Manually append a UserMessage and FinalAnswer event.
     let store = Arc::new(lattice_store_memory::MemoryStore::new());
-    let state = lattice_server::new_state(store.clone());
+    let state = new_state(store.clone());
 
     // Create session.
     let sid = store.create_session().await.unwrap();
@@ -610,4 +750,65 @@ async fn get_status_with_completed_run() {
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     // Status should be running or idle (depending on timing).
     assert!(json["runStatus"].is_string());
+}
+
+#[tokio::test]
+async fn submitted_message_runs_control_loop_to_final_answer() {
+    let app = make_app();
+    let session_id = create_test_session(&app).await;
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/sessions/{}/messages", session_id))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"content":"hello"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(250)).await;
+
+    let status_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/v1/sessions/{}/status", session_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(status_response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(status_response.into_body(), 1024)
+        .await
+        .unwrap();
+    let status_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(status_json["runStatus"], "completed");
+    assert!(status_json["runCompletedAt"].is_string());
+
+    let messages_response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/v1/sessions/{}/messages", session_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(messages_response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(messages_response.into_body(), 2048)
+        .await
+        .unwrap();
+    let messages_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let messages = messages_json["messages"].as_array().unwrap();
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[0]["role"], "user");
+    assert_eq!(messages[0]["content"], "hello");
+    assert_eq!(messages[1]["role"], "assistant");
+    assert_eq!(messages[1]["content"], "test answer");
 }


### PR DESCRIPTION
﻿## 变更说明

解决 #29 / #65 中 Server API 仍使用 mock task、不能真正驱动 agent 的问题。

本 PR 将 `POST /v1/sessions/:id/messages` 和新增的 `POST /v1/sessions/:id/run` 接入真实 `ControlLoop::run()`，并在后台任务结束后更新 run 状态。

## 主要改动

- 为 `AppState` 增加可注入的 `LlmClientFactory` 和 `ToolSet`
- 增加环境变量驱动的 LLM client factory：
  - `openai` / `openai-compatible`: `OPENAI_API_KEY` 或 `LATTICE_API_KEY`
  - `anthropic`: `ANTHROPIC_API_KEY` 或 `LATTICE_API_KEY`
  - 支持 `LATTICE_MODEL`、`OPENAI_API_BASE` / `ANTHROPIC_API_BASE` / `LATTICE_API_BASE`
- 将 `/messages` 里的 50ms mock task 替换为真实后台 `ControlLoop`
- 新增 `POST /v1/sessions/:id/run`，可对已有 session 事件触发 agent 执行
- `RunHandle` 记录 `run_id`、`completed_at`，完成后更新为 `Completed` 或 `Failed`
- 测试中注入 fake LLM，避免依赖真实 API key，同时覆盖真实 ControlLoop 完成路径

## 验证

- `cargo fmt --check`
- `cargo test -p lattice-server`
- `cargo check -p lattice-server --no-default-features`
- `cargo check --workspace --all-features`
- `cargo test -p lattice-runtime -p lattice-llm-openai -p lattice-llm-anthropic`
- `cargo llvm-cov test --workspace --all-features --summary-only`

本地 workspace coverage 行覆盖率约 94.44%。

Closes #29
Refs #65
