### PR TITLE
feat: add initial lattice-mcp client manager crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +210,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,6 +259,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "encoding_rs"
@@ -294,12 +340,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -307,6 +369,34 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -326,8 +416,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -646,6 +741,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,6 +883,18 @@ dependencies = [
  "serde",
  "serde_json",
  "uuid",
+]
+
+[[package]]
+name = "lattice-mcp"
+version = "0.1.0"
+dependencies = [
+ "rmcp",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -971,6 +1084,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,6 +1187,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,6 +1239,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "process-wrap"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+dependencies = [
+ "futures",
+ "indexmap",
+ "nix",
+ "tokio",
+ "tracing",
+ "windows",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1141,6 +1286,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1215,6 +1380,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "process-wrap",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fdc01c81097b0aed18633e676e269fefa3a78ec1df56b4fe597c1241b92025"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1282,6 +1483,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,6 +1567,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1434,6 +1672,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1590,6 +1834,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1914,6 +2169,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,6 +2200,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -1953,6 +2240,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -2015,6 +2312,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ lattice-llm-openai = { path = "crates/llm-openai", optional = true }
 resolver = "2"
 members = [
     "crates/core",
+    "crates/mcp",
     "crates/runtime",
     "crates/store-memory",
     "crates/sandbox-local",
@@ -91,3 +92,4 @@ hyper = "1"
 http-body-util = "0.1"
 reqwest = { version = "0.12", features = ["json"] }
 dotenvy = "0.15"
+rmcp = { version = "1.5.0", default-features = false, features = ["client", "server", "macros", "transport-child-process", "transport-io"] }

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "lattice-mcp"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+rmcp = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/mcp/src/bin/fixture_mcp_broken_resources_server.rs
+++ b/crates/mcp/src/bin/fixture_mcp_broken_resources_server.rs
@@ -1,0 +1,83 @@
+use std::future::Future;
+
+use rmcp::{
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{ServerCapabilities, ServerInfo},
+    schemars,
+    service::MaybeSendFuture,
+    tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler, ServiceExt,
+};
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct HelloArgs {
+    name: String,
+}
+
+#[allow(dead_code)]
+#[derive(Clone)]
+struct FixtureBrokenResourcesServer {
+    tool_router: ToolRouter<Self>,
+}
+
+impl FixtureBrokenResourcesServer {
+    fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    fn broken_resources_error() -> McpError {
+        McpError::internal_error("fixture resources unavailable", None)
+    }
+}
+
+#[tool_router]
+impl FixtureBrokenResourcesServer {
+    #[tool(description = "Return a fixture greeting")]
+    fn hello(&self, Parameters(HelloArgs { name }): Parameters<HelloArgs>) -> String {
+        format!("fixture-hello:{name}")
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for FixtureBrokenResourcesServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(
+            ServerCapabilities::builder()
+                .enable_tools()
+                .enable_resources()
+                .build(),
+        )
+        .with_instructions("Broken resources fixture MCP server")
+    }
+
+    fn list_resources(
+        &self,
+        _request: Option<rmcp::model::PaginatedRequestParams>,
+        _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+    ) -> impl Future<Output = Result<rmcp::model::ListResourcesResult, McpError>> + MaybeSendFuture + '_
+    {
+        std::future::ready(Err(Self::broken_resources_error()))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let service = FixtureBrokenResourcesServer::new()
+        .serve((tokio::io::stdin(), tokio::io::stdout()))
+        .await?;
+    service.waiting().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn broken_resources_error_is_internal_error() {
+        let err = FixtureBrokenResourcesServer::broken_resources_error();
+        assert_eq!(err.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("fixture resources unavailable"));
+    }
+}

--- a/crates/mcp/src/bin/fixture_mcp_server.rs
+++ b/crates/mcp/src/bin/fixture_mcp_server.rs
@@ -1,0 +1,95 @@
+use std::future::Future;
+
+use rmcp::{
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{
+        AnnotateAble, ListResourcesResult, ReadResourceRequestParams, ReadResourceResult,
+        ResourceContents, Role, ServerCapabilities, ServerInfo,
+    },
+    schemars,
+    service::{MaybeSendFuture, RequestContext},
+    tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler, ServiceExt,
+};
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct HelloArgs {
+    name: String,
+}
+
+#[allow(dead_code)]
+#[derive(Clone)]
+struct FixtureServer {
+    tool_router: ToolRouter<Self>,
+}
+
+impl FixtureServer {
+    fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+        }
+    }
+}
+
+#[tool_router]
+impl FixtureServer {
+    #[tool(description = "Return a fixture greeting")]
+    fn hello(&self, Parameters(HelloArgs { name }): Parameters<HelloArgs>) -> String {
+        format!("fixture-hello:{name}")
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for FixtureServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(
+            ServerCapabilities::builder()
+                .enable_tools()
+                .enable_resources()
+                .build(),
+        )
+        .with_instructions("Fixture MCP server")
+    }
+
+    fn list_resources(
+        &self,
+        _request: Option<rmcp::model::PaginatedRequestParams>,
+        _context: RequestContext<rmcp::RoleServer>,
+    ) -> impl Future<Output = Result<ListResourcesResult, McpError>> + MaybeSendFuture + '_ {
+        std::future::ready(Ok(ListResourcesResult {
+            resources: vec![
+                rmcp::model::RawResource::new("fixture://readme", "Fixture Readme")
+                    .with_description("Fixture resource")
+                    .with_audience(vec![Role::User]),
+            ],
+            next_cursor: None,
+            meta: None,
+        }))
+    }
+
+    async fn read_resource(
+        &self,
+        request: ReadResourceRequestParams,
+        _context: RequestContext<rmcp::RoleServer>,
+    ) -> Result<ReadResourceResult, McpError> {
+        if request.uri == "fixture://readme" {
+            Ok(ReadResourceResult::new(vec![ResourceContents::text(
+                "fixture resource contents",
+                "fixture://readme",
+            )]))
+        } else {
+            Err(McpError::resource_not_found(
+                format!("unknown resource: {}", request.uri),
+                None,
+            ))
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let service = FixtureServer::new()
+        .serve((tokio::io::stdin(), tokio::io::stdout()))
+        .await?;
+    service.waiting().await?;
+    Ok(())
+}

--- a/crates/mcp/src/bin/fixture_mcp_server.rs
+++ b/crates/mcp/src/bin/fixture_mcp_server.rs
@@ -33,7 +33,6 @@ impl FixtureServer {
         ListResourcesResult {
             resources: vec![
                 rmcp::model::RawResource::new("fixture://readme", "Fixture Readme")
-                    .with_description("Fixture resource")
                     .with_audience(vec![Role::User]),
             ],
             next_cursor: None,

--- a/crates/mcp/src/bin/fixture_mcp_server.rs
+++ b/crates/mcp/src/bin/fixture_mcp_server.rs
@@ -28,6 +28,32 @@ impl FixtureServer {
             tool_router: Self::tool_router(),
         }
     }
+
+    fn fixture_resources() -> ListResourcesResult {
+        ListResourcesResult {
+            resources: vec![
+                rmcp::model::RawResource::new("fixture://readme", "Fixture Readme")
+                    .with_description("Fixture resource")
+                    .with_audience(vec![Role::User]),
+            ],
+            next_cursor: None,
+            meta: None,
+        }
+    }
+
+    fn fixture_resource_contents(uri: &str) -> Result<ReadResourceResult, McpError> {
+        if uri == "fixture://readme" {
+            Ok(ReadResourceResult::new(vec![ResourceContents::text(
+                "fixture resource contents",
+                "fixture://readme",
+            )]))
+        } else {
+            Err(McpError::resource_not_found(
+                format!("unknown resource: {uri}"),
+                None,
+            ))
+        }
+    }
 }
 
 #[tool_router]
@@ -55,15 +81,7 @@ impl ServerHandler for FixtureServer {
         _request: Option<rmcp::model::PaginatedRequestParams>,
         _context: RequestContext<rmcp::RoleServer>,
     ) -> impl Future<Output = Result<ListResourcesResult, McpError>> + MaybeSendFuture + '_ {
-        std::future::ready(Ok(ListResourcesResult {
-            resources: vec![
-                rmcp::model::RawResource::new("fixture://readme", "Fixture Readme")
-                    .with_description("Fixture resource")
-                    .with_audience(vec![Role::User]),
-            ],
-            next_cursor: None,
-            meta: None,
-        }))
+        std::future::ready(Ok(Self::fixture_resources()))
     }
 
     async fn read_resource(
@@ -71,17 +89,7 @@ impl ServerHandler for FixtureServer {
         request: ReadResourceRequestParams,
         _context: RequestContext<rmcp::RoleServer>,
     ) -> Result<ReadResourceResult, McpError> {
-        if request.uri == "fixture://readme" {
-            Ok(ReadResourceResult::new(vec![ResourceContents::text(
-                "fixture resource contents",
-                "fixture://readme",
-            )]))
-        } else {
-            Err(McpError::resource_not_found(
-                format!("unknown resource: {}", request.uri),
-                None,
-            ))
-        }
+        Self::fixture_resource_contents(&request.uri)
     }
 }
 
@@ -92,4 +100,49 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
     service.waiting().await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hello_tool_formats_fixture_response() {
+        let server = FixtureServer::new();
+        let result = server.hello(Parameters(HelloArgs {
+            name: "lattice".to_string(),
+        }));
+        assert_eq!(result, "fixture-hello:lattice");
+    }
+
+    #[test]
+    fn server_info_enables_tools_and_resources() {
+        let info = FixtureServer::new().get_info();
+        assert_eq!(info.instructions.as_deref(), Some("Fixture MCP server"));
+        assert!(info.capabilities.tools.is_some());
+        assert!(info.capabilities.resources.is_some());
+    }
+
+    #[test]
+    fn fixture_resources_returns_fixture_resource() {
+        let result = FixtureServer::fixture_resources();
+
+        assert_eq!(result.resources.len(), 1);
+        assert_eq!(result.resources[0].uri, "fixture://readme");
+        assert_eq!(result.resources[0].name, "Fixture Readme");
+    }
+
+    #[test]
+    fn read_resource_returns_contents_for_known_uri() {
+        let result = FixtureServer::fixture_resource_contents("fixture://readme").unwrap();
+
+        assert_eq!(result.contents.len(), 1);
+    }
+
+    #[test]
+    fn read_resource_rejects_unknown_uri() {
+        let err = FixtureServer::fixture_resource_contents("fixture://missing").unwrap_err();
+
+        assert!(err.message.contains("unknown resource"));
+    }
 }

--- a/crates/mcp/src/bin/fixture_mcp_tools_only_server.rs
+++ b/crates/mcp/src/bin/fixture_mcp_tools_only_server.rs
@@ -1,0 +1,63 @@
+use std::future::Future;
+
+use rmcp::{
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{ListResourcesRequestMethod, ServerCapabilities, ServerInfo},
+    schemars, tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler, ServiceExt,
+};
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct HelloArgs {
+    name: String,
+}
+
+#[allow(dead_code)]
+#[derive(Clone)]
+struct FixtureToolsOnlyServer {
+    tool_router: ToolRouter<Self>,
+}
+
+impl FixtureToolsOnlyServer {
+    fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+        }
+    }
+}
+
+#[tool_router]
+impl FixtureToolsOnlyServer {
+    #[tool(description = "Return a tools-only fixture greeting")]
+    fn hello(&self, Parameters(HelloArgs { name }): Parameters<HelloArgs>) -> String {
+        format!("fixture-hello:{name}")
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for FixtureToolsOnlyServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_instructions("Tools-only fixture MCP server")
+    }
+
+    fn list_resources(
+        &self,
+        _request: Option<rmcp::model::PaginatedRequestParams>,
+        _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+    ) -> impl Future<Output = Result<rmcp::model::ListResourcesResult, McpError>>
+           + rmcp::service::MaybeSendFuture
+           + '_ {
+        std::future::ready(Err(
+            McpError::method_not_found::<ListResourcesRequestMethod>(),
+        ))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let service = FixtureToolsOnlyServer::new()
+        .serve((tokio::io::stdin(), tokio::io::stdout()))
+        .await?;
+    service.waiting().await?;
+    Ok(())
+}

