### PR TITLE
feat: bridge MCP tools into ToolSet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,6 +889,9 @@ dependencies = [
 name = "lattice-mcp"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
+ "lattice-core",
+ "lattice-tools",
  "rmcp",
  "serde",
  "serde_json",

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -13,6 +13,9 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 rmcp = { workspace = true }
+lattice-core = { path = "../core" }
+async-trait = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
+lattice-tools = { path = "../tools" }

--- a/crates/mcp/src/bin/fixture_mcp_server.rs
+++ b/crates/mcp/src/bin/fixture_mcp_server.rs
@@ -16,6 +16,11 @@ struct HelloArgs {
     name: String,
 }
 
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct FailArgs {
+    reason: String,
+}
+
 #[allow(dead_code)]
 #[derive(Clone)]
 struct FixtureServer {
@@ -60,6 +65,17 @@ impl FixtureServer {
     #[tool(description = "Return a fixture greeting")]
     fn hello(&self, Parameters(HelloArgs { name }): Parameters<HelloArgs>) -> String {
         format!("fixture-hello:{name}")
+    }
+
+    #[tool(description = "Return a deterministic fixture error")]
+    fn fail(
+        &self,
+        Parameters(FailArgs { reason }): Parameters<FailArgs>,
+    ) -> Result<String, McpError> {
+        Err(McpError::invalid_params(
+            format!("fixture-fail:{reason}"),
+            None,
+        ))
     }
 }
 
@@ -112,6 +128,17 @@ mod tests {
             name: "lattice".to_string(),
         }));
         assert_eq!(result, "fixture-hello:lattice");
+    }
+
+    #[test]
+    fn fail_tool_returns_fixture_error() {
+        let server = FixtureServer::new();
+        let err = server
+            .fail(Parameters(FailArgs {
+                reason: "boom".to_string(),
+            }))
+            .unwrap_err();
+        assert!(err.message.contains("fixture-fail:boom"));
     }
 
     #[test]

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -5,9 +5,11 @@
 //! multi-server client manager.
 
 mod manager;
+mod tool_adapter;
 mod types;
 
