### PR TITLE
feat: expose MCP visibility in server API and Web Console

### DIFF
--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -13,6 +13,7 @@ use axum::{
 };
 use chrono::Utc;
 use lattice_core::{Actor, EventFilter, EventId, SessionId};
+use lattice_mcp::McpConnectionState;
 use serde::Deserialize;
 
 use crate::api::types::*;
@@ -53,6 +54,7 @@ pub fn v1_routes() -> Router<Arc<AppState>> {
     Router::new()
         .route("/sessions", post(create_session).get(list_sessions))
         .route("/sessions/{id}", get(get_session).delete(delete_session))
+        .route("/mcp", get(get_mcp_status))
         .route("/sessions/{id}/events", get(get_events))
         .route("/sessions/{id}/stream", get(session_stream))
         .route(
@@ -61,6 +63,63 @@ pub fn v1_routes() -> Router<Arc<AppState>> {
         )
         .route("/sessions/{id}/run", post(trigger_run))
         .route("/sessions/{id}/status", get(get_status))
+}
+
+/// GET /v1/mcp - returns MCP connection status and discovered capabilities.
+async fn get_mcp_status(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<McpStatusResponse>, AppError> {
+    let statuses = state
+        .mcp_manager
+        .as_ref()
+        .map(|manager| manager.list_statuses())
+        .unwrap_or_default();
+
+    let connected_count = statuses
+        .iter()
+        .filter(|status| status.state == McpConnectionState::Connected)
+        .count();
+    let failed_count = statuses
+        .iter()
+        .filter(|status| status.state == McpConnectionState::Failed)
+        .count();
+
+    Ok(Json(McpStatusResponse {
+        enabled: state.mcp_manager.is_some(),
+        server_count: statuses.len(),
+        connected_count,
+        failed_count,
+        servers: statuses
+            .into_iter()
+            .map(|status| McpServerStatusResponse {
+                name: status.name,
+                state: status.state,
+                transport: status.transport,
+                detail: status.detail,
+                tool_count: status.tools.len(),
+                resource_count: status.resources.len(),
+                tools: status
+                    .tools
+                    .into_iter()
+                    .map(|tool| McpToolSummary {
+                        server_name: tool.server_name,
+                        name: tool.name,
+                        description: tool.description,
+                    })
+                    .collect(),
+                resources: status
+                    .resources
+                    .into_iter()
+                    .map(|resource| McpResourceSummary {
+                        server_name: resource.server_name,
+                        name: resource.name,
+                        uri: resource.uri,
+                        description: resource.description,
+                    })
+                    .collect(),
+            })
+            .collect(),
+    }))
 }
 
 /// DELETE /v1/sessions/:id — deletes a session and all of its events.

--- a/crates/server/src/api/types.rs
+++ b/crates/server/src/api/types.rs
@@ -2,6 +2,7 @@
 
 use chrono::{DateTime, Utc};
 use lattice_core::{Actor, Event, EventId, SessionId};
+use lattice_mcp::McpConnectionState;
 use serde::{Deserialize, Serialize};
 
 /// Optional metadata when creating a session.
@@ -231,4 +232,68 @@ pub struct LatestEventInfo {
     pub payload_type: String,
     /// When the event occurred.
     pub timestamp: DateTime<Utc>,
+}
+
+/// Response for GET /v1/mcp.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpStatusResponse {
+    /// Whether MCP is configured for this server process.
+    pub enabled: bool,
+    /// Total number of configured MCP servers.
+    pub server_count: usize,
+    /// Number of connected MCP servers.
+    pub connected_count: usize,
+    /// Number of failed MCP servers.
+    pub failed_count: usize,
+    /// Detailed status for each MCP server.
+    pub servers: Vec<McpServerStatusResponse>,
+}
+
+/// Detailed status for a single MCP server.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpServerStatusResponse {
+    /// Server name from MCP config.
+    pub name: String,
+    /// Connection state.
+    pub state: McpConnectionState,
+    /// Transport name (e.g. stdio/http/ws).
+    pub transport: String,
+    /// Error or status detail, if any.
+    pub detail: String,
+    /// Number of discovered tools.
+    pub tool_count: usize,
+    /// Number of discovered resources.
+    pub resource_count: usize,
+    /// Tool summaries.
+    pub tools: Vec<McpToolSummary>,
+    /// Resource summaries.
+    pub resources: Vec<McpResourceSummary>,
+}
+
+/// Tool summary for MCP status responses.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpToolSummary {
+    /// Parent MCP server name.
+    pub server_name: String,
+    /// Tool name.
+    pub name: String,
+    /// Optional human-readable description.
+    pub description: String,
+}
+
+/// Resource summary for MCP status responses.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpResourceSummary {
+    /// Parent MCP server name.
+    pub server_name: String,
+    /// Resource display name.
+    pub name: String,
+    /// Resource URI.
+    pub uri: String,
+    /// Optional human-readable description.
+    pub description: String,
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -445,6 +445,7 @@ mod tests {
         let html = String::from_utf8(body.to_vec()).unwrap();
         assert!(html.contains("Lattice Console"));
         assert!(html.contains("/ui/app.js"));
+        assert!(html.contains("mcp-panel"));
     }
 
     #[tokio::test]