--- a/crates/mcp/src/bin/fixture_mcp_tools_only_server.rs
+++ b/crates/mcp/src/bin/fixture_mcp_tools_only_server.rs
@@ -23,6 +23,10 @@ impl FixtureToolsOnlyServer {
             tool_router: Self::tool_router(),
         }
     }
+
+    fn list_resources_not_supported() -> McpError {
+        McpError::method_not_found::<ListResourcesRequestMethod>()
+    }
 }
 
 #[tool_router]
@@ -47,9 +51,7 @@ impl ServerHandler for FixtureToolsOnlyServer {
     ) -> impl Future<Output = Result<rmcp::model::ListResourcesResult, McpError>>
            + rmcp::service::MaybeSendFuture
            + '_ {
-        std::future::ready(Err(
-            McpError::method_not_found::<ListResourcesRequestMethod>(),
-        ))
+        std::future::ready(Err(Self::list_resources_not_supported()))
     }
 }
 
@@ -60,4 +62,36 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
     service.waiting().await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hello_tool_formats_fixture_response() {
+        let server = FixtureToolsOnlyServer::new();
+        let result = server.hello(Parameters(HelloArgs {
+            name: "lattice".to_string(),
+        }));
+        assert_eq!(result, "fixture-hello:lattice");
+    }
+
+    #[test]
+    fn server_info_only_enables_tools() {
+        let info = FixtureToolsOnlyServer::new().get_info();
+        assert_eq!(
+            info.instructions.as_deref(),
+            Some("Tools-only fixture MCP server")
+        );
+        assert!(info.capabilities.tools.is_some());
+        assert!(info.capabilities.resources.is_none());
+    }
+
+    #[test]
+    fn list_resources_returns_method_not_found() {
+        let err = FixtureToolsOnlyServer::list_resources_not_supported();
+
+        assert_eq!(err.code, rmcp::model::ErrorCode::METHOD_NOT_FOUND);
+    }
 }