-pub use manager::McpClientManager;
+pub use manager::{McpClientManager, McpToolCallOutput};
+pub use tool_adapter::{mcp_tool_name, McpToolAdapter};
 pub use types::{
     McpConnectionState, McpConnectionStatus, McpHttpServerConfig, McpJsonConfig, McpResourceInfo,
     McpServerConfig, McpStdioServerConfig, McpToolInfo, McpWebSocketServerConfig,

--- a/crates/mcp/src/manager.rs
+++ b/crates/mcp/src/manager.rs
@@ -1,17 +1,25 @@
 use std::collections::HashMap;
 
 use rmcp::{
-    model::{ErrorCode, Tool},
+    model::{CallToolRequestParams, ErrorCode, Tool},
     service::{RoleClient, RunningService, ServiceError},
     transport::TokioChildProcess,
     ServiceExt,
 };
+use serde_json::Value;
 use tokio::process::Command;
 use tracing::warn;
 
 use crate::types::{
     McpConnectionStatus, McpResourceInfo, McpServerConfig, McpStdioServerConfig, McpToolInfo,
 };
+use lattice_core::ToolError;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct McpToolCallOutput {
+    pub output: String,
+    pub structured_content: Option<Value>,
+}
 
 pub struct McpClientManager {
     server_configs: HashMap<String, McpServerConfig>,
@@ -60,6 +68,46 @@ impl McpClientManager {
             .into_iter()
             .flat_map(|status| status.resources)
             .collect()
+    }
+
+    pub async fn call_tool(
+        &self,
+        server_name: &str,
+        tool_name: &str,
+        arguments: Value,
+    ) -> Result<McpToolCallOutput, ToolError> {
+        let session = self.sessions.get(server_name).ok_or_else(|| {
+            ToolError::NotFound(format!("MCP server not connected: {server_name}"))
+        })?;
+
+        let request = match arguments {
+            Value::Null => CallToolRequestParams::new(tool_name.to_string()),
+            Value::Object(map) => {
+                CallToolRequestParams::new(tool_name.to_string()).with_arguments(map)
+            }
+            other => {
+                return Err(ToolError::InvalidParams(format!(
+                    "MCP tool arguments must be a JSON object, got {}",
+                    json_type_name(&other)
+                )));
+            }
+        };
+
+        let result = session.call_tool(request).await.map_err(|err| {
+            ToolError::ExecutionFailed(format!(
+                "MCP tool call failed on server '{server_name}' for '{tool_name}': {err}"
+            ))
+        })?;
+
+        let output = render_tool_result(&result);
+        if result.is_error == Some(true) {
+            return Err(ToolError::ExecutionFailed(output));
+        }
+
+        Ok(McpToolCallOutput {
+            output,
+            structured_content: result.structured_content,
+        })
     }
 
     pub async fn connect_all(&mut self) {
@@ -213,4 +261,33 @@ fn to_tool_info(server_name: &str, tool: Tool) -> McpToolInfo {
 
 fn is_method_not_found(err: &ServiceError) -> bool {
     matches!(err, ServiceError::McpError(error) if error.code == ErrorCode::METHOD_NOT_FOUND)
+}
+
+fn render_tool_result(result: &rmcp::model::CallToolResult) -> String {
+    let text_parts: Vec<String> = result
+        .content
+        .iter()
+        .filter_map(|content| content.raw.as_text().map(|text| text.text.clone()))
+        .collect();
+
+    if !text_parts.is_empty() {
+        return text_parts.join("\n");
+    }
+
+    if let Some(structured) = &result.structured_content {
+        return serde_json::to_string_pretty(structured).unwrap_or_else(|_| structured.to_string());
+    }
+
+    String::new()
+}
+
+fn json_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
 }

--- a/crates/mcp/src/tool_adapter.rs
+++ b/crates/mcp/src/tool_adapter.rs
@@ -1,0 +1,103 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use lattice_core::{ExecutionResult, ToolDescription, ToolError, ToolExecutor};
+use serde_json::Value;
+
+use crate::{McpClientManager, McpToolInfo};
+
+pub fn mcp_tool_name(server_name: &str, tool_name: &str) -> String {
+    format!(
+        "mcp__{}__{}",
+        sanitize_tool_segment(server_name),
+        sanitize_tool_segment(tool_name)
+    )
+}
+
+pub struct McpToolAdapter {
+    manager: Arc<McpClientManager>,
+    tool_info: McpToolInfo,
+}
+
+impl McpToolAdapter {
+    #[must_use]
+    pub fn new(manager: Arc<McpClientManager>, tool_info: McpToolInfo) -> Self {
+        Self { manager, tool_info }
+    }
+
+    #[must_use]
+    pub fn from_manager(manager: Arc<McpClientManager>) -> Vec<Self> {
+        manager
+            .list_tools()
+            .into_iter()
+            .map(|tool_info| Self::new(manager.clone(), tool_info))
+            .collect()
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for McpToolAdapter {
+    fn description(&self) -> ToolDescription {
+        ToolDescription {
+            name: mcp_tool_name(&self.tool_info.server_name, &self.tool_info.name),
+            description: if self.tool_info.description.is_empty() {
+                format!("MCP tool {}", self.tool_info.name)
+            } else {
+                self.tool_info.description.clone()
+            },
+            parameters_schema: Value::Object(self.tool_info.input_schema.clone()),
+        }
+    }
+
+    async fn execute(&self, params: Value) -> Result<ExecutionResult, ToolError> {
+        let output = self
+            .manager
+            .call_tool(&self.tool_info.server_name, &self.tool_info.name, params)
+            .await?;
+
+        Ok(ExecutionResult {
+            stdout: output.output,
+            stderr: String::new(),
+            exit_code: 0,
+        })
+    }
+}
+
+fn sanitize_tool_segment(value: &str) -> String {
+    let mut sanitized = String::with_capacity(value.len().max(4));
+    for ch in value.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {
+            sanitized.push(ch);
+        } else {
+            sanitized.push('_');
+        }
+    }
+
+    if sanitized.is_empty() {
+        return "tool".to_string();
+    }
+
+    if sanitized
+        .chars()
+        .next()
+        .is_some_and(|ch| ch.is_ascii_alphabetic())
+    {
+        sanitized
+    } else {
+        format!("mcp_{sanitized}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mcp_tool_name;
+
+    #[test]
+    fn tool_name_is_sanitized() {
+        assert_eq!(
+            mcp_tool_name("fixture server", "hello/world"),
+            "mcp__fixture_server__hello_world"
+        );
+        assert_eq!(mcp_tool_name("123", "!"), "mcp__mcp_123__mcp__");
+    }
+}

--- a/crates/mcp/tests/stdio_flow.rs
+++ b/crates/mcp/tests/stdio_flow.rs
@@ -1,10 +1,13 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::Arc;
 
+use lattice_core::ToolExecutor;
 use lattice_mcp::{
-    McpClientManager, McpConnectionState, McpHttpServerConfig, McpServerConfig,
-    McpStdioServerConfig, McpWebSocketServerConfig,
+    mcp_tool_name, McpClientManager, McpConnectionState, McpHttpServerConfig, McpServerConfig,
+    McpStdioServerConfig, McpToolAdapter, McpWebSocketServerConfig,
 };
+use lattice_tools::ToolSet;
 use rmcp::{
     model::ReadResourceRequestParams, service::RoleClient, transport::TokioChildProcess, ServiceExt,
 };
@@ -91,12 +94,13 @@ async fn stdio_manager_connects_and_discovers_tools_and_resources() {
     let statuses = manager.list_statuses();
     assert_eq!(statuses.len(), 1);
     assert_eq!(statuses[0].state, McpConnectionState::Connected);
-    assert_eq!(statuses[0].tools.len(), 1);
-    assert_eq!(statuses[0].tools[0].name, "hello");
+    assert_eq!(statuses[0].tools.len(), 2);
+    assert!(statuses[0].tools.iter().any(|tool| tool.name == "hello"));
+    assert!(statuses[0].tools.iter().any(|tool| tool.name == "fail"));
     assert_eq!(statuses[0].resources.len(), 1);
     assert_eq!(statuses[0].resources[0].uri, "fixture://readme");
 
-    assert_eq!(manager.list_tools().len(), 1);
+    assert_eq!(manager.list_tools().len(), 2);
     assert_eq!(manager.list_resources().len(), 1);
 
     manager.close().await;
@@ -191,7 +195,7 @@ async fn reconnect_all_reestablishes_sessions() {
 
     let statuses = manager.list_statuses();
     assert_eq!(statuses[0].state, McpConnectionState::Connected);
-    assert_eq!(statuses[0].tools[0].name, "hello");
+    assert!(statuses[0].tools.iter().any(|tool| tool.name == "hello"));
 }
 
 #[tokio::test]
@@ -254,7 +258,7 @@ async fn reconnect_all_recovers_failed_stdio_session() {
 
     let statuses = recovered.list_statuses();
     assert_eq!(statuses[0].state, McpConnectionState::Connected);
-    assert_eq!(statuses[0].tools.len(), 1);
+    assert_eq!(statuses[0].tools.len(), 2);
     assert_eq!(statuses[0].resources.len(), 1);
 }
 
@@ -327,9 +331,13 @@ async fn list_statuses_tools_and_resources_are_sorted_and_aggregated() {
     assert_eq!(statuses[1].state, McpConnectionState::Connected);
 
     let tools = manager.list_tools();
-    assert_eq!(tools.len(), 1);
-    assert_eq!(tools[0].server_name, "z-fixture");
-    assert_eq!(tools[0].name, "hello");
+    assert_eq!(tools.len(), 2);
+    assert!(tools
+        .iter()
+        .any(|tool| { tool.server_name == "z-fixture" && tool.name == "hello" }));
+    assert!(tools
+        .iter()
+        .any(|tool| { tool.server_name == "z-fixture" && tool.name == "fail" }));
 
     let resources = manager.list_resources();
     assert_eq!(resources.len(), 1);
@@ -363,4 +371,111 @@ async fn direct_client_can_read_fixture_resource() {
         .await
         .expect("resource read should succeed");
     assert_eq!(read.contents.len(), 1);
+}
+
+#[tokio::test]
+async fn manager_can_call_mcp_tool() {
+    let mut configs = HashMap::new();
+    configs.insert(
+        "fixture".to_string(),
+        McpServerConfig::Stdio(McpStdioServerConfig {
+            command: fixture_binary("fixture_mcp_server"),
+            args: vec![],
+            env: None,
+            cwd: None,
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+
+    let output = manager
+        .call_tool("fixture", "hello", serde_json::json!({ "name": "lattice" }))
+        .await
+        .unwrap();
+    assert_eq!(output.output, "fixture-hello:lattice");
+    assert_eq!(output.structured_content, None);
+}
+
+#[tokio::test]
+async fn manager_rejects_non_object_tool_arguments() {
+    let mut configs = HashMap::new();
+    configs.insert(
+        "fixture".to_string(),
+        McpServerConfig::Stdio(McpStdioServerConfig {
+            command: fixture_binary("fixture_mcp_server"),
+            args: vec![],
+            env: None,
+            cwd: None,
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+
+    let err = manager
+        .call_tool("fixture", "hello", serde_json::json!(["bad"]))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, lattice_core::ToolError::InvalidParams(_)));
+    assert!(err.to_string().contains("JSON object"));
+}
+
+#[tokio::test]
+async fn manager_surfaces_remote_tool_error() {
+    let mut configs = HashMap::new();
+    configs.insert(
+        "fixture".to_string(),
+        McpServerConfig::Stdio(McpStdioServerConfig {
+            command: fixture_binary("fixture_mcp_server"),
+            args: vec![],
+            env: None,
+            cwd: None,
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+
+    let err = manager
+        .call_tool("fixture", "fail", serde_json::json!({ "reason": "boom" }))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, lattice_core::ToolError::ExecutionFailed(_)));
+    assert!(err.to_string().contains("fixture-fail:boom"));
+}
+
+#[tokio::test]
+async fn mcp_tool_adapter_registers_into_toolset_and_executes() {
+    let mut configs = HashMap::new();
+    configs.insert(
+        "fixture".to_string(),
+        McpServerConfig::Stdio(McpStdioServerConfig {
+            command: fixture_binary("fixture_mcp_server"),
+            args: vec![],
+            env: None,
+            cwd: None,
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+    let manager = Arc::new(manager);
+
+    let mut set = ToolSet::new();
+    for tool in McpToolAdapter::from_manager(manager) {
+        if tool.description().name.ends_with("__hello") {
+            set.register(tool).unwrap();
+            break;
+        }
+    }
+
+    let result = set
+        .execute(
+            &mcp_tool_name("fixture", "hello"),
+            serde_json::json!({ "name": "bridge" }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.stdout, "fixture-hello:bridge");
 }


### PR DESCRIPTION
﻿## 背景

本 PR 对应 `#81`，在 `lattice-mcp` 已具备连接与 discovery 能力的基础上，把外部 MCP tools 桥接为 Lattice 可执行工具。

目标是让 `ToolSet` / `ControlLoop` 后续可以像调用本地工具一样调用 MCP tool，而不是停留在“只能列出 tools”的阶段。

## 本次完成内容

1. 新增 MCP tool 适配层
- 新增 `crates/mcp/src/tool_adapter.rs`
- 提供 `McpToolAdapter`
- 提供 `mcp_tool_name(server, tool)`，命名规则为：
  - `mcp__{server}__{tool}`
- 对 server/tool 名称做了安全化处理，避免非法字符直接进入 tool 名

2. 给 `McpClientManager` 增加 tool 调用能力
- 新增 `call_tool(server_name, tool_name, arguments)`
- 内部通过 rmcp 的 `call_tool` 请求实际调用远端 MCP server
- 新增 `McpToolCallOutput`

3. 错误映射
- 非 object / null 参数会转换为 `ToolError::InvalidParams`
- 未连接的 server 转换为 `ToolError::NotFound`
- 远端调用失败 / 远端返回 `is_error=true` 转换为 `ToolError::ExecutionFailed`
- 不做 panic 路径

4. ToolSet 集成验证
- 通过集成测试验证 `McpToolAdapter::from_manager()` 生成的工具可以注册进 `ToolSet`
- 并可通过 `ToolSet.execute()` 正常执行

5. fixture MCP server 补强
- 给 `fixture_mcp_server` 新增 `fail` tool
- 用于覆盖远端工具失败路径

## 设计说明

这次实现只处理“把 MCP tool 变成 Lattice tool”的桥接，不处理：
- resource tools
- server / real-agent 配置接入
- prompt / UI 展示

也就是严格对应 `#81`，不越过后续 issue 边界。

## 验证

已通过：

- `cargo fmt --all`
- `cargo test -p lattice-mcp`
- `cargo check --workspace`
- `cargo clippy -p lattice-mcp --all-targets -- -D warnings`

Closes #81