@@ -498,6 +499,7 @@ mod tests {
         assert!(js.contains("loadSessions"));
         assert!(js.contains("sendMessage"));
         assert!(js.contains("deleteSession"));
+        assert!(js.contains("loadMcpStatus"));
     }
 
     #[tokio::test]
@@ -662,6 +664,85 @@ mod tests {
         assert_eq!(json["mcp_servers"][0]["state"], "failed");
         assert_eq!(json["mcp_servers"][0]["tool_count"], 0);
         assert_eq!(json["mcp_servers"][0]["resource_count"], 0);
+    }
+
+    #[tokio::test]
+    async fn mcp_status_route_reports_disabled_when_unconfigured() {
+        let app = make_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/mcp")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 16)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["enabled"], false);
+        assert_eq!(json["serverCount"], 0);
+        assert_eq!(json["connectedCount"], 0);
+        assert_eq!(json["failedCount"], 0);
+        assert!(json["servers"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn mcp_status_route_reports_server_details() {
+        let mut configs = std::collections::HashMap::new();
+        configs.insert(
+            "http-remote".to_string(),
+            lattice_mcp::McpServerConfig::Http(lattice_mcp::McpHttpServerConfig {
+                url: "https://example.com/mcp".to_string(),
+                headers: std::collections::HashMap::new(),
+            }),
+        );
+        let mut manager = lattice_mcp::McpClientManager::new(configs);
+        manager.connect_all().await;
+
+        let state = new_state_with_mcp_components(
+            Arc::new(lattice_store_memory::MemoryStore::new()),
+            Arc::new(TestFactory),
+            Arc::new(ToolSet::new()),
+            Some(Arc::new(manager)),
+        );
+        let app = router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/mcp")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 16)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["enabled"], true);
+        assert_eq!(json["serverCount"], 1);
+        assert_eq!(json["connectedCount"], 0);
+        assert_eq!(json["failedCount"], 1);
+        assert_eq!(json["servers"][0]["name"], "http-remote");
+        assert_eq!(json["servers"][0]["transport"], "http");
+        assert_eq!(json["servers"][0]["state"], "failed");
+        assert!(json["servers"][0]["detail"]
+            .as_str()
+            .unwrap()
+            .contains("unsupported"));
+        assert!(json["servers"][0]["tools"].as_array().unwrap().is_empty());
+        assert!(json["servers"][0]["resources"]
+            .as_array()
+            .unwrap()
+            .is_empty());
     }
 
     #[tokio::test]

--- a/crates/server/src/ui/app.css
+++ b/crates/server/src/ui/app.css
@@ -106,6 +106,12 @@ textarea {
   gap: 12px;
 }
 
+.panel-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .eyebrow {
   margin: 0 0 4px;
   color: var(--text-muted);
@@ -338,9 +344,19 @@ button:focus-visible {
   color: var(--success);
 }
 
+.status-chip.connected {
+  background: #e7f6ec;
+  color: var(--success);
+}
+
 .status-chip.failed {
   background: #fdecea;
   color: var(--danger);
+}
+
+.status-chip.pending {
+  background: #fff0dc;
+  color: var(--warning);
 }
 
 .status-summary {
@@ -367,6 +383,85 @@ button:focus-visible {
   display: flex;
   flex-direction: column;
   gap: 10px;
+}
+
+.mcp-list {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.mcp-server-card {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface-muted);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.mcp-server-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.mcp-server-name,
+.mcp-server-meta,
+.mcp-server-detail,
+.mcp-detail-label {
+  margin: 0;
+}
+
+.mcp-server-name {
+  font-weight: 600;
+}
+
+.mcp-server-meta,
+.mcp-server-detail,
+.mcp-detail-label {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.mcp-server-summary {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px 12px;
+}
+
+.mcp-server-summary div {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.mcp-server-summary dt {
+  color: var(--text-muted);
+}
+
+.mcp-server-summary dd {
+  margin: 0;
+}
+
+.mcp-server-details {
+  border-top: 1px solid var(--border);
+  padding-top: 10px;
+}
+
+.mcp-server-details summary {
+  cursor: pointer;
+  color: var(--text);
+}
+
+.mcp-detail-section {
+  margin-top: 10px;
 }
 
 .event-item {

--- a/crates/server/src/ui/app.js
+++ b/crates/server/src/ui/app.js
@@ -6,17 +6,22 @@ const state = {
   currentMessages: [],
   currentEvents: [],
   currentStatus: null,
+  currentMcpStatus: null,
 };
 
 const el = {
   createSessionBtn: document.getElementById("create-session-btn"),
   refreshSessionsBtn: document.getElementById("refresh-sessions-btn"),
   refreshDetailBtn: document.getElementById("refresh-detail-btn"),
+  refreshMcpBtn: document.getElementById("refresh-mcp-btn"),
   sessionName: document.getElementById("session-name"),
   sessionList: document.getElementById("session-list"),
   activeSessionLabel: document.getElementById("active-session-label"),
   statusChip: document.getElementById("status-chip"),
   statusSummary: document.getElementById("status-summary"),
+  mcpSummary: document.getElementById("mcp-summary"),
+  mcpList: document.getElementById("mcp-list"),
+  mcpCountBadge: document.getElementById("mcp-count-badge"),
   messageList: document.getElementById("message-list"),
   eventList: document.getElementById("event-list"),
   eventCountBadge: document.getElementById("event-count-badge"),
@@ -98,10 +103,10 @@ function renderSessions(sessions) {
     const label = sessionTitle(session);
     button.innerHTML = `
       <div class="session-card-header">
-        <p class="session-title">${label.title}</p>
+        <p class="session-title">${escapeHtml(label.title)}</p>
         <span class="session-delete" data-session-id="${session.sessionId}" title="删除会话" aria-label="删除会话">×</span>
       </div>
-      <p class="session-meta">${label.meta}</p>
+      <p class="session-meta">${escapeHtml(label.meta)}</p>
     `;
     button.addEventListener("click", () => selectSession(session.sessionId));
     button.querySelector(".session-delete").addEventListener("click", (event) => {
@@ -147,7 +152,7 @@ function renderMessages(messages) {
     const item = document.createElement("article");
     item.className = `message-item ${message.role}`;
     item.innerHTML = `
-      <p class="message-meta">${message.role} · ${formatTime(message.timestamp)}</p>
+      <p class="message-meta">${escapeHtml(message.role)} · ${formatTime(message.timestamp)}</p>
       <pre class="message-content">${escapeHtml(message.content)}</pre>
     `;
     el.messageList.appendChild(item);
@@ -173,7 +178,7 @@ function renderEvents(events) {
       item.className = "event-item";
       item.innerHTML = `
         <header>
-          <p class="event-title">${event.payload.type} · ${event.actor}</p>
+          <p class="event-title">${escapeHtml(event.payload.type)} · ${escapeHtml(event.actor)}</p>
           <span class="event-time">${formatTime(event.timestamp)}</span>
         </header>
         <pre class="event-body">${escapeHtml(summarizePayload(event.payload))}</pre>
@@ -188,16 +193,85 @@ function renderStatus(status) {
     ? `${status.latestEvent.payloadType} · ${status.latestEvent.actor}`
     : "-";
   el.statusSummary.innerHTML = `
-    <div><dt>会话</dt><dd>${state.selectedSessionId || "-"}</dd></div>
-    <div><dt>开始时间</dt><dd>${formatTime(status?.runStartedAt)}</dd></div>
-    <div><dt>结束时间</dt><dd>${formatTime(status?.runCompletedAt)}</dd></div>
+    <div><dt>会话</dt><dd>${escapeHtml(state.selectedSessionId || "-")}</dd></div>
+    <div><dt>开始时间</dt><dd>${escapeHtml(formatTime(status?.runStartedAt))}</dd></div>
+    <div><dt>结束时间</dt><dd>${escapeHtml(formatTime(status?.runCompletedAt))}</dd></div>
     <div><dt>事件数</dt><dd>${status?.eventCount ?? 0}</dd></div>
-    <div><dt>最新事件</dt><dd>${latest}</dd></div>
+    <div><dt>最新事件</dt><dd>${escapeHtml(latest)}</dd></div>
   `;
 }
 
+function renderMcpStatus(mcpStatus) {
+  const enabled = Boolean(mcpStatus?.enabled);
+  const connectedCount = mcpStatus?.connectedCount ?? 0;
+  const failedCount = mcpStatus?.failedCount ?? 0;
+  const serverCount = mcpStatus?.serverCount ?? 0;
+  const servers = mcpStatus?.servers || [];
+
+  el.mcpCountBadge.textContent = String(serverCount);
+  el.mcpSummary.innerHTML = `
+    <div><dt>启用</dt><dd>${enabled ? "true" : "false"}</dd></div>
+    <div><dt>已连接</dt><dd>${connectedCount}</dd></div>
+    <div><dt>失败</dt><dd>${failedCount}</dd></div>
+    <div><dt>总数</dt><dd>${serverCount}</dd></div>
+  `;
+
+  if (!enabled) {
+    el.mcpList.className = "mcp-list empty-state";
+    el.mcpList.textContent = "当前未配置 MCP server。";
+    return;
+  }
+
+  if (!servers.length) {
+    el.mcpList.className = "mcp-list empty-state";
+    el.mcpList.textContent = "MCP 已启用，但当前没有可用 server。";
+    return;
+  }
+
+  el.mcpList.className = "mcp-list";
+  el.mcpList.innerHTML = "";
+
+  servers.forEach((server) => {
+    const item = document.createElement("article");
+    item.className = "mcp-server-card";
+    const detail = server.detail?.trim() || "OK";
+    const tools = server.tools?.length
+      ? server.tools.map((tool) => tool.name).join(", ")
+      : "无";
+    const resources = server.resources?.length
+      ? server.resources.map((resource) => resource.uri).join(", ")
+      : "无";
+    item.innerHTML = `
+      <header class="mcp-server-header">
+        <div>
+          <p class="mcp-server-name">${escapeHtml(server.name)}</p>
+          <p class="mcp-server-meta">${escapeHtml(server.transport)} · ${escapeHtml(server.state)}</p>
+        </div>
+        <span class="status-chip ${escapeHtml(server.state)}">${escapeHtml(server.state)}</span>
+      </header>
+      <dl class="mcp-server-summary">
+        <div><dt>Tools</dt><dd>${server.toolCount}</dd></div>
+        <div><dt>Resources</dt><dd>${server.resourceCount}</dd></div>
+      </dl>
+      <p class="mcp-server-detail">${escapeHtml(detail)}</p>
+      <details class="mcp-server-details">
+        <summary>能力清单</summary>
+        <div class="mcp-detail-section">
+          <p class="mcp-detail-label">Tools</p>
+          <pre class="event-body">${escapeHtml(tools)}</pre>
+        </div>
+        <div class="mcp-detail-section">
+          <p class="mcp-detail-label">Resources</p>
+          <pre class="event-body">${escapeHtml(resources)}</pre>
+        </div>
+      </details>
+    `;
+    el.mcpList.appendChild(item);
+  });
+}
+
 function escapeHtml(value) {
-  return value
+  return String(value)
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")
     .replaceAll(">", "&gt;");
@@ -380,6 +454,12 @@ async function loadCurrentSession() {
   await openSessionStream();
 }
 
+async function loadMcpStatus() {
+  const status = await api("/v1/mcp");
+  state.currentMcpStatus = status;
+  renderMcpStatus(status);
+}
+
 async function selectSession(sessionId) {
   if (sessionId === state.selectedSessionId && state.stream) {
     return;
@@ -493,9 +573,10 @@ async function sendMessage(event) {
 el.createSessionBtn.addEventListener("click", createSession);
 el.refreshSessionsBtn.addEventListener("click", () => loadSessions().catch((error) => showToast(error.message, true)));
 el.refreshDetailBtn.addEventListener("click", () => loadCurrentSession().catch((error) => showToast(error.message, true)));
+el.refreshMcpBtn.addEventListener("click", () => loadMcpStatus().catch((error) => showToast(error.message, true)));
 el.messageForm.addEventListener("submit", sendMessage);
 
-loadSessions(true)
+Promise.all([loadSessions(true), loadMcpStatus()])
   .then(() => loadCurrentSession())
   .catch((error) => showToast(error.message, true));
 

--- a/crates/server/src/ui/index.html
+++ b/crates/server/src/ui/index.html
@@ -29,7 +29,12 @@
         <div class="panel stack-sm">
           <div class="panel-title-row">
             <h2>会话列表</h2>
-            <button id="refresh-sessions-btn" class="ghost-button icon-button" type="button" title="刷新会话列表">
+            <button
+              id="refresh-sessions-btn"
+              class="ghost-button icon-button"
+              type="button"
+              title="刷新会话列表"
+            >
               ↻
             </button>
           </div>
@@ -93,7 +98,12 @@
           <div class="panel stack-sm">
             <div class="panel-title-row">
               <h2>运行状态</h2>
-              <button id="refresh-detail-btn" class="ghost-button icon-button" type="button" title="刷新当前会话">
+              <button
+                id="refresh-detail-btn"
+                class="ghost-button icon-button"
+                type="button"
+                title="刷新当前会话"
+              >
                 ↻
               </button>
             </div>
@@ -104,6 +114,32 @@
               <div><dt>事件数</dt><dd>-</dd></div>
               <div><dt>最新事件</dt><dd>-</dd></div>
             </dl>
+          </div>
+
+          <div id="mcp-panel" class="panel panel-fill stack-sm">
+            <div class="panel-title-row">
+              <h2>MCP</h2>
+              <div class="panel-actions">
+                <span id="mcp-count-badge" class="meta-pill">0</span>
+                <button
+                  id="refresh-mcp-btn"
+                  class="ghost-button icon-button"
+                  type="button"
+                  title="刷新 MCP 状态"
+                >
+                  ↻
+                </button>
+              </div>
+            </div>
+            <dl id="mcp-summary" class="status-summary">
+              <div><dt>启用</dt><dd>false</dd></div>
+              <div><dt>已连接</dt><dd>0</dd></div>
+              <div><dt>失败</dt><dd>0</dd></div>
+              <div><dt>总数</dt><dd>0</dd></div>
+            </dl>
+            <div id="mcp-list" class="mcp-list empty-state">
+              当前未配置 MCP server。
+            </div>
           </div>
 
           <div class="panel panel-fill stack-sm">


### PR DESCRIPTION
﻿## 概要

实现 `#91` 的第一版可见性能力：
- 新增 `GET /v1/mcp`，返回完整 MCP 连接状态与能力清单
- Web Console 新增 `MCP` 面板，展示 server 状态、失败摘要、tools/resources 数量
- 面板支持手动刷新，便于排障和演示

## 改动

1. server API
- 新增 `McpStatusResponse` / `McpServerStatusResponse`
- 新增 `/v1/mcp` 路由
- 返回每个 MCP server 的：
  - `name`
  - `transport`
  - `state`
  - `detail`
  - `toolCount`
  - `resourceCount`
  - `tools`
  - `resources`

2. Web Console
- 右侧新增 `MCP` 面板
- 展示是否启用、已连接数、失败数、总数
- 展示每个 server 的状态卡片与能力清单
- 增加刷新按钮，请求 `/v1/mcp`

3. 测试
- 新增 `/v1/mcp` 未配置/已配置测试
- 更新 Web UI 资源测试，校验 MCP 面板和脚本入口

## 验证

- `cargo test -p lattice-server`
- `cargo check -p lattice-server`
- `cargo clippy -p lattice-server --all-targets -- -D warnings`

## 关系

- base: `feat/mcp-runtime-integration`
- closes: #91