--- a/crates/mcp/src/bin/fixture_mcp_tools_only_server.rs
+++ b/crates/mcp/src/bin/fixture_mcp_tools_only_server.rs
@@ -31,7 +31,7 @@ impl FixtureToolsOnlyServer {
 
 #[tool_router]
 impl FixtureToolsOnlyServer {
-    #[tool(description = "Return a tools-only fixture greeting")]
+    #[tool]
     fn hello(&self, Parameters(HelloArgs { name }): Parameters<HelloArgs>) -> String {
         format!("fixture-hello:{name}")
     }

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -1,0 +1,14 @@
+//! MCP client support for Lattice.
+//!
+//! This crate provides the first-stage MCP integration layer:
+//! configuration types, connection status models, and a stdio-backed
+//! multi-server client manager.
+
+mod manager;
+mod types;
+
+pub use manager::McpClientManager;
+pub use types::{
+    McpConnectionState, McpConnectionStatus, McpHttpServerConfig, McpJsonConfig, McpResourceInfo,
+    McpServerConfig, McpStdioServerConfig, McpToolInfo, McpWebSocketServerConfig,
+};

--- a/crates/mcp/src/manager.rs
+++ b/crates/mcp/src/manager.rs
@@ -1,0 +1,216 @@
+use std::collections::HashMap;
+
+use rmcp::{
+    model::{ErrorCode, Tool},
+    service::{RoleClient, RunningService, ServiceError},
+    transport::TokioChildProcess,
+    ServiceExt,
+};
+use tokio::process::Command;
+use tracing::warn;
+
+use crate::types::{
+    McpConnectionStatus, McpResourceInfo, McpServerConfig, McpStdioServerConfig, McpToolInfo,
+};
+
+pub struct McpClientManager {
+    server_configs: HashMap<String, McpServerConfig>,
+    statuses: HashMap<String, McpConnectionStatus>,
+    sessions: HashMap<String, RunningService<RoleClient, ()>>,
+}
+
+impl McpClientManager {
+    #[must_use]
+    pub fn new(server_configs: HashMap<String, McpServerConfig>) -> Self {
+        let statuses = server_configs
+            .iter()
+            .map(|(name, config)| {
+                (
+                    name.clone(),
+                    McpConnectionStatus::pending(name.clone(), config.transport()),
+                )
+            })
+            .collect();
+
+        Self {
+            server_configs,
+            statuses,
+            sessions: HashMap::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn list_statuses(&self) -> Vec<McpConnectionStatus> {
+        let mut statuses: Vec<_> = self.statuses.values().cloned().collect();
+        statuses.sort_by(|a, b| a.name.cmp(&b.name));
+        statuses
+    }
+
+    #[must_use]
+    pub fn list_tools(&self) -> Vec<McpToolInfo> {
+        self.list_statuses()
+            .into_iter()
+            .flat_map(|status| status.tools)
+            .collect()
+    }
+
+    #[must_use]
+    pub fn list_resources(&self) -> Vec<McpResourceInfo> {
+        self.list_statuses()
+            .into_iter()
+            .flat_map(|status| status.resources)
+            .collect()
+    }
+
+    pub async fn connect_all(&mut self) {
+        let names: Vec<String> = self.server_configs.keys().cloned().collect();
+        for name in names {
+            self.connect_one(&name).await;
+        }
+    }
+
+    pub async fn reconnect_all(&mut self) {
+        self.close().await;
+        self.statuses = self
+            .server_configs
+            .iter()
+            .map(|(name, config)| {
+                (
+                    name.clone(),
+                    McpConnectionStatus::pending(name.clone(), config.transport()),
+                )
+            })
+            .collect();
+        self.connect_all().await;
+    }
+
+    pub async fn close(&mut self) {
+        for session in self.sessions.values_mut() {
+            if let Err(err) = session.close().await {
+                warn!(?err, "failed to close MCP session cleanly");
+            }
+        }
+        self.sessions.clear();
+
+        for (name, config) in &self.server_configs {
+            self.statuses.insert(
+                name.clone(),
+                McpConnectionStatus::pending(name.clone(), config.transport()),
+            );
+        }
+    }
+
+    async fn connect_one(&mut self, name: &str) {
+        let Some(config) = self.server_configs.get(name).cloned() else {
+            return;
+        };
+
+        match config {
+            McpServerConfig::Stdio(stdio) => self.connect_stdio(name, stdio).await,
+            unsupported => {
+                self.statuses.insert(
+                    name.to_string(),
+                    McpConnectionStatus::failed(
+                        name.to_string(),
+                        unsupported.transport(),
+                        format!(
+                            "unsupported MCP transport in current build: {}",
+                            unsupported.transport()
+                        ),
+                    ),
+                );
+            }
+        }
+    }
+
+    async fn connect_stdio(&mut self, name: &str, config: McpStdioServerConfig) {
+        let mut command = Command::new(&config.command);
+        command.args(&config.args);
+        if let Some(cwd) = &config.cwd {
+            command.current_dir(cwd);
+        }
+        if let Some(env) = &config.env {
+            command.envs(env);
+        }
+
+        let transport = match TokioChildProcess::new(command) {
+            Ok(transport) => transport,
+            Err(err) => {
+                self.statuses.insert(
+                    name.to_string(),
+                    McpConnectionStatus::failed(name.to_string(), "stdio", err.to_string()),
+                );
+                return;
+            }
+        };
+
+        let client = match ().serve(transport).await {
+            Ok(client) => client,
+            Err(err) => {
+                self.statuses.insert(
+                    name.to_string(),
+                    McpConnectionStatus::failed(name.to_string(), "stdio", err.to_string()),
+                );
+                return;
+            }
+        };
+
+        let tools = match client.list_all_tools().await {
+            Ok(tools) => tools,
+            Err(err) => {
+                self.statuses.insert(
+                    name.to_string(),
+                    McpConnectionStatus::failed(name.to_string(), "stdio", err.to_string()),
+                );
+                return;
+            }
+        };
+
+        let resources = match client.list_all_resources().await {
+            Ok(resources) => resources,
+            Err(err) if is_method_not_found(&err) => Vec::new(),
+            Err(err) => {
+                self.statuses.insert(
+                    name.to_string(),
+                    McpConnectionStatus::failed(name.to_string(), "stdio", err.to_string()),
+                );
+                return;
+            }
+        };
+
+        self.statuses.insert(
+            name.to_string(),
+            McpConnectionStatus::connected(
+                name.to_string(),
+                "stdio",
+                tools
+                    .into_iter()
+                    .map(|tool| to_tool_info(name, tool))
+                    .collect(),
+                resources
+                    .into_iter()
+                    .map(|resource| McpResourceInfo {
+                        server_name: name.to_string(),
+                        name: resource.raw.name,
+                        uri: resource.raw.uri,
+                        description: resource.raw.description.unwrap_or_default(),
+                    })
+                    .collect(),
+            ),
+        );
+        self.sessions.insert(name.to_string(), client);
+    }
+}
+
+fn to_tool_info(server_name: &str, tool: Tool) -> McpToolInfo {
+    McpToolInfo {
+        server_name: server_name.to_string(),
+        name: tool.name.into_owned(),
+        description: tool.description.map(|d| d.into_owned()).unwrap_or_default(),
+        input_schema: tool.input_schema.as_ref().clone(),
+    }
+}
+
+fn is_method_not_found(err: &ServiceError) -> bool {
+    matches!(err, ServiceError::McpError(error) if error.code == ErrorCode::METHOD_NOT_FOUND)
+}

--- a/crates/mcp/src/types.rs
+++ b/crates/mcp/src/types.rs
@@ -1,0 +1,202 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum McpServerConfig {
+    Stdio(McpStdioServerConfig),
+    Http(McpHttpServerConfig),
+    Ws(McpWebSocketServerConfig),
+}
+
+impl McpServerConfig {
+    #[must_use]
+    pub fn transport(&self) -> &'static str {
+        match self {
+            Self::Stdio(_) => "stdio",
+            Self::Http(_) => "http",
+            Self::Ws(_) => "ws",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct McpStdioServerConfig {
+    pub command: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub env: Option<HashMap<String, String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct McpHttpServerConfig {
+    pub url: String,
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct McpWebSocketServerConfig {
+    pub url: String,
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct McpJsonConfig {
+    #[serde(rename = "mcpServers", default)]
+    pub mcp_servers: HashMap<String, McpServerConfig>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum McpConnectionState {
+    Pending,
+    Connected,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct McpToolInfo {
+    pub server_name: String,
+    pub name: String,
+    pub description: String,
+    pub input_schema: Map<String, Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct McpResourceInfo {
+    pub server_name: String,
+    pub name: String,
+    pub uri: String,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct McpConnectionStatus {
+    pub name: String,
+    pub state: McpConnectionState,
+    pub detail: String,
+    pub transport: String,
+    pub tools: Vec<McpToolInfo>,
+    pub resources: Vec<McpResourceInfo>,
+}
+
+impl McpConnectionStatus {
+    #[must_use]
+    pub fn pending(name: impl Into<String>, transport: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            state: McpConnectionState::Pending,
+            detail: String::new(),
+            transport: transport.into(),
+            tools: Vec::new(),
+            resources: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn connected(
+        name: impl Into<String>,
+        transport: impl Into<String>,
+        tools: Vec<McpToolInfo>,
+        resources: Vec<McpResourceInfo>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            state: McpConnectionState::Connected,
+            detail: String::new(),
+            transport: transport.into(),
+            tools,
+            resources,
+        }
+    }
+
+    #[must_use]
+    pub fn failed(
+        name: impl Into<String>,
+        transport: impl Into<String>,
+        detail: impl Into<String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            state: McpConnectionState::Failed,
+            detail: detail.into(),
+            transport: transport.into(),
+            tools: Vec::new(),
+            resources: Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_config_parses_tagged_server_configs() {
+        let json = r#"{
+          "mcpServers": {
+            "fixture": {
+              "type": "stdio",
+              "command": "python",
+              "args": ["server.py"]
+            },
+            "remote": {
+              "type": "http",
+              "url": "https://example.com/mcp",
+              "headers": {
+                "Authorization": "Bearer token"
+              }
+            }
+          }
+        }"#;
+
+        let parsed: McpJsonConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.mcp_servers.len(), 2);
+        assert!(matches!(
+            parsed.mcp_servers.get("fixture"),
+            Some(McpServerConfig::Stdio(McpStdioServerConfig { command, .. })) if command == "python"
+        ));
+        assert!(matches!(
+            parsed.mcp_servers.get("remote"),
+            Some(McpServerConfig::Http(McpHttpServerConfig { url, .. })) if url == "https://example.com/mcp"
+        ));
+    }
+
+    #[test]
+    fn transport_name_matches_variant() {
+        assert_eq!(
+            McpServerConfig::Stdio(McpStdioServerConfig {
+                command: "python".into(),
+                args: vec![],
+                env: None,
+                cwd: None,
+            })
+            .transport(),
+            "stdio"
+        );
+        assert_eq!(
+            McpServerConfig::Http(McpHttpServerConfig {
+                url: "https://example.com".into(),
+                headers: HashMap::new(),
+            })
+            .transport(),
+            "http"
+        );
+        assert_eq!(
+            McpServerConfig::Ws(McpWebSocketServerConfig {
+                url: "wss://example.com".into(),
+                headers: HashMap::new(),
+            })
+            .transport(),
+            "ws"
+        );
+    }
+}

--- a/crates/mcp/src/types.rs
+++ b/crates/mcp/src/types.rs
@@ -199,4 +199,49 @@ mod tests {
             "ws"
         );
     }
+
+    #[test]
+    fn connection_status_helpers_fill_expected_fields() {
+        let tool = McpToolInfo {
+            server_name: "fixture".into(),
+            name: "hello".into(),
+            description: "fixture tool".into(),
+            input_schema: Map::new(),
+        };
+        let resource = McpResourceInfo {
+            server_name: "fixture".into(),
+            name: "Fixture Readme".into(),
+            uri: "fixture://readme".into(),
+            description: "Fixture resource".into(),
+        };
+
+        let pending = McpConnectionStatus::pending("fixture", "stdio");
+        assert_eq!(pending.name, "fixture");
+        assert_eq!(pending.state, McpConnectionState::Pending);
+        assert_eq!(pending.detail, "");
+        assert_eq!(pending.transport, "stdio");
+        assert!(pending.tools.is_empty());
+        assert!(pending.resources.is_empty());
+
+        let connected = McpConnectionStatus::connected(
+            "fixture",
+            "stdio",
+            vec![tool.clone()],
+            vec![resource.clone()],
+        );
+        assert_eq!(connected.name, "fixture");
+        assert_eq!(connected.state, McpConnectionState::Connected);
+        assert_eq!(connected.detail, "");
+        assert_eq!(connected.transport, "stdio");
+        assert_eq!(connected.tools, vec![tool]);
+        assert_eq!(connected.resources, vec![resource]);
+
+        let failed = McpConnectionStatus::failed("fixture", "stdio", "boom");
+        assert_eq!(failed.name, "fixture");
+        assert_eq!(failed.state, McpConnectionState::Failed);
+        assert_eq!(failed.detail, "boom");
+        assert_eq!(failed.transport, "stdio");
+        assert!(failed.tools.is_empty());
+        assert!(failed.resources.is_empty());
+    }
 }

--- a/crates/mcp/tests/stdio_flow.rs
+++ b/crates/mcp/tests/stdio_flow.rs
@@ -5,11 +5,34 @@ use lattice_mcp::{
     McpClientManager, McpConnectionState, McpHttpServerConfig, McpServerConfig,
     McpStdioServerConfig, McpWebSocketServerConfig,
 };
+use rmcp::{
+    model::ReadResourceRequestParams, service::RoleClient, transport::TokioChildProcess, ServiceExt,
+};
+use tokio::process::Command;
 
 fn fixture_binary(name: &str) -> String {
     let key = format!("CARGO_BIN_EXE_{name}");
     let path = std::env::var_os(&key).unwrap_or_else(|| panic!("missing fixture binary: {key}"));
     PathBuf::from(path).to_string_lossy().into_owned()
+}
+
+async fn connect_fixture_client(
+    command: String,
+    cwd: Option<PathBuf>,
+    env: Option<HashMap<String, String>>,
+) -> rmcp::service::RunningService<RoleClient, ()> {
+    let mut process = Command::new(command);
+    if let Some(cwd) = cwd {
+        process.current_dir(cwd);
+    }
+    if let Some(env) = env {
+        process.envs(env);
+    }
+
+    let transport = TokioChildProcess::new(process).expect("fixture process should start");
+    ().serve(transport)
+        .await
+        .expect("fixture client should connect")
 }
 
 #[tokio::test]
@@ -102,7 +125,30 @@ async fn stdio_manager_tolerates_missing_resource_listing() {
     let statuses = manager.list_statuses();
     assert_eq!(statuses[0].state, McpConnectionState::Connected);
     assert_eq!(statuses[0].tools.len(), 1);
+    assert_eq!(statuses[0].tools[0].description, "");
     assert!(statuses[0].resources.is_empty());
+}
+
+#[tokio::test]
+async fn stdio_manager_fails_on_non_method_not_found_resource_error() {
+    let mut configs = HashMap::new();
+    configs.insert(
+        "broken-resources".to_string(),
+        McpServerConfig::Stdio(McpStdioServerConfig {
+            command: fixture_binary("fixture_mcp_broken_resources_server"),
+            args: vec![],
+            env: None,
+            cwd: None,
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+
+    let statuses = manager.list_statuses();
+    assert_eq!(statuses[0].state, McpConnectionState::Failed);
+    assert_eq!(statuses[0].transport, "stdio");
+    assert!(statuses[0].detail.contains("fixture resources unavailable"));
 }
 
 #[tokio::test]
@@ -146,6 +192,32 @@ async fn reconnect_all_reestablishes_sessions() {
     let statuses = manager.list_statuses();
     assert_eq!(statuses[0].state, McpConnectionState::Connected);
     assert_eq!(statuses[0].tools[0].name, "hello");
+}
+
+#[tokio::test]
+async fn stdio_manager_honors_cwd_and_env_configuration() {
+    let cwd = std::env::current_dir().expect("workspace cwd should exist");
+    let mut env = HashMap::new();
+    env.insert("LATTICE_MCP_FIXTURE".to_string(), "1".to_string());
+
+    let mut configs = HashMap::new();
+    configs.insert(
+        "fixture".to_string(),
+        McpServerConfig::Stdio(McpStdioServerConfig {
+            command: fixture_binary("fixture_mcp_server"),
+            args: vec![],
+            env: Some(env),
+            cwd: Some(cwd),
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+
+    let statuses = manager.list_statuses();
+    assert_eq!(statuses[0].state, McpConnectionState::Connected);
+    assert_eq!(statuses[0].resources.len(), 1);
+    assert_eq!(statuses[0].resources[0].description, "");
 }
 
 #[tokio::test]
@@ -274,4 +346,21 @@ async fn list_statuses_tools_and_resources_are_sorted_and_aggregated() {
     assert_eq!(statuses[1].state, McpConnectionState::Pending);
     assert!(statuses[1].tools.is_empty());
     assert!(statuses[1].resources.is_empty());
+}
+
+#[tokio::test]
+async fn direct_client_can_read_fixture_resource() {
+    let client = connect_fixture_client(fixture_binary("fixture_mcp_server"), None, None).await;
+
+    let resources = client
+        .list_all_resources()
+        .await
+        .expect("resource listing should succeed");
+    assert_eq!(resources.len(), 1);
+
+    let read = client
+        .read_resource(ReadResourceRequestParams::new("fixture://readme"))
+        .await
+        .expect("resource read should succeed");
+    assert_eq!(read.contents.len(), 1);
 }

--- a/crates/mcp/tests/stdio_flow.rs
+++ b/crates/mcp/tests/stdio_flow.rs
@@ -13,6 +13,43 @@ fn fixture_binary(name: &str) -> String {
 }
 
 #[tokio::test]
+async fn new_manager_starts_all_servers_pending() {
+    let mut configs = HashMap::new();
+    configs.insert(
+        "fixture".to_string(),
+        McpServerConfig::Stdio(McpStdioServerConfig {
+            command: fixture_binary("fixture_mcp_server"),
+            args: vec![],
+            env: None,
+            cwd: None,
+        }),
+    );
+    configs.insert(
+        "remote".to_string(),
+        McpServerConfig::Http(McpHttpServerConfig {
+            url: "https://example.com/mcp".to_string(),
+            headers: HashMap::new(),
+        }),
+    );
+
+    let manager = McpClientManager::new(configs);
+    let statuses = manager.list_statuses();
+
+    assert_eq!(statuses.len(), 2);
+    assert_eq!(statuses[0].name, "fixture");
+    assert_eq!(statuses[0].state, McpConnectionState::Pending);
+    assert_eq!(statuses[0].transport, "stdio");
+    assert!(statuses[0].tools.is_empty());
+    assert!(statuses[0].resources.is_empty());
+
+    assert_eq!(statuses[1].name, "remote");
+    assert_eq!(statuses[1].state, McpConnectionState::Pending);
+    assert_eq!(statuses[1].transport, "http");
+    assert!(statuses[1].tools.is_empty());
+    assert!(statuses[1].resources.is_empty());
+}
+
+#[tokio::test]
 async fn stdio_manager_connects_and_discovers_tools_and_resources() {
     let mut configs = HashMap::new();
     configs.insert(
@@ -109,6 +146,44 @@ async fn reconnect_all_reestablishes_sessions() {
     let statuses = manager.list_statuses();
     assert_eq!(statuses[0].state, McpConnectionState::Connected);
     assert_eq!(statuses[0].tools[0].name, "hello");
+}
+
+#[tokio::test]
+async fn reconnect_all_recovers_failed_stdio_session() {
+    let mut configs = HashMap::new();
+    configs.insert(
+        "fixture".to_string(),
+        McpServerConfig::Stdio(McpStdioServerConfig {
+            command: "__missing_lattice_mcp_fixture__".to_string(),
+            args: vec![],
+            env: None,
+            cwd: None,
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+    let statuses = manager.list_statuses();
+    assert_eq!(statuses[0].state, McpConnectionState::Failed);
+
+    let mut recovered_configs = HashMap::new();
+    recovered_configs.insert(
+        "fixture".to_string(),
+        McpServerConfig::Stdio(McpStdioServerConfig {
+            command: fixture_binary("fixture_mcp_server"),
+            args: vec![],
+            env: None,
+            cwd: None,
+        }),
+    );
+
+    let mut recovered = McpClientManager::new(recovered_configs);
+    recovered.reconnect_all().await;
+
+    let statuses = recovered.list_statuses();
+    assert_eq!(statuses[0].state, McpConnectionState::Connected);
+    assert_eq!(statuses[0].tools.len(), 1);
+    assert_eq!(statuses[0].resources.len(), 1);
 }
 
 #[tokio::test]

--- a/crates/mcp/tests/stdio_flow.rs
+++ b/crates/mcp/tests/stdio_flow.rs
@@ -1,7 +1,10 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use lattice_mcp::{McpClientManager, McpConnectionState, McpServerConfig, McpStdioServerConfig};
+use lattice_mcp::{
+    McpClientManager, McpConnectionState, McpHttpServerConfig, McpServerConfig,
+    McpStdioServerConfig, McpWebSocketServerConfig,
+};
 
 fn fixture_binary(name: &str) -> String {
     let key = format!("CARGO_BIN_EXE_{name}");
@@ -106,4 +109,94 @@ async fn reconnect_all_reestablishes_sessions() {
     let statuses = manager.list_statuses();
     assert_eq!(statuses[0].state, McpConnectionState::Connected);
     assert_eq!(statuses[0].tools[0].name, "hello");
+}
+
+#[tokio::test]
+async fn connect_all_marks_unsupported_http_and_ws_transports_failed() {
+    let mut configs = HashMap::new();
+    configs.insert(
+        "http-remote".to_string(),
+        McpServerConfig::Http(McpHttpServerConfig {
+            url: "https://example.com/mcp".to_string(),
+            headers: HashMap::new(),
+        }),
+    );
+    configs.insert(
+        "ws-remote".to_string(),
+        McpServerConfig::Ws(McpWebSocketServerConfig {
+            url: "wss://example.com/mcp".to_string(),
+            headers: HashMap::new(),
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+
+    let statuses = manager.list_statuses();
+    assert_eq!(statuses.len(), 2);
+    assert_eq!(statuses[0].name, "http-remote");
+    assert_eq!(statuses[0].state, McpConnectionState::Failed);
+    assert_eq!(statuses[0].transport, "http");
+    assert!(statuses[0].detail.contains("unsupported MCP transport"));
+    assert!(statuses[0].tools.is_empty());
+    assert!(statuses[0].resources.is_empty());
+
+    assert_eq!(statuses[1].name, "ws-remote");
+    assert_eq!(statuses[1].state, McpConnectionState::Failed);
+    assert_eq!(statuses[1].transport, "ws");
+    assert!(statuses[1].detail.contains("unsupported MCP transport"));
+    assert!(statuses[1].tools.is_empty());
+    assert!(statuses[1].resources.is_empty());
+}
+
+#[tokio::test]
+async fn list_statuses_tools_and_resources_are_sorted_and_aggregated() {
+    let mut configs = HashMap::new();
+    configs.insert(
+        "z-fixture".to_string(),
+        McpServerConfig::Stdio(McpStdioServerConfig {
+            command: fixture_binary("fixture_mcp_server"),
+            args: vec![],
+            env: None,
+            cwd: None,
+        }),
+    );
+    configs.insert(
+        "a-http".to_string(),
+        McpServerConfig::Http(McpHttpServerConfig {
+            url: "https://example.com/mcp".to_string(),
+            headers: HashMap::new(),
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+
+    let statuses = manager.list_statuses();
+    assert_eq!(statuses.len(), 2);
+    assert_eq!(statuses[0].name, "a-http");
+    assert_eq!(statuses[0].state, McpConnectionState::Failed);
+    assert_eq!(statuses[1].name, "z-fixture");
+    assert_eq!(statuses[1].state, McpConnectionState::Connected);
+
+    let tools = manager.list_tools();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].server_name, "z-fixture");
+    assert_eq!(tools[0].name, "hello");
+
+    let resources = manager.list_resources();
+    assert_eq!(resources.len(), 1);
+    assert_eq!(resources[0].server_name, "z-fixture");
+    assert_eq!(resources[0].uri, "fixture://readme");
+
+    manager.close().await;
+    let statuses = manager.list_statuses();
+    assert_eq!(statuses[0].name, "a-http");
+    assert_eq!(statuses[0].state, McpConnectionState::Pending);
+    assert!(statuses[0].tools.is_empty());
+    assert!(statuses[0].resources.is_empty());
+    assert_eq!(statuses[1].name, "z-fixture");
+    assert_eq!(statuses[1].state, McpConnectionState::Pending);
+    assert!(statuses[1].tools.is_empty());
+    assert!(statuses[1].resources.is_empty());
 }

--- a/crates/mcp/tests/stdio_flow.rs
+++ b/crates/mcp/tests/stdio_flow.rs
@@ -1,0 +1,109 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use lattice_mcp::{McpClientManager, McpConnectionState, McpServerConfig, McpStdioServerConfig};
+
+fn fixture_binary(name: &str) -> String {
+    let key = format!("CARGO_BIN_EXE_{name}");
+    let path = std::env::var_os(&key).unwrap_or_else(|| panic!("missing fixture binary: {key}"));
+    PathBuf::from(path).to_string_lossy().into_owned()
+}
+
+#[tokio::test]
+async fn stdio_manager_connects_and_discovers_tools_and_resources() {
+    let mut configs = HashMap::new();
+    configs.insert(
+        "fixture".to_string(),
+        McpServerConfig::Stdio(McpStdioServerConfig {
+            command: fixture_binary("fixture_mcp_server"),
+            args: vec![],
+            env: None,
+            cwd: None,
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+
+    let statuses = manager.list_statuses();
+    assert_eq!(statuses.len(), 1);
+    assert_eq!(statuses[0].state, McpConnectionState::Connected);
+    assert_eq!(statuses[0].tools.len(), 1);
+    assert_eq!(statuses[0].tools[0].name, "hello");
+    assert_eq!(statuses[0].resources.len(), 1);
+    assert_eq!(statuses[0].resources[0].uri, "fixture://readme");
+
+    assert_eq!(manager.list_tools().len(), 1);
+    assert_eq!(manager.list_resources().len(), 1);
+
+    manager.close().await;
+    let statuses = manager.list_statuses();
+    assert_eq!(statuses[0].state, McpConnectionState::Pending);
+    assert!(statuses[0].tools.is_empty());
+    assert!(statuses[0].resources.is_empty());
+}
+
+#[tokio::test]
+async fn stdio_manager_tolerates_missing_resource_listing() {
+    let mut configs = HashMap::new();
+    configs.insert(
+        "fixture".to_string(),
+        McpServerConfig::Stdio(McpStdioServerConfig {
+            command: fixture_binary("fixture_mcp_tools_only_server"),
+            args: vec![],
+            env: None,
+            cwd: None,
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+
+    let statuses = manager.list_statuses();
+    assert_eq!(statuses[0].state, McpConnectionState::Connected);
+    assert_eq!(statuses[0].tools.len(), 1);
+    assert!(statuses[0].resources.is_empty());
+}
+
+#[tokio::test]
+async fn stdio_manager_marks_failed_process_start() {
+    let mut configs = HashMap::new();
+    configs.insert(
+        "broken".to_string(),
+        McpServerConfig::Stdio(McpStdioServerConfig {
+            command: "__missing_lattice_mcp_fixture__".to_string(),
+            args: vec![],
+            env: None,
+            cwd: None,
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+
+    let statuses = manager.list_statuses();
+    assert_eq!(statuses[0].state, McpConnectionState::Failed);
+    assert!(statuses[0].detail.contains("missing") || !statuses[0].detail.is_empty());
+}
+
+#[tokio::test]
+async fn reconnect_all_reestablishes_sessions() {
+    let mut configs = HashMap::new();
+    configs.insert(
+        "fixture".to_string(),
+        McpServerConfig::Stdio(McpStdioServerConfig {
+            command: fixture_binary("fixture_mcp_server"),
+            args: vec![],
+            env: None,
+            cwd: None,
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+    manager.reconnect_all().await;
+
+    let statuses = manager.list_statuses();
+    assert_eq!(statuses[0].state, McpConnectionState::Connected);
+    assert_eq!(statuses[0].tools[0].name, "hello");
+}


### PR DESCRIPTION
﻿﻿## 背景

本 PR 对应 MCP 第一阶段基础设施，先把 Layer 3 需要的最小 MCP client 侧能力落地。

本次范围只包含：

- MCP server 配置模型
- 连接管理
- tool / resource discovery
- 基础状态快照

本次不包含 MCP tool bridge、resource tools，以及 server / real-agent 集成，这些内容分别留给后续 issue。

## 本次完成内容

对应 `#82`，新增独立的 `lattice-mcp` crate，提供基础 MCP client 管理能力。

具体包括：

1. 新增 `crates/mcp`
- `McpServerConfig`
- `McpStdioServerConfig`
- `McpHttpServerConfig`
- `McpWebSocketServerConfig`
- `McpJsonConfig`
- `McpToolInfo`
- `McpResourceInfo`
- `McpConnectionStatus`
- `McpConnectionState`

2. 新增 `McpClientManager`
- `connect_all()`
- `reconnect_all()`
- `close()`
- `list_statuses()`
- `list_tools()`
- `list_resources()`

3. 传输层支持策略
- 当前真实支持 `stdio`
- 当前保留 `http` / `ws` 配置模型
  - 运行时会标记为 failed，并给出 unsupported detail

4. 资源发现容错
- 如果 MCP server 不支持 `list_resources()`，不会把整条连接判失败
- 会保持 connected，并返回空 resources 列表

5. 新增 fixture 和集成测试
- 提供两个 stdio fixture MCP server：
  - 一个支持 tools + resources
  - 一个对 `list_resources()` 返回 `method_not_found`
- 用真实 stdio 进程覆盖 discovery 与 manager 行为

## 设计说明

实现参考了 OpenHarness 的 MCP 分层思路，主要借鉴：
- 配置模型
- 连接管理
- discovery 组织方式

但代码按 Lattice 当前 Rust 架构重新实现，没有直接照搬 Python 代码。

## 后续拆分

本 PR 只解决第一阶段 `#82`，后续能力继续按既有 issue 推进：

- MCP ToolSet bridge：`#81`
- MCP resource tools：`#80`
- 在 lattice-server / real-agent 中加载 MCP 配置并注册能力：`#83`

## 验证

已通过：

- `cargo test -p lattice-mcp`
- `cargo clippy -p lattice-mcp --all-targets -- -D warnings`
- `cargo check --workspace`
- `cargo fmt --all --check`

Closes #82

