### PR TITLE
feat: add MCP resource tools and status snapshots

### DIFF
--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -5,12 +5,15 @@
 //! multi-server client manager.
 
 mod manager;
+mod resource_tools;
 mod tool_adapter;
 mod types;
 
 pub use manager::{McpClientManager, McpToolCallOutput};
+pub use resource_tools::{ListMcpResourcesTool, ReadMcpResourceTool};
 pub use tool_adapter::{mcp_tool_name, McpToolAdapter};
 pub use types::{
-    McpConnectionState, McpConnectionStatus, McpHttpServerConfig, McpJsonConfig, McpResourceInfo,
-    McpServerConfig, McpStdioServerConfig, McpToolInfo, McpWebSocketServerConfig,
+    McpConnectionSnapshot, McpConnectionState, McpConnectionStatus, McpHttpServerConfig,
+    McpJsonConfig, McpResourceInfo, McpServerConfig, McpStdioServerConfig, McpToolInfo,
+    McpWebSocketServerConfig,
 };

--- a/crates/mcp/src/manager.rs
+++ b/crates/mcp/src/manager.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use rmcp::{
-    model::{CallToolRequestParams, ErrorCode, Tool},
+    model::{CallToolRequestParams, ErrorCode, ReadResourceRequestParams, ResourceContents, Tool},
     service::{RoleClient, RunningService, ServiceError},
     transport::TokioChildProcess,
     ServiceExt,
@@ -11,7 +11,8 @@ use tokio::process::Command;
 use tracing::warn;
 
 use crate::types::{
-    McpConnectionStatus, McpResourceInfo, McpServerConfig, McpStdioServerConfig, McpToolInfo,
+    McpConnectionSnapshot, McpConnectionStatus, McpResourceInfo, McpServerConfig,
+    McpStdioServerConfig, McpToolInfo,
 };
 use lattice_core::ToolError;
 
@@ -70,15 +71,21 @@ impl McpClientManager {
             .collect()
     }
 
+    #[must_use]
+    pub fn list_status_snapshots(&self) -> Vec<McpConnectionSnapshot> {
+        self.list_statuses()
+            .into_iter()
+            .map(|status| status.snapshot())
+            .collect()
+    }
+
     pub async fn call_tool(
         &self,
         server_name: &str,
         tool_name: &str,
         arguments: Value,
     ) -> Result<McpToolCallOutput, ToolError> {
-        let session = self.sessions.get(server_name).ok_or_else(|| {
-            ToolError::NotFound(format!("MCP server not connected: {server_name}"))
-        })?;
+        let session = self.require_session(server_name)?;
 
         let request = match arguments {
             Value::Null => CallToolRequestParams::new(tool_name.to_string()),
@@ -108,6 +115,16 @@ impl McpClientManager {
             output,
             structured_content: result.structured_content,
         })
+    }
+
+    pub async fn read_resource(&self, server_name: &str, uri: &str) -> Result<String, ToolError> {
+        let session = self.require_session(server_name)?;
+        let result = session
+            .read_resource(ReadResourceRequestParams::new(uri))
+            .await
+            .map_err(|err| map_read_resource_error(server_name, uri, &err))?;
+
+        Ok(render_read_resource_result(&result))
     }
 
     pub async fn connect_all(&mut self) {
@@ -248,6 +265,23 @@ impl McpClientManager {
         );
         self.sessions.insert(name.to_string(), client);
     }
+
+    fn require_session(
+        &self,
+        server_name: &str,
+    ) -> Result<&RunningService<RoleClient, ()>, ToolError> {
+        self.sessions.get(server_name).ok_or_else(|| {
+            let detail = self
+                .statuses
+                .get(server_name)
+                .map(|status| status.detail.as_str())
+                .filter(|detail| !detail.is_empty())
+                .unwrap_or("server is not connected");
+            ToolError::NotFound(format!(
+                "MCP server '{server_name}' is not connected: {detail}"
+            ))
+        })
+    }
 }
 
 fn to_tool_info(server_name: &str, tool: Tool) -> McpToolInfo {
@@ -279,6 +313,47 @@ fn render_tool_result(result: &rmcp::model::CallToolResult) -> String {
     }
 
     String::new()
+}
+
+fn render_read_resource_result(result: &rmcp::model::ReadResourceResult) -> String {
+    result
+        .contents
+        .iter()
+        .map(render_resource_contents)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn render_resource_contents(content: &ResourceContents) -> String {
+    match content {
+        ResourceContents::TextResourceContents { text, .. } => text.clone(),
+        ResourceContents::BlobResourceContents { blob, .. } => blob.clone(),
+    }
+}
+
+fn map_read_resource_error(server_name: &str, uri: &str, err: &ServiceError) -> ToolError {
+    match err {
+        ServiceError::McpError(error) if error.code == ErrorCode::RESOURCE_NOT_FOUND => {
+            ToolError::NotFound(format!(
+                "MCP resource not found on server '{server_name}': {uri}"
+            ))
+        }
+        ServiceError::McpError(error) if error.code == ErrorCode::INVALID_PARAMS => {
+            ToolError::InvalidParams(format!(
+                "MCP resource read rejected by server '{server_name}' for '{uri}': {}",
+                error.message
+            ))
+        }
+        ServiceError::McpError(error) if error.code == ErrorCode::METHOD_NOT_FOUND => {
+            ToolError::ExecutionFailed(format!(
+                "MCP server '{server_name}' does not support resource reads: {}",
+                error.message
+            ))
+        }
+        _ => ToolError::ExecutionFailed(format!(
+            "MCP resource read failed on server '{server_name}' for '{uri}': {err}"
+        )),
+    }
 }
 
 fn json_type_name(value: &Value) -> &'static str {

--- a/crates/mcp/src/resource_tools.rs
+++ b/crates/mcp/src/resource_tools.rs
@@ -1,0 +1,143 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use lattice_core::{ExecutionResult, ToolDescription, ToolError, ToolExecutor};
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::McpClientManager;
+
+pub struct ListMcpResourcesTool {
+    manager: Arc<McpClientManager>,
+}
+
+impl ListMcpResourcesTool {
+    #[must_use]
+    pub fn new(manager: Arc<McpClientManager>) -> Self {
+        Self { manager }
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for ListMcpResourcesTool {
+    fn description(&self) -> ToolDescription {
+        ToolDescription {
+            name: "list_mcp_resources".to_string(),
+            description: "List MCP resources available from connected servers.".to_string(),
+            parameters_schema: serde_json::json!({
+                "type": "object",
+                "properties": {},
+                "required": []
+            }),
+        }
+    }
+
+    async fn execute(&self, params: Value) -> Result<ExecutionResult, ToolError> {
+        validate_noop_params(params)?;
+
+        let resources = self.manager.list_resources();
+        let stdout = if resources.is_empty() {
+            "(no MCP resources)".to_string()
+        } else {
+            resources
+                .into_iter()
+                .map(|item| {
+                    let mut line = format!("{} {}", item.server_name, item.uri);
+                    if !item.name.is_empty() {
+                        line.push_str(&format!(" | {}", item.name));
+                    }
+                    if !item.description.is_empty() {
+                        line.push_str(&format!(" | {}", item.description));
+                    }
+                    line
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+
+        Ok(ExecutionResult {
+            stdout,
+            stderr: String::new(),
+            exit_code: 0,
+        })
+    }
+}
+
+pub struct ReadMcpResourceTool {
+    manager: Arc<McpClientManager>,
+}
+
+impl ReadMcpResourceTool {
+    #[must_use]
+    pub fn new(manager: Arc<McpClientManager>) -> Self {
+        Self { manager }
+    }
+}
+
+#[derive(Deserialize)]
+struct ReadMcpResourceParams {
+    server: String,
+    uri: String,
+}
+
+#[async_trait]
+impl ToolExecutor for ReadMcpResourceTool {
+    fn description(&self) -> ToolDescription {
+        ToolDescription {
+            name: "read_mcp_resource".to_string(),
+            description: "Read an MCP resource by server and URI.".to_string(),
+            parameters_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "server": {
+                        "type": "string",
+                        "description": "MCP server name"
+                    },
+                    "uri": {
+                        "type": "string",
+                        "description": "Resource URI"
+                    }
+                },
+                "required": ["server", "uri"]
+            }),
+        }
+    }
+
+    async fn execute(&self, params: Value) -> Result<ExecutionResult, ToolError> {
+        let parsed: ReadMcpResourceParams = serde_json::from_value(params).map_err(|err| {
+            ToolError::InvalidParams(format!("invalid read_mcp_resource arguments: {err}"))
+        })?;
+
+        let stdout = self
+            .manager
+            .read_resource(&parsed.server, &parsed.uri)
+            .await?;
+
+        Ok(ExecutionResult {
+            stdout,
+            stderr: String::new(),
+            exit_code: 0,
+        })
+    }
+}
+
+fn validate_noop_params(params: Value) -> Result<(), ToolError> {
+    match params {
+        Value::Null | Value::Object(_) => Ok(()),
+        other => Err(ToolError::InvalidParams(format!(
+            "expected object parameters, got {}",
+            json_type_name(&other)
+        ))),
+    }
+}
+
+fn json_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}

--- a/crates/mcp/src/types.rs
+++ b/crates/mcp/src/types.rs
@@ -88,6 +88,16 @@ pub struct McpConnectionStatus {
     pub resources: Vec<McpResourceInfo>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct McpConnectionSnapshot {
+    pub name: String,
+    pub state: McpConnectionState,
+    pub detail: String,
+    pub transport: String,
+    pub tool_count: usize,
+    pub resource_count: usize,
+}
+
 impl McpConnectionStatus {
     #[must_use]
     pub fn pending(name: impl Into<String>, transport: impl Into<String>) -> Self {
@@ -131,6 +141,18 @@ impl McpConnectionStatus {
             transport: transport.into(),
             tools: Vec::new(),
             resources: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn snapshot(&self) -> McpConnectionSnapshot {
+        McpConnectionSnapshot {
+            name: self.name.clone(),
+            state: self.state.clone(),
+            detail: self.detail.clone(),
+            transport: self.transport.clone(),
+            tool_count: self.tools.len(),
+            resource_count: self.resources.len(),
         }
     }
 }
@@ -243,5 +265,32 @@ mod tests {
         assert_eq!(failed.transport, "stdio");
         assert!(failed.tools.is_empty());
         assert!(failed.resources.is_empty());
+    }
+
+    #[test]
+    fn connection_status_snapshot_reports_counts() {
+        let status = McpConnectionStatus::connected(
+            "fixture",
+            "stdio",
+            vec![McpToolInfo {
+                server_name: "fixture".into(),
+                name: "hello".into(),
+                description: String::new(),
+                input_schema: Map::new(),
+            }],
+            vec![McpResourceInfo {
+                server_name: "fixture".into(),
+                name: "Fixture Readme".into(),
+                uri: "fixture://readme".into(),
+                description: String::new(),
+            }],
+        );
+
+        let snapshot = status.snapshot();
+        assert_eq!(snapshot.name, "fixture");
+        assert_eq!(snapshot.state, McpConnectionState::Connected);
+        assert_eq!(snapshot.transport, "stdio");
+        assert_eq!(snapshot.tool_count, 1);
+        assert_eq!(snapshot.resource_count, 1);
     }
 }

--- a/crates/mcp/tests/stdio_flow.rs
+++ b/crates/mcp/tests/stdio_flow.rs
@@ -4,8 +4,9 @@ use std::sync::Arc;
 
 use lattice_core::ToolExecutor;
 use lattice_mcp::{
-    mcp_tool_name, McpClientManager, McpConnectionState, McpHttpServerConfig, McpServerConfig,
-    McpStdioServerConfig, McpToolAdapter, McpWebSocketServerConfig,
+    mcp_tool_name, ListMcpResourcesTool, McpClientManager, McpConnectionState, McpHttpServerConfig,
+    McpServerConfig, McpStdioServerConfig, McpToolAdapter, McpWebSocketServerConfig,
+    ReadMcpResourceTool,
 };
 use lattice_tools::ToolSet;
 use rmcp::{
@@ -398,6 +399,87 @@ async fn manager_can_call_mcp_tool() {
 }
 
 #[tokio::test]
+async fn manager_can_read_mcp_resource() {
+    let mut configs = HashMap::new();
+    configs.insert(
+        "fixture".to_string(),
+        McpServerConfig::Stdio(McpStdioServerConfig {
+            command: fixture_binary("fixture_mcp_server"),
+            args: vec![],
+            env: None,
+            cwd: None,
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+
+    let output = manager
+        .read_resource("fixture", "fixture://readme")
+        .await
+        .unwrap();
+    assert_eq!(output, "fixture resource contents");
+}
+
+#[tokio::test]
+async fn manager_reports_missing_mcp_resource() {
+    let mut configs = HashMap::new();
+    configs.insert(
+        "fixture".to_string(),
+        McpServerConfig::Stdio(McpStdioServerConfig {
+            command: fixture_binary("fixture_mcp_server"),
+            args: vec![],
+            env: None,
+            cwd: None,
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+
+    let err = manager
+        .read_resource("fixture", "fixture://missing")
+        .await
+        .unwrap_err();
+    assert!(matches!(err, lattice_core::ToolError::NotFound(_)));
+    assert!(err.to_string().contains("fixture://missing"));
+}
+
+#[tokio::test]
+async fn manager_connection_snapshots_include_counts() {
+    let mut configs = HashMap::new();
+    configs.insert(
+        "fixture".to_string(),
+        McpServerConfig::Stdio(McpStdioServerConfig {
+            command: fixture_binary("fixture_mcp_server"),
+            args: vec![],
+            env: None,
+            cwd: None,
+        }),
+    );
+    configs.insert(
+        "http-remote".to_string(),
+        McpServerConfig::Http(McpHttpServerConfig {
+            url: "https://example.com/mcp".to_string(),
+            headers: HashMap::new(),
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+
+    let snapshots = manager.list_status_snapshots();
+    assert_eq!(snapshots.len(), 2);
+    assert_eq!(snapshots[0].name, "fixture");
+    assert_eq!(snapshots[0].tool_count, 2);
+    assert_eq!(snapshots[0].resource_count, 1);
+    assert_eq!(snapshots[1].name, "http-remote");
+    assert_eq!(snapshots[1].tool_count, 0);
+    assert_eq!(snapshots[1].resource_count, 0);
+    assert_eq!(snapshots[1].state, McpConnectionState::Failed);
+}
+
+#[tokio::test]
 async fn manager_rejects_non_object_tool_arguments() {
     let mut configs = HashMap::new();
     configs.insert(
@@ -478,4 +560,91 @@ async fn mcp_tool_adapter_registers_into_toolset_and_executes() {
         .await
         .unwrap();
     assert_eq!(result.stdout, "fixture-hello:bridge");
+}
+
+#[tokio::test]
+async fn mcp_resource_tools_register_into_toolset_and_execute() {
+    let mut configs = HashMap::new();
+    configs.insert(
+        "fixture".to_string(),
+        McpServerConfig::Stdio(McpStdioServerConfig {
+            command: fixture_binary("fixture_mcp_server"),
+            args: vec![],
+            env: None,
+            cwd: None,
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+    let manager = Arc::new(manager);
+
+    let mut set = ToolSet::new();
+    set.register(ListMcpResourcesTool::new(manager.clone()))
+        .unwrap();
+    set.register(ReadMcpResourceTool::new(manager.clone()))
+        .unwrap();
+
+    let listed = set
+        .execute("list_mcp_resources", serde_json::json!({}))
+        .await
+        .unwrap();
+    assert!(listed.stdout.contains("fixture fixture://readme"));
+
+    let read = set
+        .execute(
+            "read_mcp_resource",
+            serde_json::json!({
+                "server": "fixture",
+                "uri": "fixture://readme"
+            }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(read.stdout, "fixture resource contents");
+}
+
+#[tokio::test]
+async fn list_mcp_resources_handles_empty_servers() {
+    let mut configs = HashMap::new();
+    configs.insert(
+        "fixture".to_string(),
+        McpServerConfig::Stdio(McpStdioServerConfig {
+            command: fixture_binary("fixture_mcp_tools_only_server"),
+            args: vec![],
+            env: None,
+            cwd: None,
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+    let tool = ListMcpResourcesTool::new(Arc::new(manager));
+
+    let result = tool.execute(serde_json::json!({})).await.unwrap();
+    assert_eq!(result.stdout, "(no MCP resources)");
+}
+
+#[tokio::test]
+async fn list_mcp_resources_rejects_non_object_params() {
+    let manager = Arc::new(McpClientManager::new(HashMap::new()));
+    let tool = ListMcpResourcesTool::new(manager);
+
+    let err = tool.execute(serde_json::json!(["bad"])).await.unwrap_err();
+    assert!(matches!(err, lattice_core::ToolError::InvalidParams(_)));
+}
+
+#[tokio::test]
+async fn read_mcp_resource_rejects_invalid_params() {
+    let manager = Arc::new(McpClientManager::new(HashMap::new()));
+    let tool = ReadMcpResourceTool::new(manager);
+
+    let err = tool
+        .execute(serde_json::json!({ "server": 1, "uri": true }))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, lattice_core::ToolError::InvalidParams(_)));
+    assert!(err
+        .to_string()
+        .contains("invalid read_mcp_resource arguments"));
 }


### PR DESCRIPTION
﻿## 背景

继续推进 #80，在 MCP tool bridge 的基础上补齐 resource 访问能力与连接状态快照。

这个 PR 依赖 #87，base 指向 `feat/mcp-tool-bridge-v2`，避免在 `main` 还未合入 tool bridge 时重复带入前序改动。

参考了 OpenHarness 在 MCP manager / resource tools 上的分层思路，但实现按 Lattice 当前 Rust 架构落地。

## 本次改动

1. 在 `lattice-mcp` 增加 resource 读取能力
   - `McpClientManager::read_resource(server, uri)`
   - 统一渲染 `text/blob` resource contents
   - 区分 server 未连接、resource 不存在、普通执行失败

2. 增加连接状态快照
   - 新增 `McpConnectionSnapshot`
   - 暴露 `list_status_snapshots()`
   - 包含 `name/state/transport/detail/tool_count/resource_count`

3. 增加两个 MCP resource tools
   - `list_mcp_resources`
   - `read_mcp_resource`

4. 补充测试
   - manager 读取 resource 成功 / 失败
   - snapshot 计数
   - resource tools 注册进 `ToolSet` 后执行
   - 空 resources 场景
   - 坏参数场景

## 验证

已本地通过：

- `cargo fmt --all`
- `cargo test -p lattice-mcp`
- `cargo check --workspace`
- `cargo clippy -p lattice-mcp --all-targets -- -D warnings`
- `cargo llvm-cov test -p lattice-mcp --lcov --output-path target\\llvmcov-mcp.lcov`

## 说明

- 本 PR 不接入 `lattice-server` / `real-agent`
- 本 PR 不做 UI 展示
- 这些属于后续 `#83` 的接入范围
