### PR TITLE
feat: support remote MCP transports and auth config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,10 +136,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -210,6 +225,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +275,22 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -425,6 +475,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -838,7 +898,7 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "uuid",
 ]
 
@@ -849,10 +909,10 @@ dependencies = [
  "async-trait",
  "lattice-core",
  "lattice-llm-protocol",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -866,10 +926,10 @@ dependencies = [
  "dotenvy",
  "lattice-core",
  "lattice-llm-protocol",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -890,13 +950,19 @@ name = "lattice-mcp"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "axum",
+ "futures-util",
+ "http",
  "lattice-core",
  "lattice-tools",
+ "reqwest 0.12.28",
  "rmcp",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite",
+ "tokio-util",
  "tracing",
 ]
 
@@ -924,7 +990,7 @@ dependencies = [
  "lattice-core",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -969,7 +1035,7 @@ dependencies = [
  "lattice-core",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "uuid",
 ]
@@ -1224,6 +1290,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1270,6 +1345,36 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "real-agent"
@@ -1371,6 +1476,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,14 +1532,17 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures",
+ "http",
  "pastey",
  "pin-project-lite",
  "process-wrap",
+ "reqwest 0.13.3",
  "rmcp-macros",
  "schemars",
  "serde",
  "serde_json",
- "thiserror",
+ "sse-stream",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1626,6 +1768,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1670,6 +1823,19 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1757,11 +1923,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1851,6 +2037,18 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -1982,6 +2180,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2012,6 +2234,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2040,6 +2268,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -2149,6 +2383,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -2497,6 +2744,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -212,7 +212,13 @@ http://127.0.0.1:3001
 LATTICE_MCP_CONFIG=/path/to/mcp.json
 ```
 
-配置文件格式直接复用 `mcpServers` JSON，至少支持 `stdio`：
+配置文件格式直接复用 `mcpServers` JSON。当前支持：
+
+- `stdio`
+- `http`
+- `ws`
+
+`stdio` 示例：
 
 ```json
 {
@@ -225,6 +231,37 @@ LATTICE_MCP_CONFIG=/path/to/mcp.json
   }
 }
 ```
+
+远端 MCP 示例，支持 `bearer_token` 和自定义 headers：
+
+```json
+{
+  "mcpServers": {
+    "remote-http": {
+      "type": "http",
+      "url": "https://mcp.example.com/mcp",
+      "bearer_token": "your_token",
+      "headers": {
+        "x-client-id": "lattice"
+      }
+    },
+    "remote-ws": {
+      "type": "ws",
+      "url": "wss://mcp.example.com/mcp",
+      "bearer_token": "your_token",
+      "headers": {
+        "x-client-id": "lattice"
+      }
+    }
+  }
+}
+```
+
+配置约束：
+
+- `bearer_token` 会自动写入 `Authorization: Bearer ...`
+- 如果已经配置 `bearer_token`，就不要再在 `headers` 里手动填写 `Authorization`
+- 远端 `http/ws` 连接失败时只影响对应 server，不会阻塞其他 MCP server 启动
 
 `real-agent` 示例：
 

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -12,10 +12,16 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-rmcp = { workspace = true }
+rmcp = { workspace = true, features = ["transport-streamable-http-client-reqwest"] }
 lattice-core = { path = "../core" }
 lattice-tools = { path = "../tools" }
 async-trait = { workspace = true }
+http = "1"
+futures-util = "0.3"
+tokio-tungstenite = "0.24"
 
 [dev-dependencies]
 tokio = { workspace = true }
+axum = { workspace = true }
+reqwest = { workspace = true }
+tokio-util = "0.7"

--- a/crates/mcp/src/manager.rs
+++ b/crates/mcp/src/manager.rs
@@ -1,25 +1,52 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, future::Future, sync::Arc};
 
+use futures_util::{SinkExt, StreamExt};
+use http::{HeaderName, HeaderValue};
+use lattice_core::ToolError;
 use rmcp::{
     model::{CallToolRequestParams, ErrorCode, ReadResourceRequestParams, ResourceContents, Tool},
-    service::{RoleClient, RunningService, ServiceError},
-    transport::TokioChildProcess,
+    service::{RoleClient, RunningService, RxJsonRpcMessage, ServiceError, TxJsonRpcMessage},
+    transport::{
+        streamable_http_client::StreamableHttpClientTransportConfig, StreamableHttpClientTransport,
+        TokioChildProcess, Transport,
+    },
     ServiceExt,
 };
 use serde_json::Value;
+use tokio::net::TcpStream;
 use tokio::process::Command;
+use tokio::sync::Mutex;
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{self, client::IntoClientRequest, Message},
+    MaybeTlsStream, WebSocketStream,
+};
 use tracing::warn;
 
 use crate::types::{
-    McpConnectionSnapshot, McpConnectionStatus, McpResourceInfo, McpServerConfig,
-    McpStdioServerConfig, McpToolInfo,
+    McpConnectionSnapshot, McpConnectionStatus, McpHttpServerConfig, McpResourceInfo,
+    McpServerConfig, McpStdioServerConfig, McpToolInfo, McpWebSocketServerConfig,
 };
-use lattice_core::ToolError;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct McpToolCallOutput {
     pub output: String,
     pub structured_content: Option<Value>,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum WebSocketTransportError {
+    #[error("websocket error: {0}")]
+    WebSocket(#[from] tungstenite::Error),
+    #[error("json serialization error: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+struct WsClientTransport {
+    sink: Arc<
+        Mutex<futures_util::stream::SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>>,
+    >,
+    stream: futures_util::stream::SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>,
 }
 
 pub struct McpClientManager {
@@ -172,19 +199,8 @@ impl McpClientManager {
 
         match config {
             McpServerConfig::Stdio(stdio) => self.connect_stdio(name, stdio).await,
-            unsupported => {
-                self.statuses.insert(
-                    name.to_string(),
-                    McpConnectionStatus::failed(
-                        name.to_string(),
-                        unsupported.transport(),
-                        format!(
-                            "unsupported MCP transport in current build: {}",
-                            unsupported.transport()
-                        ),
-                    ),
-                );
-            }
+            McpServerConfig::Http(http) => self.connect_http(name, http).await,
+            McpServerConfig::Ws(ws) => self.connect_ws(name, ws).await,
         }
     }
 
@@ -201,10 +217,7 @@ impl McpClientManager {
         let transport = match TokioChildProcess::new(command) {
             Ok(transport) => transport,
             Err(err) => {
-                self.statuses.insert(
-                    name.to_string(),
-                    McpConnectionStatus::failed(name.to_string(), "stdio", err.to_string()),
-                );
+                self.record_failed_status(name, "stdio", err.to_string());
                 return;
             }
         };
@@ -212,21 +225,87 @@ impl McpClientManager {
         let client = match ().serve(transport).await {
             Ok(client) => client,
             Err(err) => {
-                self.statuses.insert(
-                    name.to_string(),
-                    McpConnectionStatus::failed(name.to_string(), "stdio", err.to_string()),
-                );
+                self.record_failed_status(name, "stdio", err.to_string());
                 return;
             }
         };
 
+        self.store_connected_client(name, "stdio", client).await;
+    }
+
+    async fn connect_http(&mut self, name: &str, config: McpHttpServerConfig) {
+        let headers = match parse_custom_headers(&config.headers, config.bearer_token.as_deref()) {
+            Ok(headers) => headers,
+            Err(err) => {
+                self.record_failed_status(name, "http", err);
+                return;
+            }
+        };
+
+        let mut transport_config = StreamableHttpClientTransportConfig::with_uri(config.url);
+        if let Some(token) = config.bearer_token {
+            transport_config = transport_config.auth_header(token);
+        }
+        transport_config = transport_config.custom_headers(headers);
+
+        let transport = StreamableHttpClientTransport::from_config(transport_config);
+        let client = match ().serve(transport).await {
+            Ok(client) => client,
+            Err(err) => {
+                self.record_failed_status(name, "http", err.to_string());
+                return;
+            }
+        };
+
+        self.store_connected_client(name, "http", client).await;
+    }
+
+    async fn connect_ws(&mut self, name: &str, config: McpWebSocketServerConfig) {
+        let headers = match parse_custom_headers(&config.headers, config.bearer_token.as_deref()) {
+            Ok(headers) => headers,
+            Err(err) => {
+                self.record_failed_status(name, "ws", err);
+                return;
+            }
+        };
+
+        let request = match build_websocket_request(&config.url, headers, config.bearer_token) {
+            Ok(request) => request,
+            Err(err) => {
+                self.record_failed_status(name, "ws", err);
+                return;
+            }
+        };
+
+        let stream = match connect_async(request).await {
+            Ok((stream, _)) => stream,
+            Err(err) => {
+                self.record_failed_status(name, "ws", err.to_string());
+                return;
+            }
+        };
+
+        let client = match connect_ws_client(stream).await {
+            Ok(client) => client,
+            Err(err) => {
+                self.record_failed_status(name, "ws", err.to_string());
+                return;
+            }
+        };
+
+        self.store_connected_client(name, "ws", client).await;
+    }
+
+    async fn store_connected_client(
+        &mut self,
+        name: &str,
+        transport: &str,
+        client: RunningService<RoleClient, ()>,
+    ) {
         let tools = match client.list_all_tools().await {
             Ok(tools) => tools,
             Err(err) => {
-                self.statuses.insert(
-                    name.to_string(),
-                    McpConnectionStatus::failed(name.to_string(), "stdio", err.to_string()),
-                );
+                self.record_failed_status(name, transport, err.to_string());
                 return;
             }
         };
@@ -235,10 +314,7 @@ impl McpClientManager {
             Ok(resources) => resources,
             Err(err) if is_method_not_found(&err) => Vec::new(),
             Err(err) => {
-                self.statuses.insert(
-                    name.to_string(),
-                    McpConnectionStatus::failed(name.to_string(), "stdio", err.to_string()),
-                );
+                self.record_failed_status(name, transport, err.to_string());
                 return;
             }
         };
@@ -247,7 +323,7 @@ impl McpClientManager {
             name.to_string(),
             McpConnectionStatus::connected(
                 name.to_string(),
-                "stdio",
+                transport,
                 tools
                     .into_iter()
                     .map(|tool| to_tool_info(name, tool))
@@ -264,6 +340,13 @@ impl McpClientManager {
             ),
         );
         self.sessions.insert(name.to_string(), client);
+    }
+
+    fn record_failed_status(&mut self, name: &str, transport: &str, detail: impl Into<String>) {
+        self.statuses.insert(
+            name.to_string(),
+            McpConnectionStatus::failed(name.to_string(), transport, detail),
+        );
     }
 
     fn require_session(
@@ -295,6 +378,120 @@ fn to_tool_info(server_name: &str, tool: Tool) -> McpToolInfo {
 
 fn is_method_not_found(err: &ServiceError) -> bool {
     matches!(err, ServiceError::McpError(error) if error.code == ErrorCode::METHOD_NOT_FOUND)
+}
+
+fn parse_custom_headers(
+    raw_headers: &HashMap<String, String>,
+    bearer_token: Option<&str>,
+) -> Result<HashMap<HeaderName, HeaderValue>, String> {
+    if bearer_token.is_some()
+        && raw_headers
+            .keys()
+            .any(|name| name.eq_ignore_ascii_case("authorization"))
+    {
+        return Err(
+            "authorization header must not be set when bearer_token is configured".to_string(),
+        );
+    }
+
+    let mut headers = HashMap::with_capacity(raw_headers.len());
+    for (name, value) in raw_headers {
+        let header_name = HeaderName::from_bytes(name.as_bytes())
+            .map_err(|err| format!("invalid MCP header name '{name}': {err}"))?;
+        let header_value = HeaderValue::from_str(value)
+            .map_err(|err| format!("invalid MCP header value for '{name}': {err}"))?;
+        headers.insert(header_name, header_value);
+    }
+    Ok(headers)
+}
+
+fn build_websocket_request(
+    url: &str,
+    headers: HashMap<HeaderName, HeaderValue>,
+    bearer_token: Option<String>,
+) -> Result<http::Request<()>, String> {
+    let mut request = url
+        .into_client_request()
+        .map_err(|err| format!("invalid websocket request for '{url}': {err}"))?;
+
+    for (name, value) in headers {
+        request.headers_mut().insert(name, value);
+    }
+
+    if let Some(token) = bearer_token {
+        let value = HeaderValue::from_str(&format!("Bearer {token}"))
+            .map_err(|err| format!("invalid websocket bearer token: {err}"))?;
+        request
+            .headers_mut()
+            .insert(HeaderName::from_static("authorization"), value);
+    }
+
+    Ok(request)
+}
+
+async fn connect_ws_client(
+    stream: WebSocketStream<MaybeTlsStream<TcpStream>>,
+) -> Result<RunningService<RoleClient, ()>, rmcp::service::ClientInitializeError> {
+    let (sink, stream) = stream.split();
+    let transport = WsClientTransport {
+        sink: Arc::new(Mutex::new(sink)),
+        stream,
+    };
+    ().serve(transport).await
+}
+
+impl Transport<RoleClient> for WsClientTransport {
+    type Error = WebSocketTransportError;
+
+    fn send(
+        &mut self,
+        item: TxJsonRpcMessage<RoleClient>,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'static {
+        let sink = Arc::clone(&self.sink);
+        async move {
+            let payload = serde_json::to_string(&item)?;
+            let mut sink = sink.lock().await;
+            sink.send(Message::Text(payload)).await?;
+            Ok(())
+        }
+    }
+
+    async fn receive(&mut self) -> Option<RxJsonRpcMessage<RoleClient>> {
+        while let Some(message) = self.stream.next().await {
+            match message {
+                Ok(Message::Text(text)) => {
+                    match serde_json::from_str::<RxJsonRpcMessage<RoleClient>>(&text) {
+                        Ok(message) => return Some(message),
+                        Err(err) => {
+                            warn!(?err, "dropping invalid websocket MCP text frame");
+                        }
+                    }
+                }
+                Ok(Message::Binary(bytes)) => {
+                    match std::str::from_utf8(&bytes).ok().and_then(|text| {
+                        serde_json::from_str::<RxJsonRpcMessage<RoleClient>>(text).ok()
+                    }) {
+                        Some(message) => return Some(message),
+                        None => warn!("dropping invalid websocket MCP binary frame"),
+                    }
+                }
+                Ok(Message::Ping(_)) | Ok(Message::Pong(_)) | Ok(Message::Frame(_)) => {}
+                Ok(Message::Close(_)) => return None,
+                Err(err) => {
+                    warn!(?err, "websocket MCP stream closed with transport error");
+                    return None;
+                }
+            }
+        }
+
+        None
+    }
+
+    async fn close(&mut self) -> Result<(), Self::Error> {
+        let mut sink = self.sink.lock().await;
+        sink.send(Message::Close(None)).await?;
+        Ok(())
+    }
 }
 
 fn render_tool_result(result: &rmcp::model::CallToolResult) -> String {

--- a/crates/mcp/src/types.rs
+++ b/crates/mcp/src/types.rs
@@ -37,6 +37,8 @@ pub struct McpStdioServerConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct McpHttpServerConfig {
     pub url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bearer_token: Option<String>,
     #[serde(default)]
     pub headers: HashMap<String, String>,
 }
@@ -44,6 +46,8 @@ pub struct McpHttpServerConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct McpWebSocketServerConfig {
     pub url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bearer_token: Option<String>,
     #[serde(default)]
     pub headers: HashMap<String, String>,
 }
@@ -207,6 +211,7 @@ mod tests {
         assert_eq!(
             McpServerConfig::Http(McpHttpServerConfig {
                 url: "https://example.com".into(),
+                bearer_token: None,
                 headers: HashMap::new(),
             })
             .transport(),
@@ -215,6 +220,7 @@ mod tests {
         assert_eq!(
             McpServerConfig::Ws(McpWebSocketServerConfig {
                 url: "wss://example.com".into(),
+                bearer_token: None,
                 headers: HashMap::new(),
             })
             .transport(),

--- a/crates/mcp/tests/remote_transports.rs
+++ b/crates/mcp/tests/remote_transports.rs
@@ -1,0 +1,464 @@
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::{
+    body::Bytes,
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    response::IntoResponse,
+    routing::post,
+    Router,
+};
+use futures_util::{SinkExt, StreamExt};
+use lattice_mcp::{
+    McpClientManager, McpConnectionState, McpHttpServerConfig, McpServerConfig,
+    McpWebSocketServerConfig,
+};
+use serde_json::{json, Value};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::Notify;
+use tokio_tungstenite::{
+    accept_hdr_async,
+    tungstenite::{
+        handshake::server::{Request as WsRequest, Response as WsResponse},
+        Message,
+    },
+};
+
+#[derive(Clone, Default)]
+struct ManualMcpState {
+    expected_auth: Option<String>,
+    expected_custom_header: Option<(String, String)>,
+    initialize_seen: Arc<Notify>,
+}
+
+impl ManualMcpState {
+    fn expect_bearer_and_header(token: &str, name: &str, value: &str) -> Self {
+        Self {
+            expected_auth: Some(format!("Bearer {token}")),
+            expected_custom_header: Some((name.to_string(), value.to_string())),
+            initialize_seen: Arc::new(Notify::new()),
+        }
+    }
+
+    fn validate_headers(&self, headers: &HeaderMap) -> Result<(), String> {
+        if let Some(expected_auth) = &self.expected_auth {
+            let actual = headers
+                .get("authorization")
+                .and_then(|value| value.to_str().ok())
+                .ok_or_else(|| "missing authorization header".to_string())?;
+            if actual != expected_auth {
+                return Err(format!(
+                    "unexpected authorization header: expected '{expected_auth}', got '{actual}'"
+                ));
+            }
+        }
+
+        if let Some((name, expected_value)) = &self.expected_custom_header {
+            let actual = headers
+                .get(name)
+                .and_then(|value| value.to_str().ok())
+                .ok_or_else(|| format!("missing custom header '{name}'"))?;
+            if actual != expected_value {
+                return Err(format!(
+                    "unexpected custom header for '{name}': expected '{expected_value}', got '{actual}'"
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn initialize_result() -> Value {
+    json!({
+        "protocolVersion": "2025-03-26",
+        "capabilities": {
+            "tools": {},
+            "resources": {}
+        },
+        "serverInfo": {
+            "name": "fixture-remote",
+            "version": "1.0.0"
+        }
+    })
+}
+
+fn tools_result() -> Value {
+    json!({
+        "tools": [
+            {
+                "name": "hello",
+                "description": "fixture remote hello",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" }
+                    },
+                    "required": ["name"]
+                }
+            }
+        ]
+    })
+}
+
+fn resources_result() -> Value {
+    json!({
+        "resources": [
+            {
+                "uri": "fixture://readme",
+                "name": "Fixture Readme",
+                "description": "Fixture resource"
+            }
+        ]
+    })
+}
+
+fn response_for_body(body: &Value) -> Option<Value> {
+    let method = body.get("method")?.as_str()?;
+    let id = body.get("id").cloned();
+    match method {
+        "initialize" => Some(json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": initialize_result()
+        })),
+        "tools/list" => Some(json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": tools_result()
+        })),
+        "resources/list" => Some(json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": resources_result()
+        })),
+        _ => None,
+    }
+}
+
+async fn manual_http_mcp_handler(
+    State(state): State<ManualMcpState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> impl IntoResponse {
+    if let Err(err) = state.validate_headers(&headers) {
+        return (
+            StatusCode::UNAUTHORIZED,
+            [(axum::http::header::CONTENT_TYPE, "text/plain")],
+            err,
+        )
+            .into_response();
+    }
+
+    let Ok(body) = serde_json::from_slice::<Value>(&body) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            [(axum::http::header::CONTENT_TYPE, "text/plain")],
+            "invalid JSON body".to_string(),
+        )
+            .into_response();
+    };
+
+    match body.get("method").and_then(Value::as_str) {
+        Some("initialize") => {
+            state.initialize_seen.notify_one();
+            (
+                StatusCode::OK,
+                [
+                    (axum::http::header::CONTENT_TYPE, "application/json"),
+                    (
+                        axum::http::HeaderName::from_static("mcp-session-id"),
+                        "fixture-http-session",
+                    ),
+                ],
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": body.get("id"),
+                    "result": initialize_result()
+                })
+                .to_string(),
+            )
+                .into_response()
+        }
+        Some("notifications/initialized") => (
+            StatusCode::ACCEPTED,
+            [
+                (axum::http::header::CONTENT_TYPE, "application/json"),
+                (
+                    axum::http::HeaderName::from_static("mcp-session-id"),
+                    "fixture-http-session",
+                ),
+            ],
+            String::new(),
+        )
+            .into_response(),
+        Some("tools/list") | Some("resources/list") => (
+            StatusCode::OK,
+            [
+                (axum::http::header::CONTENT_TYPE, "application/json"),
+                (
+                    axum::http::HeaderName::from_static("mcp-session-id"),
+                    "fixture-http-session",
+                ),
+            ],
+            response_for_body(&body)
+                .expect("tool/resource response should exist")
+                .to_string(),
+        )
+            .into_response(),
+        Some(other) => (
+            StatusCode::BAD_REQUEST,
+            [(axum::http::header::CONTENT_TYPE, "text/plain")],
+            format!("unexpected MCP method: {other}"),
+        )
+            .into_response(),
+        None => (
+            StatusCode::BAD_REQUEST,
+            [(axum::http::header::CONTENT_TYPE, "text/plain")],
+            "missing MCP method".to_string(),
+        )
+            .into_response(),
+    }
+}
+
+async fn spawn_http_mcp_server(state: ManualMcpState) -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind local HTTP MCP listener");
+    let addr = listener.local_addr().expect("resolve bound local address");
+    let app = Router::new()
+        .route("/mcp", post(manual_http_mcp_handler))
+        .with_state(state);
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("serve HTTP MCP listener");
+    });
+    (addr, handle)
+}
+
+#[allow(clippy::result_large_err)]
+async fn run_manual_ws_mcp_connection(
+    stream: TcpStream,
+    state: ManualMcpState,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let state_for_callback = state.clone();
+    let callback = move |request: &WsRequest, response: WsResponse| {
+        let mut headers = HeaderMap::new();
+        for (name, value) in request.headers() {
+            headers.insert(name.clone(), value.clone());
+        }
+        state_for_callback
+            .validate_headers(&headers)
+            .map_err(|message| {
+                let mut error_response = http::Response::new(Some(message));
+                *error_response.status_mut() = StatusCode::UNAUTHORIZED;
+                error_response
+            })?;
+        Ok(response)
+    };
+
+    let mut websocket = accept_hdr_async(stream, callback)
+        .await
+        .map_err(|err| format!("accept websocket handshake: {err}"))?;
+
+    while let Some(message) = websocket.next().await {
+        let message = message?;
+        if !message.is_text() && !message.is_binary() {
+            continue;
+        }
+
+        let payload = if message.is_text() {
+            message.into_text()?.to_string()
+        } else {
+            String::from_utf8(message.into_data().to_vec())?
+        };
+        let body: Value = serde_json::from_str(&payload)?;
+
+        match body.get("method").and_then(Value::as_str) {
+            Some("initialize") => {
+                state.initialize_seen.notify_one();
+                websocket
+                    .send(Message::text(
+                        json!({
+                            "jsonrpc": "2.0",
+                            "id": body.get("id"),
+                            "result": initialize_result()
+                        })
+                        .to_string(),
+                    ))
+                    .await?;
+            }
+            Some("notifications/initialized") => {}
+            Some("tools/list") | Some("resources/list") => {
+                websocket
+                    .send(Message::text(
+                        response_for_body(&body)
+                            .expect("tool/resource response should exist")
+                            .to_string(),
+                    ))
+                    .await?;
+            }
+            Some(other) => {
+                websocket
+                    .send(Message::text(
+                        json!({
+                            "jsonrpc": "2.0",
+                            "id": body.get("id"),
+                            "error": {
+                                "code": -32601,
+                                "message": format!("unexpected MCP method: {other}")
+                            }
+                        })
+                        .to_string(),
+                    ))
+                    .await?;
+            }
+            None => break,
+        }
+    }
+
+    Ok(())
+}
+
+async fn spawn_ws_mcp_server(state: ManualMcpState) -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind local websocket MCP listener");
+    let addr = listener.local_addr().expect("resolve bound local address");
+    let handle = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.expect("accept websocket client");
+        run_manual_ws_mcp_connection(stream, state)
+            .await
+            .expect("serve websocket MCP session");
+    });
+    (addr, handle)
+}
+
+#[tokio::test]
+async fn http_remote_connects_and_discovers_capabilities() {
+    let state = ManualMcpState::expect_bearer_and_header("http-token", "x-lattice-test", "http");
+    let notified = state.initialize_seen.clone();
+    let (addr, server_handle) = spawn_http_mcp_server(state).await;
+
+    let mut headers = HashMap::new();
+    headers.insert("x-lattice-test".to_string(), "http".to_string());
+
+    let mut configs = HashMap::new();
+    configs.insert(
+        "http-remote".to_string(),
+        McpServerConfig::Http(McpHttpServerConfig {
+            url: format!("http://{addr}/mcp"),
+            bearer_token: Some("http-token".to_string()),
+            headers,
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+
+    tokio::time::timeout(std::time::Duration::from_secs(5), notified.notified())
+        .await
+        .expect("HTTP initialize request should arrive");
+
+    let statuses = manager.list_statuses();
+    assert_eq!(statuses.len(), 1);
+    assert_eq!(statuses[0].name, "http-remote");
+    assert_eq!(statuses[0].state, McpConnectionState::Connected);
+    assert_eq!(statuses[0].transport, "http");
+    assert_eq!(statuses[0].tools.len(), 1);
+    assert_eq!(statuses[0].tools[0].name, "hello");
+    assert_eq!(statuses[0].resources.len(), 1);
+    assert_eq!(statuses[0].resources[0].uri, "fixture://readme");
+
+    manager.close().await;
+    server_handle.abort();
+}
+
+#[tokio::test]
+async fn websocket_remote_connects_and_discovers_capabilities() {
+    let state = ManualMcpState::expect_bearer_and_header("ws-token", "x-lattice-test", "ws");
+    let notified = state.initialize_seen.clone();
+    let (addr, server_handle) = spawn_ws_mcp_server(state).await;
+
+    let mut headers = HashMap::new();
+    headers.insert("x-lattice-test".to_string(), "ws".to_string());
+
+    let mut configs = HashMap::new();
+    configs.insert(
+        "ws-remote".to_string(),
+        McpServerConfig::Ws(McpWebSocketServerConfig {
+            url: format!("ws://{addr}/mcp"),
+            bearer_token: Some("ws-token".to_string()),
+            headers,
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+
+    tokio::time::timeout(std::time::Duration::from_secs(5), notified.notified())
+        .await
+        .expect("websocket initialize request should arrive");
+
+    let statuses = manager.list_statuses();
+    assert_eq!(statuses.len(), 1);
+    assert_eq!(statuses[0].name, "ws-remote");
+    assert_eq!(statuses[0].state, McpConnectionState::Connected);
+    assert_eq!(statuses[0].transport, "ws");
+    assert_eq!(statuses[0].tools.len(), 1);
+    assert_eq!(statuses[0].tools[0].name, "hello");
+    assert_eq!(statuses[0].resources.len(), 1);
+    assert_eq!(statuses[0].resources[0].uri, "fixture://readme");
+
+    manager.close().await;
+    server_handle.abort();
+}
+
+#[tokio::test]
+async fn bearer_token_conflicts_with_explicit_authorization_header() {
+    let mut http_headers = HashMap::new();
+    http_headers.insert(
+        "Authorization".to_string(),
+        "Bearer explicit-http".to_string(),
+    );
+    let mut ws_headers = HashMap::new();
+    ws_headers.insert(
+        "authorization".to_string(),
+        "Bearer explicit-ws".to_string(),
+    );
+
+    let mut configs = HashMap::new();
+    configs.insert(
+        "http-remote".to_string(),
+        McpServerConfig::Http(McpHttpServerConfig {
+            url: "http://127.0.0.1:1/mcp".to_string(),
+            bearer_token: Some("http-token".to_string()),
+            headers: http_headers,
+        }),
+    );
+    configs.insert(
+        "ws-remote".to_string(),
+        McpServerConfig::Ws(McpWebSocketServerConfig {
+            url: "ws://127.0.0.1:1/mcp".to_string(),
+            bearer_token: Some("ws-token".to_string()),
+            headers: ws_headers,
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+
+    let statuses = manager.list_statuses();
+    assert_eq!(statuses.len(), 2);
+    assert_eq!(statuses[0].state, McpConnectionState::Failed);
+    assert!(statuses[0]
+        .detail
+        .contains("authorization header must not be set when bearer_token is configured"));
+    assert_eq!(statuses[1].state, McpConnectionState::Failed);
+    assert!(statuses[1]
+        .detail
+        .contains("authorization header must not be set when bearer_token is configured"));
+}

--- a/crates/mcp/tests/stdio_flow.rs
+++ b/crates/mcp/tests/stdio_flow.rs
@@ -78,6 +78,7 @@ async fn new_manager_starts_all_servers_pending() {
         "remote".to_string(),
         McpServerConfig::Http(McpHttpServerConfig {
             url: "https://example.com/mcp".to_string(),
+            bearer_token: None,
             headers: HashMap::new(),
         }),
     );
@@ -287,12 +288,13 @@ async fn reconnect_all_recovers_failed_stdio_session() {
 }
 
 #[tokio::test]
-async fn connect_all_marks_unsupported_http_and_ws_transports_failed() {
+async fn connect_all_marks_unreachable_http_and_ws_transports_failed() {
     let mut configs = HashMap::new();
     configs.insert(
         "http-remote".to_string(),
         McpServerConfig::Http(McpHttpServerConfig {
             url: "https://example.com/mcp".to_string(),
+            bearer_token: None,
             headers: HashMap::new(),
         }),
     );
@@ -300,6 +302,7 @@ async fn connect_all_marks_unsupported_http_and_ws_transports_failed() {
         "ws-remote".to_string(),
         McpServerConfig::Ws(McpWebSocketServerConfig {
             url: "wss://example.com/mcp".to_string(),
+            bearer_token: None,
             headers: HashMap::new(),
         }),
     );
@@ -312,14 +315,14 @@ async fn connect_all_marks_unsupported_http_and_ws_transports_failed() {
     assert_eq!(statuses[0].name, "http-remote");
     assert_eq!(statuses[0].state, McpConnectionState::Failed);
     assert_eq!(statuses[0].transport, "http");
-    assert!(statuses[0].detail.contains("unsupported MCP transport"));
+    assert!(!statuses[0].detail.is_empty());
     assert!(statuses[0].tools.is_empty());
     assert!(statuses[0].resources.is_empty());
 
     assert_eq!(statuses[1].name, "ws-remote");
     assert_eq!(statuses[1].state, McpConnectionState::Failed);
     assert_eq!(statuses[1].transport, "ws");
-    assert!(statuses[1].detail.contains("unsupported MCP transport"));
+    assert!(!statuses[1].detail.is_empty());
     assert!(statuses[1].tools.is_empty());
     assert!(statuses[1].resources.is_empty());
 }
@@ -340,6 +343,7 @@ async fn list_statuses_tools_and_resources_are_sorted_and_aggregated() {
         "a-http".to_string(),
         McpServerConfig::Http(McpHttpServerConfig {
             url: "https://example.com/mcp".to_string(),
+            bearer_token: None,
             headers: HashMap::new(),
         }),
     );
@@ -524,6 +528,7 @@ async fn manager_connection_snapshots_include_counts() {
         "http-remote".to_string(),
         McpServerConfig::Http(McpHttpServerConfig {
             url: "https://example.com/mcp".to_string(),
+            bearer_token: None,
             headers: HashMap::new(),
         }),
     );

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -628,6 +628,7 @@ mod tests {
             "http-remote".to_string(),
             lattice_mcp::McpServerConfig::Http(lattice_mcp::McpHttpServerConfig {
                 url: "https://example.com/mcp".to_string(),
+                bearer_token: None,
                 headers: std::collections::HashMap::new(),
             }),
         );


### PR DESCRIPTION
﻿## 说明

对应 issue `#90`，这次把 `lattice-mcp` 从“只有 `stdio` 可用”推进到真正支持远端 MCP transport。

本 PR 包含：

- 支持 `http` MCP transport
- 支持 `ws` MCP transport
- 支持 `bearer_token` 与自定义 `headers`
- `Authorization` 与 `bearer_token` 冲突时直接给出失败状态
- 保留不可达远端的失败状态建模
- README 补充 `stdio/http/ws` 配置示例与认证说明

## 实现要点

1. 在 `McpClientManager` 中新增：
   - `connect_http()`
   - `connect_ws()`
2. `http` 走 `rmcp` 的 `StreamableHttpClientTransport`
3. `ws` 增加一个轻量 websocket client transport 适配层
4. `McpHttpServerConfig` / `McpWebSocketServerConfig` 增加 `bearer_token`
5. 连接失败、认证配置错误仍然落到 `McpConnectionStatus::Failed`

## 测试

已本地通过：

- `cargo test -p lattice-mcp`
- `cargo clippy -p lattice-mcp --all-targets -- -D warnings`
- `cargo check --workspace`
- `cargo llvm-cov test -p lattice-mcp --lcov --output-path target\\llvmcov-mcp-remote.lcov`

新增覆盖包括：

- 本地 HTTP MCP server 连通与 discovery
- 本地 WebSocket MCP server 连通与 discovery
- `bearer_token` + 自定义 header 透传
- `bearer_token` 与手工 `Authorization` header 冲突
- 不可达远端 transport 的失败状态

参考了 OpenHarness 在 MCP client 分层与失败路径测试上的思路，但实现按 Lattice 当前 Rust 架构落地。
