### PR TITLE
feat: 支持从 Web Console 删除会话

### DIFF
--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -13,6 +13,9 @@ pub trait SessionStore: Send + Sync {
     /// Create a new session and return its id.
     async fn create_session(&self) -> Result<SessionId, StoreError>;
 
+    /// Delete an entire session and all of its events.
+    async fn delete_session(&self, session_id: SessionId) -> Result<(), StoreError>;
+
     /// Append an immutable event to the session.
     ///
     /// Returns the newly assigned `EventId`.

--- a/crates/runtime/src/control_loop.rs
+++ b/crates/runtime/src/control_loop.rs
@@ -405,6 +405,17 @@ mod tests {
                 .insert(session_id, vec![event]);
             Ok(session_id)
         }
+        async fn delete_session(
+            &self,
+            session_id: SessionId,
+        ) -> Result<(), lattice_core::error::StoreError> {
+            let removed = self.sessions.lock().unwrap().remove(&session_id);
+            if removed.is_some() {
+                Ok(())
+            } else {
+                Err(lattice_core::error::StoreError::SessionNotFound(session_id))
+            }
+        }
         async fn append_event(
             &self,
             session_id: SessionId,
@@ -858,6 +869,12 @@ mod tests {
             async fn create_session(&self) -> Result<SessionId, lattice_core::error::StoreError> {
                 self.inner.create_session().await
             }
+            async fn delete_session(
+                &self,
+                session_id: SessionId,
+            ) -> Result<(), lattice_core::error::StoreError> {
+                self.inner.delete_session(session_id).await
+            }
             async fn append_event(
                 &self,
                 _session_id: SessionId,
@@ -954,6 +971,12 @@ mod tests {
         impl lattice_core::SessionStore for CallCountingStore {
             async fn create_session(&self) -> Result<SessionId, lattice_core::error::StoreError> {
                 self.inner.create_session().await
+            }
+            async fn delete_session(
+                &self,
+                session_id: SessionId,
+            ) -> Result<(), lattice_core::error::StoreError> {
+                self.inner.delete_session(session_id).await
             }
 
             async fn append_event(

--- a/crates/runtime/src/control_loop.rs
+++ b/crates/runtime/src/control_loop.rs
@@ -908,6 +908,8 @@ mod tests {
         let tools = make_tools();
 
         let failing_store = FailingAppendStore::with_session(session_id);
+        let temp_session = failing_store.create_session().await.unwrap();
+        failing_store.delete_session(temp_session).await.unwrap();
 
         let control_loop = crate::ControlLoop::with_options(
             Arc::new(failing_store),
@@ -1011,6 +1013,8 @@ mod tests {
         }
 
         let store = Arc::new(CallCountingStore::with_session(session_id));
+        let temp_session = store.create_session().await.unwrap();
+        store.delete_session(temp_session).await.unwrap();
 
         // LLM will return ToolCall twice, then FinalAnswer
         // This creates 3 iterations, which would call get_events 3 times in the old code

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -52,7 +52,7 @@ fn default_limit() -> usize {
 pub fn v1_routes() -> Router<Arc<AppState>> {
     Router::new()
         .route("/sessions", post(create_session).get(list_sessions))
-        .route("/sessions/{id}", get(get_session))
+        .route("/sessions/{id}", get(get_session).delete(delete_session))
         .route("/sessions/{id}/events", get(get_events))
         .route("/sessions/{id}/stream", get(session_stream))
         .route(
@@ -61,6 +61,39 @@ pub fn v1_routes() -> Router<Arc<AppState>> {
         )
         .route("/sessions/{id}/run", post(trigger_run))
         .route("/sessions/{id}/status", get(get_status))
+}
+
+/// DELETE /v1/sessions/:id — deletes a session and all of its events.
+async fn delete_session(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<SessionId>,
+) -> Result<axum::http::StatusCode, AppError> {
+    {
+        let sessions = state.sessions.read().await;
+        if !sessions.iter().any(|s| s.session_id == session_id) {
+            return Err(AppError::SessionNotFound(session_id));
+        }
+    }
+
+    {
+        let mut runs = state.active_runs.write().await;
+        if let Some(handle) = runs.remove(&session_id) {
+            handle.abort_handle.abort();
+        }
+    }
+
+    state
+        .store
+        .delete_session(session_id)
+        .await
+        .map_err(|e| AppError::InternalError(e.to_string()))?;
+
+    {
+        let mut sessions = state.sessions.write().await;
+        sessions.retain(|session| session.session_id != session_id);
+    }
+
+    Ok(axum::http::StatusCode::NO_CONTENT)
 }
 
 /// POST /v1/sessions — creates a new session.

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -454,6 +454,7 @@ mod tests {
         let js = String::from_utf8(body.to_vec()).unwrap();
         assert!(js.contains("loadSessions"));
         assert!(js.contains("sendMessage"));
+        assert!(js.contains("deleteSession"));
     }
 
     #[tokio::test]

--- a/crates/server/src/streaming.rs
+++ b/crates/server/src/streaming.rs
@@ -58,6 +58,12 @@ impl EventHub {
         };
         let _ = sender.send(event.clone());
     }
+
+    /// Remove and drop the channel for a deleted session.
+    pub async fn remove_session(&self, session_id: SessionId) {
+        let mut channels = self.channels.write().await;
+        channels.remove(&session_id);
+    }
 }
 
 /// SessionStore decorator that broadcasts newly appended events.
@@ -77,6 +83,12 @@ impl NotifyingStore {
 impl SessionStore for NotifyingStore {
     async fn create_session(&self) -> Result<SessionId, lattice_core::StoreError> {
         self.inner.create_session().await
+    }
+
+    async fn delete_session(&self, session_id: SessionId) -> Result<(), lattice_core::StoreError> {
+        self.inner.delete_session(session_id).await?;
+        self.hub.remove_session(session_id).await;
+        Ok(())
     }
 
     async fn append_event(

--- a/crates/server/src/streaming.rs
+++ b/crates/server/src/streaming.rs
@@ -131,3 +131,62 @@ impl SessionStore for NotifyingStore {
         self.inner.latest_event_id(session_id).await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lattice_core::StoreError;
+    use lattice_store_memory::MemoryStore;
+
+    #[tokio::test]
+    async fn remove_session_drops_existing_channel() {
+        let hub = EventHub::new();
+        let session_id = SessionId::new_v4();
+
+        let mut receiver = hub.subscribe(session_id).await;
+        assert!(hub.channels.read().await.contains_key(&session_id));
+
+        hub.remove_session(session_id).await;
+
+        assert!(!hub.channels.read().await.contains_key(&session_id));
+        assert!(matches!(
+            receiver.try_recv(),
+            Err(broadcast::error::TryRecvError::Closed)
+        ));
+    }
+
+    #[tokio::test]
+    async fn notifying_store_delete_session_removes_channel_after_store_delete() {
+        let inner: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let hub = Arc::new(EventHub::new());
+        let store = NotifyingStore::new(Arc::clone(&inner), Arc::clone(&hub));
+        let session_id = inner.create_session().await.unwrap();
+
+        let _receiver = hub.subscribe(session_id).await;
+        assert!(hub.channels.read().await.contains_key(&session_id));
+
+        store.delete_session(session_id).await.unwrap();
+
+        assert!(!hub.channels.read().await.contains_key(&session_id));
+        let err = inner
+            .get_events(session_id, &EventFilter::default())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, StoreError::SessionNotFound(id) if id == session_id));
+    }
+
+    #[tokio::test]
+    async fn notifying_store_delete_missing_session_preserves_error_and_channel() {
+        let inner: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let hub = Arc::new(EventHub::new());
+        let store = NotifyingStore::new(inner, Arc::clone(&hub));
+        let missing = SessionId::new_v4();
+
+        let _receiver = hub.subscribe(missing).await;
+        assert!(hub.channels.read().await.contains_key(&missing));
+
+        let err = store.delete_session(missing).await.unwrap_err();
+        assert!(matches!(err, StoreError::SessionNotFound(id) if id == missing));
+        assert!(hub.channels.read().await.contains_key(&missing));
+    }
+}

--- a/crates/server/src/ui/app.css
+++ b/crates/server/src/ui/app.css
@@ -232,6 +232,13 @@ button:focus-visible {
   cursor: pointer;
 }
 
+.session-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
 .session-card.active {
   border-color: var(--primary);
   background: #eef4ff;
@@ -244,6 +251,24 @@ button:focus-visible {
 .session-title {
   font-weight: 600;
   margin: 0 0 4px;
+}
+
+.session-delete {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  color: var(--text-muted);
+  font-size: 16px;
+  line-height: 1;
+}
+
+.session-delete:hover {
+  background: #fdecea;
+  color: var(--danger);
 }
 
 .session-meta {

--- a/crates/server/src/ui/app.js
+++ b/crates/server/src/ui/app.js
@@ -97,10 +97,17 @@ function renderSessions(sessions) {
     button.className = `session-card${session.sessionId === state.selectedSessionId ? " active" : ""}`;
     const label = sessionTitle(session);
     button.innerHTML = `
-      <p class="session-title">${label.title}</p>
+      <div class="session-card-header">
+        <p class="session-title">${label.title}</p>
+        <span class="session-delete" data-session-id="${session.sessionId}" title="删除会话" aria-label="删除会话">×</span>
+      </div>
       <p class="session-meta">${label.meta}</p>
     `;
     button.addEventListener("click", () => selectSession(session.sessionId));
+    button.querySelector(".session-delete").addEventListener("click", (event) => {
+      event.stopPropagation();
+      deleteSession(session.sessionId).catch((error) => showToast(error.message, true));
+    });
     el.sessionList.appendChild(button);
   });
 }
@@ -406,6 +413,34 @@ async function createSession() {
   } finally {
     el.createSessionBtn.disabled = false;
   }
+}
+
+async function deleteSession(sessionId) {
+  const confirmed = window.confirm("确认删除这个会话及其全部消息和事件记录吗？");
+  if (!confirmed) {
+    return;
+  }
+
+  if (sessionId === state.selectedSessionId) {
+    closeSessionStream();
+  }
+
+  await api(`/v1/sessions/${sessionId}`, {
+    method: "DELETE",
+  });
+
+  if (sessionId === state.selectedSessionId) {
+    state.selectedSessionId = null;
+    resetCurrentSessionState();
+  }
+
+  const sessions = await loadSessions();
+  if (!state.selectedSessionId && sessions.length) {
+    state.selectedSessionId = sessions[0].sessionId;
+    await loadCurrentSession();
+  }
+
+  showToast("会话已删除");
 }
 
 async function sendMessage(event) {

--- a/crates/server/tests/agent_run_api_tests.rs
+++ b/crates/server/tests/agent_run_api_tests.rs
@@ -254,6 +254,50 @@ async fn delete_session_not_found_returns_404() {
 }
 
 #[tokio::test]
+async fn delete_running_session_aborts_and_removes_it() {
+    let app = make_app();
+    let session_id = create_test_session(&app).await;
+
+    let submit_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/sessions/{session_id}/messages"))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"content":"delete while running"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(submit_response.status(), StatusCode::ACCEPTED);
+
+    let delete_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/v1/sessions/{session_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(delete_response.status(), StatusCode::NO_CONTENT);
+
+    let status_response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/v1/sessions/{session_id}/status"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(status_response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
 async fn post_message_session_not_found_returns_404() {
     let app = make_app();
     let fake_id = "00000000-0000-0000-0000-000000000000";

--- a/crates/server/tests/agent_run_api_tests.rs
+++ b/crates/server/tests/agent_run_api_tests.rs
@@ -186,6 +186,74 @@ async fn create_session_with_metadata_is_visible_in_session_detail_and_list() {
 }
 
 #[tokio::test]
+async fn delete_session_removes_session_and_history() {
+    let app = make_app();
+    let session_id = create_test_session(&app).await;
+
+    let delete_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/v1/sessions/{session_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(delete_response.status(), StatusCode::NO_CONTENT);
+
+    let get_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/v1/sessions/{session_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(get_response.status(), StatusCode::NOT_FOUND);
+
+    let list_response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/sessions")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(list_response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(list_response.into_body(), 4096)
+        .await
+        .unwrap();
+    let list: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(!list["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|session| session["sessionId"] == session_id));
+}
+
+#[tokio::test]
+async fn delete_session_not_found_returns_404() {
+    let app = make_app();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/v1/sessions/00000000-0000-0000-0000-000000000000")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
 async fn post_message_session_not_found_returns_404() {
     let app = make_app();
     let fake_id = "00000000-0000-0000-0000-000000000000";

--- a/crates/store-memory/src/memory_store.rs
+++ b/crates/store-memory/src/memory_store.rs
@@ -56,6 +56,15 @@ impl SessionStore for MemoryStore {
         Ok(session_id)
     }
 
+    async fn delete_session(&self, session_id: SessionId) -> Result<(), StoreError> {
+        let mut sessions = self.sessions.write().await;
+        if sessions.remove(&session_id).is_some() {
+            Ok(())
+        } else {
+            Err(StoreError::SessionNotFound(session_id))
+        }
+    }
+
     /// Appends an immutable event to the session's event log.
     async fn append_event(
         &self,
@@ -156,6 +165,20 @@ mod tests {
             events[1].payload,
             EventPayload::UserMessage { .. }
         ));
+    }
+
+    #[tokio::test]
+    async fn test_delete_session() {
+        let store = MemoryStore::new();
+        let id = store.create_session().await.unwrap();
+
+        store.delete_session(id).await.unwrap();
+
+        let err = store
+            .get_events(id, &EventFilter::default())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, StoreError::SessionNotFound(_)));
     }
 
     #[tokio::test]

--- a/crates/store-memory/src/memory_store.rs
+++ b/crates/store-memory/src/memory_store.rs
@@ -182,6 +182,15 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_delete_missing_session() {
+        let store = MemoryStore::new();
+        let missing = SessionId::new_v4();
+
+        let err = store.delete_session(missing).await.unwrap_err();
+        assert!(matches!(err, StoreError::SessionNotFound(id) if id == missing));
+    }
+
+    #[tokio::test]
     async fn test_filter_by_actor() {
         let store = MemoryStore::new();
         let id = store.create_session().await.unwrap();


### PR DESCRIPTION
## 背景
当前 Web Console 已支持创建、查看和发送消息，但会话列表无法删除，导致前端手工测试后会积累大量历史 session。

这次改动补上前后端完整删除链路：前端点击删除，后端同步删除 session 记录和事件历史。

## 改动
1. 后端新增会话删除接口
- `DELETE /v1/sessions/:id`
- 删除 session 索引
- 删除对应事件历史
- 如果该 session 有运行中的 task，会先 abort 再移除

2. Store trait 扩展
- 为 `SessionStore` 增加 `delete_session()`
- `MemoryStore` 和 `NotifyingStore` 都已适配
- runtime 里的测试桩也已同步补齐

3. Web Console 支持删除
- 会话卡片增加删除按钮
- 点击后会二次确认
- 删除选中会话时，前端会同步清空并切换到剩余会话
- 删除后前后端记录都会消失，不只是前端隐藏

4. 测试
- `MemoryStore` 删除测试
- server 删除 session 的 204 / 404 测试
- Web UI 脚本路由测试补充 `deleteSession`

## 验证
已本地通过：
- `cargo test -p lattice-server`
- `cargo check --workspace`
- `cargo clippy -p lattice-server --all-targets -- -D warnings`
- `cargo fmt --all`

## 冲突情况
提交前已确认：
- 本地基线来自最新 `origin/main`
- 提交前 `origin/main...HEAD` 为 `0 0`
- 本次改动在独立分支 `feat/session-delete` 上提交