### PR TITLE
fix: Anthropic 历史消息跳过 System 角色

### DIFF
--- a/crates/llm-anthropic/src/client.rs
+++ b/crates/llm-anthropic/src/client.rs
@@ -9,7 +9,7 @@ use lattice_core::{Event, ToolDescription};
 use lattice_llm_protocol::convert::{events_to_messages, tool_descriptions_to_specs};
 use lattice_llm_protocol::message::{ContentBlock, Message, Role};
 use lattice_llm_protocol::response::LLMResponse;
-use tracing::{debug, instrument};
+use tracing::{debug, instrument, warn};
 
 use crate::types::*;
 
@@ -71,15 +71,20 @@ impl AnthropicClient {
     fn to_anthropic_messages(&self, messages: &[Message]) -> Vec<AnthropicMessage> {
         messages
             .iter()
-            .map(|msg| {
+            .filter_map(|msg| {
                 let role = match msg.role {
                     Role::User | Role::Tool => "user".to_string(),
                     Role::Assistant => "assistant".to_string(),
-                    Role::System => "user".to_string(), // system is handled separately
+                    Role::System => {
+                        warn!(
+                            "system-role message found in Anthropic conversation history; skipping"
+                        );
+                        return None;
+                    }
                 };
 
                 let content = self.to_anthropic_content(&msg.content, msg.role);
-                AnthropicMessage { role, content }
+                Some(AnthropicMessage { role, content })
             })
             .collect()
     }
@@ -353,11 +358,30 @@ mod tests {
     #[test]
     fn test_to_anthropic_messages_system() {
         let client = AnthropicClient::new("key", "claude");
-        // System role maps to "user" (system prompt handled separately in decide())
+        // System prompt is handled by the top-level request field, not history.
         let messages = vec![Message::text(Role::System, "instructions")];
         let result = client.to_anthropic_messages(&messages);
-        assert_eq!(result.len(), 1);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_to_anthropic_messages_skips_system_without_dropping_neighbors() {
+        let client = AnthropicClient::new("key", "claude");
+        let messages = vec![
+            Message::text(Role::User, "hello"),
+            Message::text(Role::System, "must not become user content"),
+            Message::text(Role::Assistant, "hi"),
+        ];
+
+        let result = client.to_anthropic_messages(&messages);
+
+        assert_eq!(result.len(), 2);
         assert_eq!(result[0].role, "user");
+        assert_eq!(result[1].role, "assistant");
+        assert!(result.iter().all(|msg| match &msg.content {
+            AnthropicContent::Text(text) => !text.contains("must not become user content"),
+            AnthropicContent::Blocks(_) => true,
+        }));
     }
 
     #[test]


### PR DESCRIPTION
## 问题

AnthropicClient::to_anthropic_messages() 原先会把 Role::System 静默映射成 Anthropic 的 user 消息。系统提示本应通过 Anthropic request 的顶层 system 字段传递，如果历史消息里意外出现 System 角色，继续降级成 user 会造成语义混淆，也可能扩大提示注入风险。

Fixes #33

## 修复

- 将 Anthropic 历史消息转换从 map 改为 ilter_map。
- 遇到 Role::System 时记录 warning 并跳过，不再作为 user 消息发送。
- 更新 System 角色测试，并补充混合消息场景，验证跳过 System 时不会丢失相邻 user/assistant 消息，也不会泄露 System 内容。

## 验证

- cargo fmt --check
- cargo test -p lattice-llm-anthropic
- cargo check --workspace
