### PR TITLE
feat: 新增最小可用 Web Console

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,88 @@ cargo run -p lattice-server
 curl http://localhost:3000/health
 ```
 
+启动后直接打开浏览器访问：
+
+```text
+http://127.0.0.1:3000
+```
+
+当前主干内置了一个最小可用 Web UI，可用于：
+
+- 创建 session
+- 提交消息并触发 agent run
+- 查看消息历史
+- 查看事件列表
+- 查看运行状态
+
+如果要让 Web UI 真正调用模型，需要先配置服务端使用的 LLM 环境变量，例如：
+
+```powershell
+$env:LATTICE_LLM_PROVIDER="openai"
+$env:OPENAI_API_KEY="sk-xxx"
+$env:LATTICE_MODEL="gpt-4o"
+cargo run -p lattice-server
+```
+
+### Web UI 使用说明
+
+Web UI 底部的发送面板里：
+
+- `Provider` 是**可选项**
+- `模型` 是**可选项**
+
+它们的行为是：
+
+- **不填写 `Provider` / `模型`**  
+  本次请求直接使用服务端启动时的默认环境变量
+- **填写 `Provider` / `模型`**  
+  仅覆盖这一次请求的 provider / model
+
+也就是说，如果你在启动 `lattice-server` 前已经设置好了：
+
+```powershell
+$env:LATTICE_LLM_PROVIDER="openai"
+$env:LATTICE_API_BASE="https://api.siliconflow.cn/v1"
+$env:LATTICE_MODEL="Pro/MiniMaxAI/MiniMax-M2.5"
+```
+
+那么进入 Web UI 后，`Provider` 和 `模型` 两个输入框都可以留空，直接发送消息即可。
+
+### MiniMax / SiliconFlow 示例
+
+Lattice 当前通过 **OpenAI-compatible** 适配器接入 MiniMax、SiliconFlow、vLLM、Ollama 等服务。
+
+这里的：
+
+```text
+LATTICE_LLM_PROVIDER="openai"
+```
+
+表示“使用 OpenAI 兼容请求格式”，**不是**要求你使用 OpenAI 官方服务。
+
+例如，通过 SiliconFlow 调用 MiniMax：
+
+```powershell
+$env:LATTICE_LLM_PROVIDER="openai"
+$env:LATTICE_API_KEY="your_key"
+$env:LATTICE_API_BASE="https://api.siliconflow.cn/v1"
+$env:LATTICE_MODEL="Pro/MiniMaxAI/MiniMax-M2.5"
+$env:LATTICE_PORT="3001"
+
+cargo run -p lattice-server
+```
+
+然后打开：
+
+```text
+http://127.0.0.1:3001
+```
+
+如果服务端已经按上面方式启动，Web UI 中推荐：
+
+- `Provider` 留空（使用服务端默认值）
+- `模型` 留空，或显式填写 `Pro/MiniMaxAI/MiniMax-M2.5`
+
 ## LLM Provider 支持
 
 | Provider         | 包                      | 状态 |

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -69,13 +69,14 @@ async fn create_session(
         sessions.push(SessionInfo {
             session_id,
             created_at,
-            metadata,
+            metadata: metadata.clone(),
         });
     }
 
     let response = SessionResponse {
         session_id,
         created_at,
+        metadata,
         status: SessionStatus::Created,
         event_count: 1,
         run_info: None,
@@ -112,6 +113,7 @@ async fn list_sessions(
         responses.push(SessionResponse {
             session_id: info.session_id,
             created_at: info.created_at,
+            metadata: info.metadata.clone(),
             status,
             event_count,
             run_info: None,
@@ -154,6 +156,7 @@ async fn get_session(
     Ok(Json(SessionResponse {
         session_id,
         created_at: info.created_at,
+        metadata: info.metadata,
         status,
         event_count,
         run_info,

--- a/crates/server/src/api/types.rs
+++ b/crates/server/src/api/types.rs
@@ -30,6 +30,9 @@ pub struct SessionResponse {
     pub session_id: SessionId,
     /// When the session was created.
     pub created_at: DateTime<Utc>,
+    /// Optional session metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<SessionMetadata>,
     /// Current session status.
     pub status: SessionStatus,
     /// Total number of events in the session.

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -5,6 +5,7 @@
 
 mod api;
 mod error;
+mod ui;
 
 use std::collections::HashMap;
 use std::env;
@@ -258,6 +259,9 @@ async fn health_check(State(state): State<Arc<AppState>>) -> impl IntoResponse {
 /// Builds the application router with all routes and middleware.
 fn app(state: AppState) -> Router {
     Router::new()
+        .route("/", get(ui::index))
+        .route("/ui/app.css", get(ui::styles))
+        .route("/ui/app.js", get(ui::script))
         .route("/health", get(health_check))
         .nest("/v1", crate::api::v1_routes())
         .layer(TraceLayer::new_for_http())
@@ -363,6 +367,23 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn root_serves_web_ui() {
+        let app = make_app();
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(html.contains("Lattice Console"));
+        assert!(html.contains("/ui/app.js"));
     }
 
     #[tokio::test]

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -387,6 +387,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn web_ui_styles_route_serves_css() {
+        let app = make_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/ui/app.css")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get("content-type").unwrap(),
+            "text/css; charset=utf-8"
+        );
+
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let css = String::from_utf8(body.to_vec()).unwrap();
+        assert!(css.contains(".app-shell"));
+        assert!(css.contains(".status-chip"));
+    }
+
+    #[tokio::test]
+    async fn web_ui_script_route_serves_javascript() {
+        let app = make_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/ui/app.js")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get("content-type").unwrap(),
+            "application/javascript; charset=utf-8"
+        );
+
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let js = String::from_utf8(body.to_vec()).unwrap();
+        assert!(js.contains("loadSessions"));
+        assert!(js.contains("sendMessage"));
+    }
+
+    #[tokio::test]
     async fn health_response_body_is_valid_json() {
         let app = make_app();
         let response = app

--- a/crates/server/src/ui.rs
+++ b/crates/server/src/ui.rs
@@ -1,0 +1,34 @@
+//! Minimal Web UI served by lattice-server.
+
+use axum::{
+    http::{header, HeaderValue},
+    response::{Html, IntoResponse},
+};
+
+const INDEX_HTML: &str = include_str!("ui/index.html");
+const APP_CSS: &str = include_str!("ui/app.css");
+const APP_JS: &str = include_str!("ui/app.js");
+
+pub async fn index() -> Html<&'static str> {
+    Html(INDEX_HTML)
+}
+
+pub async fn styles() -> impl IntoResponse {
+    (
+        [(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("text/css; charset=utf-8"),
+        )],
+        APP_CSS,
+    )
+}
+
+pub async fn script() -> impl IntoResponse {
+    (
+        [(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/javascript; charset=utf-8"),
+        )],
+        APP_JS,
+    )
+}

--- a/crates/server/src/ui/app.css
+++ b/crates/server/src/ui/app.css
@@ -1,0 +1,446 @@
+:root {
+  color-scheme: light;
+  --bg: #eff2f7;
+  --surface: #ffffff;
+  --surface-muted: #f8fafc;
+  --border: #d7dfeb;
+  --text: #172033;
+  --text-muted: #5f6d86;
+  --primary: #2563eb;
+  --primary-dark: #1d4ed8;
+  --danger: #b42318;
+  --success: #067647;
+  --warning: #b54708;
+  --shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font: 14px/1.5 "Segoe UI", system-ui, sans-serif;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 300px minmax(0, 1fr);
+}
+
+.sidebar,
+.workspace {
+  padding: 20px;
+}
+
+.sidebar {
+  border-right: 1px solid var(--border);
+  background: #eef3fb;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1.55fr) minmax(300px, 0.85fr);
+  gap: 20px;
+}
+
+.chat-column,
+.detail-column {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+  padding: 16px;
+}
+
+.panel-fill {
+  flex: 1;
+  min-height: 0;
+}
+
+.stack-sm {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.stack-md {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.sidebar-header,
+.panel-title-row,
+.composer-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.eyebrow {
+  margin: 0 0 4px;
+  color: var(--text-muted);
+  font-size: 12px;
+  text-transform: uppercase;
+}
+
+h1,
+h2 {
+  margin: 0;
+  font-weight: 600;
+}
+
+h1 {
+  font-size: 24px;
+}
+
+h2 {
+  font-size: 18px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.field span {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+}
+
+textarea {
+  resize: vertical;
+  min-height: 110px;
+}
+
+input:focus,
+select:focus,
+textarea:focus,
+button:focus-visible {
+  outline: 2px solid rgba(37, 99, 235, 0.24);
+  outline-offset: 1px;
+}
+
+.grid-two {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.narrow {
+  width: 132px;
+}
+
+.primary-button,
+.ghost-button {
+  border: 0;
+  border-radius: 8px;
+  cursor: pointer;
+  min-height: 40px;
+  padding: 0 14px;
+}
+
+.primary-button {
+  background: var(--primary);
+  color: #fff;
+}
+
+.primary-button:hover {
+  background: var(--primary-dark);
+}
+
+.primary-button:disabled {
+  background: #9db7f5;
+  cursor: wait;
+}
+
+.ghost-button {
+  background: var(--surface-muted);
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+
+.icon-button {
+  width: 40px;
+  padding: 0;
+}
+
+.session-list,
+.message-list,
+.event-list {
+  min-height: 0;
+  overflow: auto;
+}
+
+.session-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: calc(100vh - 255px);
+}
+
+.session-card {
+  width: 100%;
+  text-align: left;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  padding: 12px;
+  cursor: pointer;
+}
+
+.session-card.active {
+  border-color: var(--primary);
+  background: #eef4ff;
+}
+
+.session-card:hover {
+  border-color: #9fb8ef;
+}
+
+.session-title {
+  font-weight: 600;
+  margin: 0 0 4px;
+}
+
+.session-meta {
+  color: var(--text-muted);
+  font-size: 12px;
+  margin: 0;
+}
+
+.message-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-right: 2px;
+}
+
+.message-item {
+  max-width: 85%;
+  padding: 12px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--surface-muted);
+}
+
+.message-item.user {
+  align-self: flex-end;
+  background: #e8f0ff;
+  border-color: #b9cdf7;
+}
+
+.message-item.assistant {
+  align-self: flex-start;
+}
+
+.message-meta {
+  margin: 0 0 6px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.message-content {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.status-chip,
+.meta-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 72px;
+  min-height: 28px;
+  padding: 0 10px;
+  border-radius: 999px;
+  background: #eef2f7;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.status-chip.running {
+  background: #fff0dc;
+  color: var(--warning);
+}
+
+.status-chip.completed {
+  background: #e7f6ec;
+  color: var(--success);
+}
+
+.status-chip.failed {
+  background: #fdecea;
+  color: var(--danger);
+}
+
+.status-summary {
+  margin: 0;
+  display: grid;
+  grid-template-columns: minmax(76px, auto) minmax(0, 1fr);
+  gap: 10px 12px;
+}
+
+.status-summary div {
+  display: contents;
+}
+
+.status-summary dt {
+  color: var(--text-muted);
+}
+
+.status-summary dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.event-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.event-item {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface-muted);
+  padding: 12px;
+}
+
+.event-item header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.event-title {
+  font-weight: 600;
+  margin: 0;
+}
+
+.event-time {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.event-body {
+  margin: 0;
+  color: var(--text-muted);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-family: Consolas, "SFMono-Regular", monospace;
+  font-size: 12px;
+}
+
+.empty-state {
+  display: grid;
+  place-items: center;
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  padding: 24px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.toast {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  max-width: 420px;
+  padding: 12px 14px;
+  border-radius: 8px;
+  background: #1f2937;
+  color: #fff;
+  box-shadow: var(--shadow);
+}
+
+.toast.error {
+  background: #9f1239;
+}
+
+.hidden {
+  display: none;
+}
+
+@media (max-width: 1180px) {
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 900px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .session-list {
+    max-height: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .sidebar,
+  .workspace {
+    padding: 14px;
+  }
+
+  .grid-two {
+    grid-template-columns: 1fr;
+  }
+
+  .composer-footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .narrow {
+    width: 100%;
+  }
+
+  .message-item {
+    max-width: 100%;
+  }
+}

--- a/crates/server/src/ui/app.js
+++ b/crates/server/src/ui/app.js
@@ -1,0 +1,311 @@
+const state = {
+  selectedSessionId: null,
+  pollHandle: null,
+};
+
+const el = {
+  createSessionBtn: document.getElementById("create-session-btn"),
+  refreshSessionsBtn: document.getElementById("refresh-sessions-btn"),
+  refreshDetailBtn: document.getElementById("refresh-detail-btn"),
+  sessionName: document.getElementById("session-name"),
+  sessionList: document.getElementById("session-list"),
+  activeSessionLabel: document.getElementById("active-session-label"),
+  statusChip: document.getElementById("status-chip"),
+  statusSummary: document.getElementById("status-summary"),
+  messageList: document.getElementById("message-list"),
+  eventList: document.getElementById("event-list"),
+  eventCountBadge: document.getElementById("event-count-badge"),
+  messageForm: document.getElementById("message-form"),
+  messageInput: document.getElementById("message-input"),
+  sendBtn: document.getElementById("send-btn"),
+  provider: document.getElementById("provider"),
+  model: document.getElementById("model"),
+  maxIterations: document.getElementById("max-iterations"),
+  toast: document.getElementById("toast"),
+};
+
+function showToast(message, isError = false) {
+  el.toast.textContent = message;
+  el.toast.classList.remove("hidden", "error");
+  if (isError) {
+    el.toast.classList.add("error");
+  }
+  window.clearTimeout(showToast.timer);
+  showToast.timer = window.setTimeout(() => {
+    el.toast.classList.add("hidden");
+  }, 3200);
+}
+
+async function api(path, options = {}) {
+  const response = await fetch(path, {
+    headers: { "Content-Type": "application/json", ...(options.headers || {}) },
+    ...options,
+  });
+
+  if (!response.ok) {
+    let message = `${response.status} ${response.statusText}`;
+    try {
+      const data = await response.json();
+      message = data.error?.message || message;
+    } catch {}
+    throw new Error(message);
+  }
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  return response.json();
+}
+
+function formatTime(value) {
+  if (!value) return "-";
+  return new Date(value).toLocaleString();
+}
+
+function setStatusChip(status) {
+  el.statusChip.textContent = status || "idle";
+  el.statusChip.className = `status-chip ${status || "idle"}`;
+}
+
+function sessionTitle(session) {
+  const created = formatTime(session.createdAt);
+  return {
+    title: session.metadata?.name || session.sessionId.slice(0, 8),
+    meta: `${session.status} · ${created}`,
+  };
+}
+
+function renderSessions(sessions) {
+  if (!sessions.length) {
+    el.sessionList.className = "session-list empty-state";
+    el.sessionList.textContent = "还没有会话，先创建一个。";
+    return;
+  }
+
+  el.sessionList.className = "session-list";
+  el.sessionList.innerHTML = "";
+
+  sessions.forEach((session) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = `session-card${session.sessionId === state.selectedSessionId ? " active" : ""}`;
+    const label = sessionTitle(session);
+    button.innerHTML = `
+      <p class="session-title">${label.title}</p>
+      <p class="session-meta">${label.meta}</p>
+    `;
+    button.addEventListener("click", () => selectSession(session.sessionId));
+    el.sessionList.appendChild(button);
+  });
+}
+
+function summarizePayload(payload) {
+  switch (payload.type) {
+    case "userMessage":
+      return payload.content;
+    case "thinking":
+      return payload.reasoning;
+    case "toolCallRequested":
+      return `${payload.tool} ${JSON.stringify(payload.params)}`;
+    case "toolCallResult":
+      return `exit=${payload.exitCode}\nstdout:\n${payload.stdout}\nstderr:\n${payload.stderr}`;
+    case "toolCallError":
+      return payload.error;
+    case "finalAnswer":
+      return payload.answer;
+    case "stateChange":
+      return `${payload.from} -> ${payload.to}`;
+    default:
+      return JSON.stringify(payload, null, 2);
+  }
+}
+
+function renderMessages(messages) {
+  if (!messages.length) {
+    el.messageList.className = "message-list empty-state";
+    el.messageList.textContent = "当前会话还没有消息。";
+    return;
+  }
+
+  el.messageList.className = "message-list";
+  el.messageList.innerHTML = "";
+
+  messages.forEach((message) => {
+    const item = document.createElement("article");
+    item.className = `message-item ${message.role}`;
+    item.innerHTML = `
+      <p class="message-meta">${message.role} · ${formatTime(message.timestamp)}</p>
+      <pre class="message-content">${escapeHtml(message.content)}</pre>
+    `;
+    el.messageList.appendChild(item);
+  });
+}
+
+function renderEvents(events) {
+  el.eventCountBadge.textContent = String(events.length);
+  if (!events.length) {
+    el.eventList.className = "event-list empty-state";
+    el.eventList.textContent = "当前会话还没有事件。";
+    return;
+  }
+
+  el.eventList.className = "event-list";
+  el.eventList.innerHTML = "";
+
+  events
+    .slice()
+    .reverse()
+    .forEach((event) => {
+      const item = document.createElement("article");
+      item.className = "event-item";
+      item.innerHTML = `
+        <header>
+          <p class="event-title">${event.payload.type} · ${event.actor}</p>
+          <span class="event-time">${formatTime(event.timestamp)}</span>
+        </header>
+        <pre class="event-body">${escapeHtml(summarizePayload(event.payload))}</pre>
+      `;
+      el.eventList.appendChild(item);
+    });
+}
+
+function renderStatus(status) {
+  setStatusChip(status.runStatus);
+  const latest = status.latestEvent
+    ? `${status.latestEvent.payloadType} · ${status.latestEvent.actor}`
+    : "-";
+  el.statusSummary.innerHTML = `
+    <div><dt>会话</dt><dd>${state.selectedSessionId || "-"}</dd></div>
+    <div><dt>开始时间</dt><dd>${formatTime(status.runStartedAt)}</dd></div>
+    <div><dt>结束时间</dt><dd>${formatTime(status.runCompletedAt)}</dd></div>
+    <div><dt>事件数</dt><dd>${status.eventCount}</dd></div>
+    <div><dt>最新事件</dt><dd>${latest}</dd></div>
+  `;
+}
+
+function escapeHtml(value) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+async function loadSessions(selectLatest = false) {
+  const data = await api("/v1/sessions");
+  renderSessions(data.sessions);
+
+  if (!state.selectedSessionId && data.sessions.length) {
+    state.selectedSessionId = data.sessions[0].sessionId;
+  }
+
+  if (selectLatest && data.sessions.length) {
+    state.selectedSessionId = data.sessions[data.sessions.length - 1].sessionId;
+  }
+
+  if (state.selectedSessionId) {
+    await loadCurrentSession();
+    renderSessions(data.sessions);
+  }
+}
+
+async function loadCurrentSession() {
+  if (!state.selectedSessionId) return;
+
+  el.activeSessionLabel.textContent = `会话 ${state.selectedSessionId.slice(0, 8)}`;
+
+  const [messages, events, status] = await Promise.all([
+    api(`/v1/sessions/${state.selectedSessionId}/messages`),
+    api(`/v1/sessions/${state.selectedSessionId}/events`),
+    api(`/v1/sessions/${state.selectedSessionId}/status`),
+  ]);
+
+  renderMessages(messages.messages);
+  renderEvents(events.events);
+  renderStatus(status);
+}
+
+function startPolling() {
+  window.clearInterval(state.pollHandle);
+  state.pollHandle = window.setInterval(async () => {
+    if (!state.selectedSessionId) return;
+    try {
+      await loadSessions();
+    } catch (error) {
+      showToast(error.message, true);
+    }
+  }, 2500);
+}
+
+async function selectSession(sessionId) {
+  state.selectedSessionId = sessionId;
+  try {
+    await loadSessions();
+  } catch (error) {
+    showToast(error.message, true);
+  }
+}
+
+async function createSession() {
+  el.createSessionBtn.disabled = true;
+  try {
+    const name = el.sessionName.value.trim();
+    const body = name ? { metadata: { name, tags: [] } } : {};
+    await api("/v1/sessions", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+    el.sessionName.value = "";
+    await loadSessions(true);
+    showToast("会话已创建");
+  } catch (error) {
+    showToast(error.message, true);
+  } finally {
+    el.createSessionBtn.disabled = false;
+  }
+}
+
+async function sendMessage(event) {
+  event.preventDefault();
+  if (!state.selectedSessionId) {
+    showToast("请先创建或选择一个会话", true);
+    return;
+  }
+
+  const content = el.messageInput.value.trim();
+  if (!content) {
+    showToast("消息不能为空", true);
+    return;
+  }
+
+  el.sendBtn.disabled = true;
+  try {
+    const body = { content };
+    if (el.provider.value) body.provider = el.provider.value;
+    if (el.model.value.trim()) body.model = el.model.value.trim();
+    if (el.maxIterations.value.trim()) {
+      body.maxIterations = Number(el.maxIterations.value);
+    }
+
+    const data = await api(`/v1/sessions/${state.selectedSessionId}/messages`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+    el.messageInput.value = "";
+    showToast(`任务已提交：${data.runId}`);
+    await loadCurrentSession();
+  } catch (error) {
+    showToast(error.message, true);
+  } finally {
+    el.sendBtn.disabled = false;
+  }
+}
+
+el.createSessionBtn.addEventListener("click", createSession);
+el.refreshSessionsBtn.addEventListener("click", () => loadSessions().catch((error) => showToast(error.message, true)));
+el.refreshDetailBtn.addEventListener("click", () => loadCurrentSession().catch((error) => showToast(error.message, true)));
+el.messageForm.addEventListener("submit", sendMessage);
+
+loadSessions()
+  .catch((error) => showToast(error.message, true))
+  .finally(startPolling);

--- a/crates/server/src/ui/index.html
+++ b/crates/server/src/ui/index.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Lattice Console</title>
+    <link rel="stylesheet" href="/ui/app.css" />
+  </head>
+  <body>
+    <div class="app-shell">
+      <aside class="sidebar">
+        <div class="sidebar-header">
+          <div>
+            <p class="eyebrow">Lattice</p>
+            <h1>Console</h1>
+          </div>
+          <button id="create-session-btn" class="primary-button" type="button">
+            新建会话
+          </button>
+        </div>
+
+        <form id="session-form" class="panel stack-sm">
+          <label class="field">
+            <span>会话名称</span>
+            <input id="session-name" type="text" placeholder="可选，例如 Debug run" />
+          </label>
+        </form>
+
+        <div class="panel stack-sm">
+          <div class="panel-title-row">
+            <h2>会话列表</h2>
+            <button id="refresh-sessions-btn" class="ghost-button icon-button" type="button" title="刷新会话列表">
+              ↻
+            </button>
+          </div>
+          <div id="session-list" class="session-list empty-state">
+            还没有会话，先创建一个。
+          </div>
+        </div>
+      </aside>
+
+      <main class="workspace">
+        <section class="chat-column">
+          <div class="panel panel-fill">
+            <div class="panel-title-row">
+              <div>
+                <p id="active-session-label" class="eyebrow">未选择会话</p>
+                <h2>消息</h2>
+              </div>
+              <div id="status-chip" class="status-chip idle">idle</div>
+            </div>
+            <div id="message-list" class="message-list empty-state">
+              创建或选择一个会话后，可以在这里查看消息历史。
+            </div>
+          </div>
+
+          <form id="message-form" class="panel stack-md">
+            <div class="grid-two">
+              <label class="field">
+                <span>Provider</span>
+                <select id="provider">
+                  <option value="">使用服务端默认值</option>
+                  <option value="openai">openai</option>
+                  <option value="anthropic">anthropic</option>
+                </select>
+              </label>
+              <label class="field">
+                <span>模型</span>
+                <input id="model" type="text" placeholder="可选，例如 gpt-4o" />
+              </label>
+            </div>
+
+            <label class="field">
+              <span>问题</span>
+              <textarea
+                id="message-input"
+                rows="4"
+                placeholder="向当前会话发送消息，服务端会触发一次新的 agent run。"
+              ></textarea>
+            </label>
+
+            <div class="composer-footer">
+              <label class="field narrow">
+                <span>最大迭代</span>
+                <input id="max-iterations" type="number" min="1" placeholder="默认 50" />
+              </label>
+              <button id="send-btn" class="primary-button" type="submit">发送消息</button>
+            </div>
+          </form>
+        </section>
+
+        <section class="detail-column">
+          <div class="panel stack-sm">
+            <div class="panel-title-row">
+              <h2>运行状态</h2>
+              <button id="refresh-detail-btn" class="ghost-button icon-button" type="button" title="刷新当前会话">
+                ↻
+              </button>
+            </div>
+            <dl id="status-summary" class="status-summary">
+              <div><dt>会话</dt><dd>-</dd></div>
+              <div><dt>开始时间</dt><dd>-</dd></div>
+              <div><dt>结束时间</dt><dd>-</dd></div>
+              <div><dt>事件数</dt><dd>-</dd></div>
+              <div><dt>最新事件</dt><dd>-</dd></div>
+            </dl>
+          </div>
+
+          <div class="panel panel-fill stack-sm">
+            <div class="panel-title-row">
+              <h2>事件</h2>
+              <span id="event-count-badge" class="meta-pill">0</span>
+            </div>
+            <div id="event-list" class="event-list empty-state">
+              事件流会显示在这里。
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+
+    <div id="toast" class="toast hidden" role="status" aria-live="polite"></div>
+    <script type="module" src="/ui/app.js"></script>
+  </body>
+</html>

--- a/crates/server/tests/agent_run_api_tests.rs
+++ b/crates/server/tests/agent_run_api_tests.rs
@@ -114,6 +114,75 @@ async fn post_message_returns_202_accepted() {
 }
 
 #[tokio::test]
+async fn create_session_with_metadata_is_visible_in_session_detail_and_list() {
+    let app = make_app();
+
+    let create_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/sessions")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"metadata":{"name":"MiniMax debug","tags":["ui","test"]}}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(create_response.status(), StatusCode::CREATED);
+    let body = axum::body::to_bytes(create_response.into_body(), 1024)
+        .await
+        .unwrap();
+    let created: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let session_id = created["sessionId"].as_str().unwrap();
+    assert_eq!(created["metadata"]["name"], "MiniMax debug");
+    assert_eq!(created["metadata"]["tags"][0], "ui");
+
+    let detail_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/v1/sessions/{session_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(detail_response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(detail_response.into_body(), 1024)
+        .await
+        .unwrap();
+    let detail: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(detail["metadata"]["name"], "MiniMax debug");
+    assert_eq!(detail["metadata"]["tags"][1], "test");
+
+    let list_response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/sessions")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(list_response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(list_response.into_body(), 4096)
+        .await
+        .unwrap();
+    let list: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let matching = list["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["sessionId"] == session_id)
+        .unwrap();
+    assert_eq!(matching["metadata"]["name"], "MiniMax debug");
+    assert_eq!(matching["metadata"]["tags"][0], "ui");
+}
+
+#[tokio::test]
 async fn post_message_session_not_found_returns_404() {
     let app = make_app();
     let fake_id = "00000000-0000-0000-0000-000000000000";


### PR DESCRIPTION
## 背景\n- 对应 issue #74\n- 当前主干已经有 session / messages / events / status 等后端接口，但还没有可直接操作的前端页面\n- 现在用户只能靠 PowerShell、curl、Postman 调 API，验证连续对话和事件查看都比较低效\n\n## 改动\n- 在 lattice-server 中内置一个最小可用 Web UI：\n  - GET / 返回控制台首页\n  - GET /ui/app.css 返回样式\n  - GET /ui/app.js 返回前端逻辑\n- Web UI 支持：\n  - 创建 session\n  - 查看 session 列表\n  - 选择当前 session\n  - 提交消息并触发 run\n  - 查看消息历史\n  - 查看运行状态\n  - 查看原始事件列表\n- 扩展 SessionResponse，返回 metadata，使前端能显示会话名称\n- README 增加 Web UI 启动方式，以及 MiniMax / OpenAI-compatible 的使用说明\n\n## 设计说明\n- 这次实现没有引入额外前端构建链，直接以静态资源方式挂在 lattice-server 内\n- 这样做的目的是先快速把已有 REST API 变成一个可操作界面，降低测试门槛\n- 当前 UI 使用 REST polling 刷新会话详情；后续可以在 #73 落地后接入 SSE /stream\n- 参考了 D:\\Workbench\\atombot-main 的 Web UI 形态，但没有复用它的 /chat 模式，而是直接消费 Lattice 现有 session-based API\n\n## 验证\n- cargo test -p lattice-server\n- cargo check -p lattice-server\n- cargo check --workspace\n- cargo fmt --all --check\n\n## 使用\n`powershell\ncargo run -p lattice-server\n`\n\n然后浏览器打开：\n\n`	ext\nhttp://127.0.0.1:3000\n`\n