### PR TITLE
feat: integrate MCP config into server and real-agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,6 +945,7 @@ dependencies = [
  "lattice-llm-anthropic",
  "lattice-llm-openai",
  "lattice-llm-protocol",
+ "lattice-mcp",
  "lattice-runtime",
  "lattice-sandbox-local",
  "lattice-store-memory",
@@ -1276,6 +1277,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "lattice",
+ "lattice-mcp",
  "serde_json",
  "tokio",
  "tracing",

--- a/README.md
+++ b/README.md
@@ -202,6 +202,58 @@ http://127.0.0.1:3001
 - `Provider` 留空（使用服务端默认值）
 - `模型` 留空，或显式填写 `Pro/MiniMaxAI/MiniMax-M2.5`
 
+### MCP 配置接入
+
+`real-agent` 和 `lattice-server` 现在都支持在启动时加载 MCP 配置，并把 MCP tools 注入 `ToolSet`。
+
+当前入口是环境变量：
+
+```text
+LATTICE_MCP_CONFIG=/path/to/mcp.json
+```
+
+配置文件格式直接复用 `mcpServers` JSON，至少支持 `stdio`：
+
+```json
+{
+  "mcpServers": {
+    "fixture": {
+      "type": "stdio",
+      "command": "python",
+      "args": ["./path/to/server.py"]
+    }
+  }
+}
+```
+
+`real-agent` 示例：
+
+```powershell
+$env:LATTICE_LLM_PROVIDER="openai"
+$env:LATTICE_API_KEY="your_key"
+$env:LATTICE_MODEL="gpt-4o"
+$env:LATTICE_MCP_CONFIG="D:\\path\\to\\mcp.json"
+
+cargo run -p real-agent -- "Use the MCP tools to inspect available resources"
+```
+
+`lattice-server` 示例：
+
+```powershell
+$env:LATTICE_LLM_PROVIDER="openai"
+$env:LATTICE_API_KEY="your_key"
+$env:LATTICE_MODEL="gpt-4o"
+$env:LATTICE_MCP_CONFIG="D:\\path\\to\\mcp.json"
+
+cargo run -p lattice-server
+```
+
+行为说明：
+
+- 如果未设置 `LATTICE_MCP_CONFIG`，系统按无 MCP 配置启动
+- 如果某个 MCP server 连接失败，其余 server 仍继续工作
+- `GET /health` 会返回 `mcp_servers` 快照，包含 `state / transport / tool_count / resource_count`
+
 ## LLM Provider 支持
 
 | Provider         | 包                      | 状态 |

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -14,8 +14,8 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 rmcp = { workspace = true }
 lattice-core = { path = "../core" }
+lattice-tools = { path = "../tools" }
 async-trait = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
-lattice-tools = { path = "../tools" }

--- a/crates/mcp/src/integration.rs
+++ b/crates/mcp/src/integration.rs
@@ -1,0 +1,56 @@
+use std::collections::HashMap;
+use std::env;
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+
+use lattice_core::ToolError;
+use lattice_tools::ToolSet;
+
+use crate::{
+    ListMcpResourcesTool, McpClientManager, McpJsonConfig, McpServerConfig, McpToolAdapter,
+    ReadMcpResourceTool,
+};
+
+pub const LATTICE_MCP_CONFIG_ENV: &str = "LATTICE_MCP_CONFIG";
+
+pub fn load_mcp_server_configs_from_path(
+    path: impl AsRef<Path>,
+) -> Result<HashMap<String, McpServerConfig>, String> {
+    let path = path.as_ref();
+    let content = fs::read_to_string(path)
+        .map_err(|err| format!("failed to read MCP config '{}': {err}", path.display()))?;
+    let parsed: McpJsonConfig = serde_json::from_str(&content)
+        .map_err(|err| format!("failed to parse MCP config '{}': {err}", path.display()))?;
+    Ok(parsed.mcp_servers)
+}
+
+pub fn load_mcp_server_configs_from_env() -> Result<HashMap<String, McpServerConfig>, String> {
+    let Some(path) = env::var_os(LATTICE_MCP_CONFIG_ENV) else {
+        return Ok(HashMap::new());
+    };
+    load_mcp_server_configs_from_path(path)
+}
+
+pub async fn load_mcp_manager_from_env() -> Result<Option<Arc<McpClientManager>>, String> {
+    let configs = load_mcp_server_configs_from_env()?;
+    if configs.is_empty() {
+        return Ok(None);
+    }
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+    Ok(Some(Arc::new(manager)))
+}
+
+pub fn register_mcp_tools(
+    toolset: &mut ToolSet,
+    manager: Arc<McpClientManager>,
+) -> Result<(), ToolError> {
+    toolset.register(ListMcpResourcesTool::new(manager.clone()))?;
+    toolset.register(ReadMcpResourceTool::new(manager.clone()))?;
+    for tool in McpToolAdapter::from_manager(manager) {
+        toolset.register(tool)?;
+    }
+    Ok(())
+}

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -4,11 +4,16 @@
 //! configuration types, connection status models, and a stdio-backed
 //! multi-server client manager.
 
+mod integration;
 mod manager;
 mod resource_tools;
 mod tool_adapter;
 mod types;
 
+pub use integration::{
+    load_mcp_manager_from_env, load_mcp_server_configs_from_env, load_mcp_server_configs_from_path,
+    register_mcp_tools, LATTICE_MCP_CONFIG_ENV,
+};
 pub use manager::{McpClientManager, McpToolCallOutput};
 pub use resource_tools::{ListMcpResourcesTool, ReadMcpResourceTool};
 pub use tool_adapter::{mcp_tool_name, McpToolAdapter};

--- a/crates/mcp/tests/stdio_flow.rs
+++ b/crates/mcp/tests/stdio_flow.rs
@@ -1,18 +1,22 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use lattice_core::ToolExecutor;
 use lattice_mcp::{
-    mcp_tool_name, ListMcpResourcesTool, McpClientManager, McpConnectionState, McpHttpServerConfig,
-    McpServerConfig, McpStdioServerConfig, McpToolAdapter, McpWebSocketServerConfig,
-    ReadMcpResourceTool,
+    load_mcp_manager_from_env, load_mcp_server_configs_from_path, mcp_tool_name,
+    register_mcp_tools, ListMcpResourcesTool, McpClientManager, McpConnectionState,
+    McpHttpServerConfig, McpServerConfig, McpStdioServerConfig, McpToolAdapter,
+    McpWebSocketServerConfig, ReadMcpResourceTool, LATTICE_MCP_CONFIG_ENV,
 };
 use lattice_tools::ToolSet;
 use rmcp::{
     model::ReadResourceRequestParams, service::RoleClient, transport::TokioChildProcess, ServiceExt,
 };
 use tokio::process::Command;
+
+static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 fn fixture_binary(name: &str) -> String {
     let key = format!("CARGO_BIN_EXE_{name}");
@@ -37,6 +41,25 @@ async fn connect_fixture_client(
     ().serve(transport)
         .await
         .expect("fixture client should connect")
+}
+
+fn write_temp_mcp_config(command: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("lattice-mcp-{unique}.json"));
+    let json = serde_json::json!({
+        "mcpServers": {
+            "fixture": {
+                "type": "stdio",
+                "command": command,
+                "args": []
+            }
+        }
+    });
+    std::fs::write(&path, serde_json::to_vec(&json).unwrap()).unwrap();
+    path
 }
 
 #[tokio::test]
@@ -396,6 +419,46 @@ async fn manager_can_call_mcp_tool() {
         .unwrap();
     assert_eq!(output.output, "fixture-hello:lattice");
     assert_eq!(output.structured_content, None);
+}
+
+#[test]
+fn load_mcp_server_configs_from_path_parses_json_file() {
+    let path = write_temp_mcp_config("fixture-command");
+    let configs = load_mcp_server_configs_from_path(&path).unwrap();
+    std::fs::remove_file(path).ok();
+
+    let Some(McpServerConfig::Stdio(config)) = configs.get("fixture") else {
+        panic!("expected stdio fixture config");
+    };
+    assert_eq!(config.command, "fixture-command");
+}
+
+#[tokio::test]
+async fn load_mcp_manager_from_env_and_register_mcp_tools() {
+    let _guard = ENV_LOCK.lock().await;
+    let path = write_temp_mcp_config(&fixture_binary("fixture_mcp_server"));
+    unsafe {
+        std::env::set_var(LATTICE_MCP_CONFIG_ENV, &path);
+    }
+
+    let manager = load_mcp_manager_from_env()
+        .await
+        .unwrap()
+        .expect("manager should load from env config");
+    let snapshots = manager.list_status_snapshots();
+    assert_eq!(snapshots.len(), 1);
+    assert_eq!(snapshots[0].state, McpConnectionState::Connected);
+
+    let mut toolset = ToolSet::new();
+    register_mcp_tools(&mut toolset, manager).unwrap();
+    assert!(toolset.contains("list_mcp_resources"));
+    assert!(toolset.contains("read_mcp_resource"));
+    assert!(toolset.contains(&mcp_tool_name("fixture", "hello")));
+
+    unsafe {
+        std::env::remove_var(LATTICE_MCP_CONFIG_ENV);
+    }
+    std::fs::remove_file(path).ok();
 }
 
 #[tokio::test]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -19,6 +19,7 @@ lattice-runtime = { path = "../runtime" }
 lattice-store-memory = { path = "../store-memory" }
 lattice-sandbox-local = { path = "../sandbox-local" }
 lattice-tools = { path = "../tools" }
+lattice-mcp = { path = "../mcp" }
 lattice-llm-protocol = { path = "../llm-protocol", optional = true }
 lattice-llm-anthropic = { path = "../llm-anthropic", optional = true }
 lattice-llm-openai = { path = "../llm-openai", optional = true }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -16,6 +16,9 @@ use axum::{extract::State, http::StatusCode, response::IntoResponse, routing::ge
 use chrono::{DateTime, Utc};
 pub use lattice_core::SessionId;
 use lattice_core::{LLMClient, Sandbox};
+use lattice_mcp::{
+    load_mcp_manager_from_env, register_mcp_tools, McpClientManager, McpConnectionSnapshot,
+};
 use lattice_runtime::ControlLoop;
 use lattice_sandbox_local::LocalSandbox;
 use lattice_tools::ToolSet;
@@ -38,6 +41,8 @@ pub struct AppState {
     pub llm_factory: Arc<dyn LlmClientFactory>,
     /// Tool registry used by agent runs.
     pub tools: Arc<ToolSet>,
+    /// Optional MCP manager backing registered MCP tools.
+    pub mcp_manager: Option<Arc<McpClientManager>>,
     /// Active ControlLoop task handles.
     pub active_runs: Arc<RwLock<HashMap<SessionId, RunHandle>>>,
     /// Server start time (for uptime reporting).
@@ -243,6 +248,8 @@ pub struct HealthResponse {
     pub uptime_seconds: i64,
     /// Which LLM providers are compiled in.
     pub features: serde_json::Value,
+    /// Current MCP server connection snapshots.
+    pub mcp_servers: Vec<McpConnectionSnapshot>,
 }
 
 /// Returns which LLM providers are enabled at compile time.
@@ -264,6 +271,11 @@ async fn health_check(State(state): State<Arc<AppState>>) -> impl IntoResponse {
         version: env!("CARGO_PKG_VERSION"),
         uptime_seconds: uptime,
         features: enabled_features(),
+        mcp_servers: state
+            .mcp_manager
+            .as_ref()
+            .map(|manager| manager.list_status_snapshots())
+            .unwrap_or_default(),
     };
 
     (StatusCode::OK, Json(response))
@@ -290,11 +302,31 @@ fn app(state: AppState) -> Router {
 /// Creates a new AppState with the given session store.
 pub fn new_state(store: Arc<dyn lattice_core::SessionStore>) -> AppState {
     let sandbox: Arc<dyn Sandbox> = Arc::new(LocalSandbox::new());
-    new_state_with_components(
+    new_state_with_mcp_components(
         store,
         Arc::new(EnvLlmClientFactory),
         Arc::new(ToolSet::with_defaults(sandbox)),
+        None,
     )
+}
+
+/// Creates a new AppState using environment-backed MCP configuration when present.
+pub async fn new_state_from_env(
+    store: Arc<dyn lattice_core::SessionStore>,
+) -> Result<AppState, String> {
+    let sandbox: Arc<dyn Sandbox> = Arc::new(LocalSandbox::new());
+    let mut tools = ToolSet::with_defaults(sandbox);
+    let mcp_manager = load_mcp_manager_from_env().await?;
+    if let Some(manager) = &mcp_manager {
+        register_mcp_tools(&mut tools, Arc::clone(manager)).map_err(|err| err.to_string())?;
+    }
+
+    Ok(new_state_with_mcp_components(
+        store,
+        Arc::new(EnvLlmClientFactory),
+        Arc::new(tools),
+        mcp_manager,
+    ))
 }
 
 /// Creates a new AppState with injectable runtime components.
@@ -302,6 +334,16 @@ pub fn new_state_with_components(
     store: Arc<dyn lattice_core::SessionStore>,
     llm_factory: Arc<dyn LlmClientFactory>,
     tools: Arc<ToolSet>,
+) -> AppState {
+    new_state_with_mcp_components(store, llm_factory, tools, None)
+}
+
+/// Creates a new AppState with injectable runtime components and optional MCP manager.
+pub fn new_state_with_mcp_components(
+    store: Arc<dyn lattice_core::SessionStore>,
+    llm_factory: Arc<dyn LlmClientFactory>,
+    tools: Arc<ToolSet>,
+    mcp_manager: Option<Arc<McpClientManager>>,
 ) -> AppState {
     let event_hub = Arc::new(EventHub::new());
     let store: Arc<dyn lattice_core::SessionStore> =
@@ -312,6 +354,7 @@ pub fn new_state_with_components(
         event_hub,
         llm_factory,
         tools,
+        mcp_manager,
         active_runs: Arc::new(RwLock::new(HashMap::new())),
         started_at: Utc::now(),
         sessions: Arc::new(RwLock::new(Vec::new())),
@@ -481,6 +524,7 @@ mod tests {
         assert!(json["features"].is_object());
         assert!(json["features"]["anthropic"].is_boolean());
         assert!(json["features"]["openai"].is_boolean());
+        assert!(json["mcp_servers"].is_array());
     }
 
     #[tokio::test]
@@ -568,12 +612,56 @@ mod tests {
             new_state_with_components(store, Arc::new(TestFactory), Arc::new(ToolSet::new()));
 
         assert_eq!(state.tools.len(), 0);
+        assert!(state.mcp_manager.is_none());
         let client = state.llm_factory.create(None, None).unwrap();
         let decision = client.decide(&[], &[], "").await.unwrap();
         match decision {
             Decision::FinalAnswer { answer } => assert_eq!(answer, "done"),
             _ => panic!("expected final answer"),
         }
+    }
+
+    #[tokio::test]
+    async fn health_reports_mcp_server_snapshots() {
+        let mut configs = std::collections::HashMap::new();
+        configs.insert(
+            "http-remote".to_string(),
+            lattice_mcp::McpServerConfig::Http(lattice_mcp::McpHttpServerConfig {
+                url: "https://example.com/mcp".to_string(),
+                headers: std::collections::HashMap::new(),
+            }),
+        );
+        let mut manager = lattice_mcp::McpClientManager::new(configs);
+        manager.connect_all().await;
+
+        let state = new_state_with_mcp_components(
+            Arc::new(lattice_store_memory::MemoryStore::new()),
+            Arc::new(TestFactory),
+            Arc::new(ToolSet::new()),
+            Some(Arc::new(manager)),
+        );
+        let app = router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 16)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["mcp_servers"].as_array().unwrap().len(), 1);
+        assert_eq!(json["mcp_servers"][0]["name"], "http-remote");
+        assert_eq!(json["mcp_servers"][0]["state"], "failed");
+        assert_eq!(json["mcp_servers"][0]["tool_count"], 0);
+        assert_eq!(json["mcp_servers"][0]["resource_count"], 0);
     }
 
     #[tokio::test]

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -4,7 +4,7 @@ use std::env;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use lattice_server::{new_state, router};
+use lattice_server::{new_state_from_env, router};
 use tracing::info;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
@@ -29,7 +29,35 @@ async fn main() -> anyhow::Result<()> {
         Arc::new(lattice_store_memory::MemoryStore::new());
 
     // Build router and state.
-    let state = new_state(store);
+    let state = new_state_from_env(store)
+        .await
+        .map_err(anyhow::Error::msg)?;
+    if let Some(manager) = &state.mcp_manager {
+        for snapshot in manager.list_status_snapshots() {
+            match snapshot.state {
+                lattice_mcp::McpConnectionState::Connected => {
+                    info!(
+                        server = %snapshot.name,
+                        transport = %snapshot.transport,
+                        tool_count = snapshot.tool_count,
+                        resource_count = snapshot.resource_count,
+                        "MCP server connected"
+                    );
+                }
+                lattice_mcp::McpConnectionState::Failed => {
+                    tracing::warn!(
+                        server = %snapshot.name,
+                        transport = %snapshot.transport,
+                        detail = %snapshot.detail,
+                        "MCP server failed to connect"
+                    );
+                }
+                lattice_mcp::McpConnectionState::Pending => {
+                    info!(server = %snapshot.name, "MCP server pending");
+                }
+            }
+        }
+    }
     let app = router(state);
 
     // Print startup banner.

--- a/examples/real-agent/Cargo.toml
+++ b/examples/real-agent/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 lattice = { path = "../..", features = ["full"] }
+lattice-mcp = { path = "../../crates/mcp" }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/examples/real-agent/src/main.rs
+++ b/examples/real-agent/src/main.rs
@@ -23,7 +23,7 @@ use lattice::runtime::ControlLoop;
 use lattice::sandbox_local::LocalSandbox;
 use lattice::store_memory::MemoryStore;
 use lattice::tools::ToolSet;
-use tracing::info;
+use tracing::{info, warn};
 
 fn main() -> Result<()> {
     // Initialize tracing.
@@ -84,7 +84,38 @@ async fn run(task: String) -> Result<()> {
     // Assemble the agent components.
     let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
     let sandbox = Arc::new(LocalSandbox::new());
-    let tools = Arc::new(ToolSet::with_defaults(sandbox));
+    let mut tools = ToolSet::with_defaults(sandbox);
+    let mcp_manager = lattice_mcp::load_mcp_manager_from_env()
+        .await
+        .map_err(anyhow::Error::msg)?;
+    if let Some(manager) = &mcp_manager {
+        lattice_mcp::register_mcp_tools(&mut tools, Arc::clone(manager))?;
+        for snapshot in manager.list_status_snapshots() {
+            match snapshot.state {
+                lattice_mcp::McpConnectionState::Connected => {
+                    info!(
+                        server = %snapshot.name,
+                        transport = %snapshot.transport,
+                        tool_count = snapshot.tool_count,
+                        resource_count = snapshot.resource_count,
+                        "MCP server connected"
+                    );
+                }
+                lattice_mcp::McpConnectionState::Failed => {
+                    warn!(
+                        server = %snapshot.name,
+                        transport = %snapshot.transport,
+                        detail = %snapshot.detail,
+                        "MCP server failed to connect"
+                    );
+                }
+                lattice_mcp::McpConnectionState::Pending => {
+                    info!(server = %snapshot.name, "MCP server pending");
+                }
+            }
+        }
+    }
+    let tools = Arc::new(tools);
     let control_loop = ControlLoop::with_options(
         store.clone(),
         llm,


### PR DESCRIPTION
﻿## 背景

继续推进 #83，在 #86 / #87 / #88 的基础上，把 MCP 配置真正接入 `lattice-server` 和 `real-agent`。

这个 PR 依赖 #88，base 指向 `feat/mcp-resource-tools`，避免在 `main` 尚未合入前序 MCP 能力时重复带入历史提交。

参考了 OpenHarness 在 MCP runtime 装配上的分层思路：
- 先加载配置
- 再连接 manager
- 再注册 resource tools + MCP tool adapters
- 最后把状态暴露给运行入口

但实现按 Lattice 当前 Rust 架构落地。

## 本次改动

1. 在 `lattice-mcp` 增加接入辅助层
   - `load_mcp_server_configs_from_path()`
   - `load_mcp_server_configs_from_env()`
   - `load_mcp_manager_from_env()`
   - `register_mcp_tools()`
   - 统一使用 `LATTICE_MCP_CONFIG` 作为配置入口

2. 接入 `lattice-server`
   - 新增 `new_state_from_env()`
   - 启动时加载 MCP 配置并注册 MCP tools
   - `AppState` 持有可选 `McpClientManager`
   - `GET /health` 返回 `mcp_servers` 快照
   - server 启动日志会输出 MCP 连接状态

3. 接入 `real-agent`
   - 启动时加载 `LATTICE_MCP_CONFIG`
   - 把 MCP resource tools 和 MCP tool adapters 注入 `ToolSet`
   - 启动日志输出 MCP 连接状态

4. 文档更新
   - README 补充 MCP 配置格式和 `real-agent` / `lattice-server` 启动示例

## 验证

已本地通过：

- `cargo fmt --all`
- `cargo test -p lattice-mcp`
- `cargo test -p lattice-server`
- `cargo check -p real-agent`
- `cargo check --workspace`
- `cargo clippy -p lattice-mcp --all-targets -- -D warnings`
- `cargo clippy -p lattice-server --all-targets -- -D warnings`
- `cargo clippy -p real-agent -- -D warnings`

## 说明

- 当前配置入口只做本地 JSON 文件：`LATTICE_MCP_CONFIG=/path/to/mcp.json`
- 当前至少保证 `stdio` MCP server 可用
- 单个 server 连接失败采用 `warn + continue`，不会阻断其余 MCP servers
- 本 PR 不做 Web UI 的 MCP 配置页面，这部分仍属于后续扩展范围
