### PR TITLE
feat: roll MCP client stack into main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,10 +136,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -210,6 +225,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +275,22 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -425,6 +475,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -838,7 +898,7 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "uuid",
 ]
 
@@ -849,10 +909,10 @@ dependencies = [
  "async-trait",
  "lattice-core",
  "lattice-llm-protocol",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -866,10 +926,10 @@ dependencies = [
  "dotenvy",
  "lattice-core",
  "lattice-llm-protocol",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -890,13 +950,19 @@ name = "lattice-mcp"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "axum",
+ "futures-util",
+ "http",
  "lattice-core",
  "lattice-tools",
+ "reqwest 0.12.28",
  "rmcp",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite",
+ "tokio-util",
  "tracing",
 ]
 
@@ -924,7 +990,7 @@ dependencies = [
  "lattice-core",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -969,7 +1035,7 @@ dependencies = [
  "lattice-core",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "uuid",
 ]
@@ -1224,6 +1290,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1270,6 +1345,36 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "real-agent"
@@ -1371,6 +1476,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,14 +1532,17 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures",
+ "http",
  "pastey",
  "pin-project-lite",
  "process-wrap",
+ "reqwest 0.13.3",
  "rmcp-macros",
  "schemars",
  "serde",
  "serde_json",
- "thiserror",
+ "sse-stream",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1626,6 +1768,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1670,6 +1823,19 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1757,11 +1923,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1851,6 +2037,18 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -1982,6 +2180,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2012,6 +2234,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2040,6 +2268,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -2149,6 +2383,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -2497,6 +2744,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,6 +945,7 @@ dependencies = [
  "lattice-llm-anthropic",
  "lattice-llm-openai",
  "lattice-llm-protocol",
+ "lattice-mcp",
  "lattice-runtime",
  "lattice-sandbox-local",
  "lattice-store-memory",
@@ -1276,6 +1277,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "lattice",
+ "lattice-mcp",
  "serde_json",
  "tokio",
  "tracing",

--- a/README.md
+++ b/README.md
@@ -212,7 +212,13 @@ http://127.0.0.1:3001
 LATTICE_MCP_CONFIG=/path/to/mcp.json
 ```
 
-配置文件格式直接复用 `mcpServers` JSON，至少支持 `stdio`：
+配置文件格式直接复用 `mcpServers` JSON。当前支持：
+
+- `stdio`
+- `http`
+- `ws`
+
+`stdio` 示例：
 
 ```json
 {
@@ -225,6 +231,37 @@ LATTICE_MCP_CONFIG=/path/to/mcp.json
   }
 }
 ```
+
+远端 MCP 示例，支持 `bearer_token` 和自定义 headers：
+
+```json
+{
+  "mcpServers": {
+    "remote-http": {
+      "type": "http",
+      "url": "https://mcp.example.com/mcp",
+      "bearer_token": "your_token",
+      "headers": {
+        "x-client-id": "lattice"
+      }
+    },
+    "remote-ws": {
+      "type": "ws",
+      "url": "wss://mcp.example.com/mcp",
+      "bearer_token": "your_token",
+      "headers": {
+        "x-client-id": "lattice"
+      }
+    }
+  }
+}
+```
+
+配置约束：
+
+- `bearer_token` 会自动写入 `Authorization: Bearer ...`
+- 如果已经配置 `bearer_token`，就不要再在 `headers` 里手动填写 `Authorization`
+- 远端 `http/ws` 连接失败时只影响对应 server，不会阻塞其他 MCP server 启动
 
 `real-agent` 示例：
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,58 @@ http://127.0.0.1:3001
 - `Provider` 留空（使用服务端默认值）
 - `模型` 留空，或显式填写 `Pro/MiniMaxAI/MiniMax-M2.5`
 
+### MCP 配置接入
+
+`real-agent` 和 `lattice-server` 现在都支持在启动时加载 MCP 配置，并把 MCP tools 注入 `ToolSet`。
+
+当前入口是环境变量：
+
+```text
+LATTICE_MCP_CONFIG=/path/to/mcp.json
+```
+
+配置文件格式直接复用 `mcpServers` JSON，至少支持 `stdio`：
+
+```json
+{
+  "mcpServers": {
+    "fixture": {
+      "type": "stdio",
+      "command": "python",
+      "args": ["./path/to/server.py"]
+    }
+  }
+}
+```
+
+`real-agent` 示例：
+
+```powershell
+$env:LATTICE_LLM_PROVIDER="openai"
+$env:LATTICE_API_KEY="your_key"
+$env:LATTICE_MODEL="gpt-4o"
+$env:LATTICE_MCP_CONFIG="D:\\path\\to\\mcp.json"
+
+cargo run -p real-agent -- "Use the MCP tools to inspect available resources"
+```
+
+`lattice-server` 示例：
+
+```powershell
+$env:LATTICE_LLM_PROVIDER="openai"
+$env:LATTICE_API_KEY="your_key"
+$env:LATTICE_MODEL="gpt-4o"
+$env:LATTICE_MCP_CONFIG="D:\\path\\to\\mcp.json"
+
+cargo run -p lattice-server
+```
+
+行为说明：
+
+- 如果未设置 `LATTICE_MCP_CONFIG`，系统按无 MCP 配置启动
+- 如果某个 MCP server 连接失败，其余 server 仍继续工作
+- `GET /health` 会返回 `mcp_servers` 快照，包含 `state / transport / tool_count / resource_count`
+
 ## LLM Provider 支持
 
 | Provider         | 包                      | 状态 |

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -14,8 +14,8 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 rmcp = { workspace = true }
 lattice-core = { path = "../core" }
+lattice-tools = { path = "../tools" }
 async-trait = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
-lattice-tools = { path = "../tools" }

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -12,10 +12,16 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-rmcp = { workspace = true }
+rmcp = { workspace = true, features = ["transport-streamable-http-client-reqwest"] }
 lattice-core = { path = "../core" }
 lattice-tools = { path = "../tools" }
 async-trait = { workspace = true }
+http = "1"
+futures-util = "0.3"
+tokio-tungstenite = "0.24"
 
 [dev-dependencies]
 tokio = { workspace = true }
+axum = { workspace = true }
+reqwest = { workspace = true }
+tokio-util = "0.7"

--- a/crates/mcp/src/integration.rs
+++ b/crates/mcp/src/integration.rs
@@ -1,0 +1,56 @@
+use std::collections::HashMap;
+use std::env;
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+
+use lattice_core::ToolError;
+use lattice_tools::ToolSet;
+
+use crate::{
+    ListMcpResourcesTool, McpClientManager, McpJsonConfig, McpServerConfig, McpToolAdapter,
+    ReadMcpResourceTool,
+};
+
+pub const LATTICE_MCP_CONFIG_ENV: &str = "LATTICE_MCP_CONFIG";
+
+pub fn load_mcp_server_configs_from_path(
+    path: impl AsRef<Path>,
+) -> Result<HashMap<String, McpServerConfig>, String> {
+    let path = path.as_ref();
+    let content = fs::read_to_string(path)
+        .map_err(|err| format!("failed to read MCP config '{}': {err}", path.display()))?;
+    let parsed: McpJsonConfig = serde_json::from_str(&content)
+        .map_err(|err| format!("failed to parse MCP config '{}': {err}", path.display()))?;
+    Ok(parsed.mcp_servers)
+}
+
+pub fn load_mcp_server_configs_from_env() -> Result<HashMap<String, McpServerConfig>, String> {
+    let Some(path) = env::var_os(LATTICE_MCP_CONFIG_ENV) else {
+        return Ok(HashMap::new());
+    };
+    load_mcp_server_configs_from_path(path)
+}
+
+pub async fn load_mcp_manager_from_env() -> Result<Option<Arc<McpClientManager>>, String> {
+    let configs = load_mcp_server_configs_from_env()?;
+    if configs.is_empty() {
+        return Ok(None);
+    }
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+    Ok(Some(Arc::new(manager)))
+}
+
+pub fn register_mcp_tools(
+    toolset: &mut ToolSet,
+    manager: Arc<McpClientManager>,
+) -> Result<(), ToolError> {
+    toolset.register(ListMcpResourcesTool::new(manager.clone()))?;
+    toolset.register(ReadMcpResourceTool::new(manager.clone()))?;
+    for tool in McpToolAdapter::from_manager(manager) {
+        toolset.register(tool)?;
+    }
+    Ok(())
+}

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -5,12 +5,15 @@
 //! multi-server client manager.
 
 mod manager;
+mod resource_tools;
 mod tool_adapter;
 mod types;
 
 pub use manager::{McpClientManager, McpToolCallOutput};
+pub use resource_tools::{ListMcpResourcesTool, ReadMcpResourceTool};
 pub use tool_adapter::{mcp_tool_name, McpToolAdapter};
 pub use types::{
-    McpConnectionState, McpConnectionStatus, McpHttpServerConfig, McpJsonConfig, McpResourceInfo,
-    McpServerConfig, McpStdioServerConfig, McpToolInfo, McpWebSocketServerConfig,
+    McpConnectionSnapshot, McpConnectionState, McpConnectionStatus, McpHttpServerConfig,
+    McpJsonConfig, McpResourceInfo, McpServerConfig, McpStdioServerConfig, McpToolInfo,
+    McpWebSocketServerConfig,
 };

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -4,11 +4,16 @@
 //! configuration types, connection status models, and a stdio-backed
 //! multi-server client manager.
 
+mod integration;
 mod manager;
 mod resource_tools;
 mod tool_adapter;
 mod types;
 
+pub use integration::{
+    load_mcp_manager_from_env, load_mcp_server_configs_from_env, load_mcp_server_configs_from_path,
+    register_mcp_tools, LATTICE_MCP_CONFIG_ENV,
+};
 pub use manager::{McpClientManager, McpToolCallOutput};
 pub use resource_tools::{ListMcpResourcesTool, ReadMcpResourceTool};
 pub use tool_adapter::{mcp_tool_name, McpToolAdapter};

--- a/crates/mcp/src/manager.rs
+++ b/crates/mcp/src/manager.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use rmcp::{
-    model::{CallToolRequestParams, ErrorCode, Tool},
+    model::{CallToolRequestParams, ErrorCode, ReadResourceRequestParams, ResourceContents, Tool},
     service::{RoleClient, RunningService, ServiceError},
     transport::TokioChildProcess,
     ServiceExt,
@@ -11,7 +11,8 @@ use tokio::process::Command;
 use tracing::warn;
 
 use crate::types::{
-    McpConnectionStatus, McpResourceInfo, McpServerConfig, McpStdioServerConfig, McpToolInfo,
+    McpConnectionSnapshot, McpConnectionStatus, McpResourceInfo, McpServerConfig,
+    McpStdioServerConfig, McpToolInfo,
 };
 use lattice_core::ToolError;
 
@@ -70,15 +71,21 @@ impl McpClientManager {
             .collect()
     }
 
+    #[must_use]
+    pub fn list_status_snapshots(&self) -> Vec<McpConnectionSnapshot> {
+        self.list_statuses()
+            .into_iter()
+            .map(|status| status.snapshot())
+            .collect()
+    }
+
     pub async fn call_tool(
         &self,
         server_name: &str,
         tool_name: &str,
         arguments: Value,
     ) -> Result<McpToolCallOutput, ToolError> {
-        let session = self.sessions.get(server_name).ok_or_else(|| {
-            ToolError::NotFound(format!("MCP server not connected: {server_name}"))
-        })?;
+        let session = self.require_session(server_name)?;
 
         let request = match arguments {
             Value::Null => CallToolRequestParams::new(tool_name.to_string()),
@@ -108,6 +115,16 @@ impl McpClientManager {
             output,
             structured_content: result.structured_content,
         })
+    }
+
+    pub async fn read_resource(&self, server_name: &str, uri: &str) -> Result<String, ToolError> {
+        let session = self.require_session(server_name)?;
+        let result = session
+            .read_resource(ReadResourceRequestParams::new(uri))
+            .await
+            .map_err(|err| map_read_resource_error(server_name, uri, &err))?;
+
+        Ok(render_read_resource_result(&result))
     }
 
     pub async fn connect_all(&mut self) {
@@ -248,6 +265,23 @@ impl McpClientManager {
         );
         self.sessions.insert(name.to_string(), client);
     }
+
+    fn require_session(
+        &self,
+        server_name: &str,
+    ) -> Result<&RunningService<RoleClient, ()>, ToolError> {
+        self.sessions.get(server_name).ok_or_else(|| {
+            let detail = self
+                .statuses
+                .get(server_name)
+                .map(|status| status.detail.as_str())
+                .filter(|detail| !detail.is_empty())
+                .unwrap_or("server is not connected");
+            ToolError::NotFound(format!(
+                "MCP server '{server_name}' is not connected: {detail}"
+            ))
+        })
+    }
 }
 
 fn to_tool_info(server_name: &str, tool: Tool) -> McpToolInfo {
@@ -279,6 +313,47 @@ fn render_tool_result(result: &rmcp::model::CallToolResult) -> String {
     }
 
     String::new()
+}
+
+fn render_read_resource_result(result: &rmcp::model::ReadResourceResult) -> String {
+    result
+        .contents
+        .iter()
+        .map(render_resource_contents)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn render_resource_contents(content: &ResourceContents) -> String {
+    match content {
+        ResourceContents::TextResourceContents { text, .. } => text.clone(),
+        ResourceContents::BlobResourceContents { blob, .. } => blob.clone(),
+    }
+}
+
+fn map_read_resource_error(server_name: &str, uri: &str, err: &ServiceError) -> ToolError {
+    match err {
+        ServiceError::McpError(error) if error.code == ErrorCode::RESOURCE_NOT_FOUND => {
+            ToolError::NotFound(format!(
+                "MCP resource not found on server '{server_name}': {uri}"
+            ))
+        }
+        ServiceError::McpError(error) if error.code == ErrorCode::INVALID_PARAMS => {
+            ToolError::InvalidParams(format!(
+                "MCP resource read rejected by server '{server_name}' for '{uri}': {}",
+                error.message
+            ))
+        }
+        ServiceError::McpError(error) if error.code == ErrorCode::METHOD_NOT_FOUND => {
+            ToolError::ExecutionFailed(format!(
+                "MCP server '{server_name}' does not support resource reads: {}",
+                error.message
+            ))
+        }
+        _ => ToolError::ExecutionFailed(format!(
+            "MCP resource read failed on server '{server_name}' for '{uri}': {err}"
+        )),
+    }
 }
 
 fn json_type_name(value: &Value) -> &'static str {

--- a/crates/mcp/src/manager.rs
+++ b/crates/mcp/src/manager.rs
@@ -1,25 +1,52 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, future::Future, sync::Arc};
 
+use futures_util::{SinkExt, StreamExt};
+use http::{HeaderName, HeaderValue};
+use lattice_core::ToolError;
 use rmcp::{
     model::{CallToolRequestParams, ErrorCode, ReadResourceRequestParams, ResourceContents, Tool},
-    service::{RoleClient, RunningService, ServiceError},
-    transport::TokioChildProcess,
+    service::{RoleClient, RunningService, RxJsonRpcMessage, ServiceError, TxJsonRpcMessage},
+    transport::{
+        streamable_http_client::StreamableHttpClientTransportConfig, StreamableHttpClientTransport,
+        TokioChildProcess, Transport,
+    },
     ServiceExt,
 };
 use serde_json::Value;
+use tokio::net::TcpStream;
 use tokio::process::Command;
+use tokio::sync::Mutex;
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{self, client::IntoClientRequest, Message},
+    MaybeTlsStream, WebSocketStream,
+};
 use tracing::warn;
 
 use crate::types::{
-    McpConnectionSnapshot, McpConnectionStatus, McpResourceInfo, McpServerConfig,
-    McpStdioServerConfig, McpToolInfo,
+    McpConnectionSnapshot, McpConnectionStatus, McpHttpServerConfig, McpResourceInfo,
+    McpServerConfig, McpStdioServerConfig, McpToolInfo, McpWebSocketServerConfig,
 };
-use lattice_core::ToolError;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct McpToolCallOutput {
     pub output: String,
     pub structured_content: Option<Value>,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum WebSocketTransportError {
+    #[error("websocket error: {0}")]
+    WebSocket(#[from] tungstenite::Error),
+    #[error("json serialization error: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+struct WsClientTransport {
+    sink: Arc<
+        Mutex<futures_util::stream::SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>>,
+    >,
+    stream: futures_util::stream::SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>,
 }
 
 pub struct McpClientManager {
@@ -172,19 +199,8 @@ impl McpClientManager {
 
         match config {
             McpServerConfig::Stdio(stdio) => self.connect_stdio(name, stdio).await,
-            unsupported => {
-                self.statuses.insert(
-                    name.to_string(),
-                    McpConnectionStatus::failed(
-                        name.to_string(),
-                        unsupported.transport(),
-                        format!(
-                            "unsupported MCP transport in current build: {}",
-                            unsupported.transport()
-                        ),
-                    ),
-                );
-            }
+            McpServerConfig::Http(http) => self.connect_http(name, http).await,
+            McpServerConfig::Ws(ws) => self.connect_ws(name, ws).await,
         }
     }
 
@@ -201,10 +217,7 @@ impl McpClientManager {
         let transport = match TokioChildProcess::new(command) {
             Ok(transport) => transport,
             Err(err) => {
-                self.statuses.insert(
-                    name.to_string(),
-                    McpConnectionStatus::failed(name.to_string(), "stdio", err.to_string()),
-                );
+                self.record_failed_status(name, "stdio", err.to_string());
                 return;
             }
         };
@@ -212,21 +225,87 @@ impl McpClientManager {
         let client = match ().serve(transport).await {
             Ok(client) => client,
             Err(err) => {
-                self.statuses.insert(
-                    name.to_string(),
-                    McpConnectionStatus::failed(name.to_string(), "stdio", err.to_string()),
-                );
+                self.record_failed_status(name, "stdio", err.to_string());
                 return;
             }
         };
 
+        self.store_connected_client(name, "stdio", client).await;
+    }
+
+    async fn connect_http(&mut self, name: &str, config: McpHttpServerConfig) {
+        let headers = match parse_custom_headers(&config.headers, config.bearer_token.as_deref()) {
+            Ok(headers) => headers,
+            Err(err) => {
+                self.record_failed_status(name, "http", err);
+                return;
+            }
+        };
+
+        let mut transport_config = StreamableHttpClientTransportConfig::with_uri(config.url);
+        if let Some(token) = config.bearer_token {
+            transport_config = transport_config.auth_header(token);
+        }
+        transport_config = transport_config.custom_headers(headers);
+
+        let transport = StreamableHttpClientTransport::from_config(transport_config);
+        let client = match ().serve(transport).await {
+            Ok(client) => client,
+            Err(err) => {
+                self.record_failed_status(name, "http", err.to_string());
+                return;
+            }
+        };
+
+        self.store_connected_client(name, "http", client).await;
+    }
+
+    async fn connect_ws(&mut self, name: &str, config: McpWebSocketServerConfig) {
+        let headers = match parse_custom_headers(&config.headers, config.bearer_token.as_deref()) {
+            Ok(headers) => headers,
+            Err(err) => {
+                self.record_failed_status(name, "ws", err);
+                return;
+            }
+        };
+
+        let request = match build_websocket_request(&config.url, headers, config.bearer_token) {
+            Ok(request) => request,
+            Err(err) => {
+                self.record_failed_status(name, "ws", err);
+                return;
+            }
+        };
+
+        let stream = match connect_async(request).await {
+            Ok((stream, _)) => stream,
+            Err(err) => {
+                self.record_failed_status(name, "ws", err.to_string());
+                return;
+            }
+        };
+
+        let client = match connect_ws_client(stream).await {
+            Ok(client) => client,
+            Err(err) => {
+                self.record_failed_status(name, "ws", err.to_string());
+                return;
+            }
+        };
+
+        self.store_connected_client(name, "ws", client).await;
+    }
+
+    async fn store_connected_client(
+        &mut self,
+        name: &str,
+        transport: &str,
+        client: RunningService<RoleClient, ()>,
+    ) {
         let tools = match client.list_all_tools().await {
             Ok(tools) => tools,
             Err(err) => {
-                self.statuses.insert(
-                    name.to_string(),
-                    McpConnectionStatus::failed(name.to_string(), "stdio", err.to_string()),
-                );
+                self.record_failed_status(name, transport, err.to_string());
                 return;
             }
         };
@@ -235,10 +314,7 @@ impl McpClientManager {
             Ok(resources) => resources,
             Err(err) if is_method_not_found(&err) => Vec::new(),
             Err(err) => {
-                self.statuses.insert(
-                    name.to_string(),
-                    McpConnectionStatus::failed(name.to_string(), "stdio", err.to_string()),
-                );
+                self.record_failed_status(name, transport, err.to_string());
                 return;
             }
         };
@@ -247,7 +323,7 @@ impl McpClientManager {
             name.to_string(),
             McpConnectionStatus::connected(
                 name.to_string(),
-                "stdio",
+                transport,
                 tools
                     .into_iter()
                     .map(|tool| to_tool_info(name, tool))
@@ -264,6 +340,13 @@ impl McpClientManager {
             ),
         );
         self.sessions.insert(name.to_string(), client);
+    }
+
+    fn record_failed_status(&mut self, name: &str, transport: &str, detail: impl Into<String>) {
+        self.statuses.insert(
+            name.to_string(),
+            McpConnectionStatus::failed(name.to_string(), transport, detail),
+        );
     }
 
     fn require_session(
@@ -295,6 +378,120 @@ fn to_tool_info(server_name: &str, tool: Tool) -> McpToolInfo {
 
 fn is_method_not_found(err: &ServiceError) -> bool {
     matches!(err, ServiceError::McpError(error) if error.code == ErrorCode::METHOD_NOT_FOUND)
+}
+
+fn parse_custom_headers(
+    raw_headers: &HashMap<String, String>,
+    bearer_token: Option<&str>,
+) -> Result<HashMap<HeaderName, HeaderValue>, String> {
+    if bearer_token.is_some()
+        && raw_headers
+            .keys()
+            .any(|name| name.eq_ignore_ascii_case("authorization"))
+    {
+        return Err(
+            "authorization header must not be set when bearer_token is configured".to_string(),
+        );
+    }
+
+    let mut headers = HashMap::with_capacity(raw_headers.len());
+    for (name, value) in raw_headers {
+        let header_name = HeaderName::from_bytes(name.as_bytes())
+            .map_err(|err| format!("invalid MCP header name '{name}': {err}"))?;
+        let header_value = HeaderValue::from_str(value)
+            .map_err(|err| format!("invalid MCP header value for '{name}': {err}"))?;
+        headers.insert(header_name, header_value);
+    }
+    Ok(headers)
+}
+
+fn build_websocket_request(
+    url: &str,
+    headers: HashMap<HeaderName, HeaderValue>,
+    bearer_token: Option<String>,
+) -> Result<http::Request<()>, String> {
+    let mut request = url
+        .into_client_request()
+        .map_err(|err| format!("invalid websocket request for '{url}': {err}"))?;
+
+    for (name, value) in headers {
+        request.headers_mut().insert(name, value);
+    }
+
+    if let Some(token) = bearer_token {
+        let value = HeaderValue::from_str(&format!("Bearer {token}"))
+            .map_err(|err| format!("invalid websocket bearer token: {err}"))?;
+        request
+            .headers_mut()
+            .insert(HeaderName::from_static("authorization"), value);
+    }
+
+    Ok(request)
+}
+
+async fn connect_ws_client(
+    stream: WebSocketStream<MaybeTlsStream<TcpStream>>,
+) -> Result<RunningService<RoleClient, ()>, rmcp::service::ClientInitializeError> {
+    let (sink, stream) = stream.split();
+    let transport = WsClientTransport {
+        sink: Arc::new(Mutex::new(sink)),
+        stream,
+    };
+    ().serve(transport).await
+}
+
+impl Transport<RoleClient> for WsClientTransport {
+    type Error = WebSocketTransportError;
+
+    fn send(
+        &mut self,
+        item: TxJsonRpcMessage<RoleClient>,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'static {
+        let sink = Arc::clone(&self.sink);
+        async move {
+            let payload = serde_json::to_string(&item)?;
+            let mut sink = sink.lock().await;
+            sink.send(Message::Text(payload)).await?;
+            Ok(())
+        }
+    }
+
+    async fn receive(&mut self) -> Option<RxJsonRpcMessage<RoleClient>> {
+        while let Some(message) = self.stream.next().await {
+            match message {
+                Ok(Message::Text(text)) => {
+                    match serde_json::from_str::<RxJsonRpcMessage<RoleClient>>(&text) {
+                        Ok(message) => return Some(message),
+                        Err(err) => {
+                            warn!(?err, "dropping invalid websocket MCP text frame");
+                        }
+                    }
+                }
+                Ok(Message::Binary(bytes)) => {
+                    match std::str::from_utf8(&bytes).ok().and_then(|text| {
+                        serde_json::from_str::<RxJsonRpcMessage<RoleClient>>(text).ok()
+                    }) {
+                        Some(message) => return Some(message),
+                        None => warn!("dropping invalid websocket MCP binary frame"),
+                    }
+                }
+                Ok(Message::Ping(_)) | Ok(Message::Pong(_)) | Ok(Message::Frame(_)) => {}
+                Ok(Message::Close(_)) => return None,
+                Err(err) => {
+                    warn!(?err, "websocket MCP stream closed with transport error");
+                    return None;
+                }
+            }
+        }
+
+        None
+    }
+
+    async fn close(&mut self) -> Result<(), Self::Error> {
+        let mut sink = self.sink.lock().await;
+        sink.send(Message::Close(None)).await?;
+        Ok(())
+    }
 }
 
 fn render_tool_result(result: &rmcp::model::CallToolResult) -> String {

--- a/crates/mcp/src/resource_tools.rs
+++ b/crates/mcp/src/resource_tools.rs
@@ -1,0 +1,143 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use lattice_core::{ExecutionResult, ToolDescription, ToolError, ToolExecutor};
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::McpClientManager;
+
+pub struct ListMcpResourcesTool {
+    manager: Arc<McpClientManager>,
+}
+
+impl ListMcpResourcesTool {
+    #[must_use]
+    pub fn new(manager: Arc<McpClientManager>) -> Self {
+        Self { manager }
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for ListMcpResourcesTool {
+    fn description(&self) -> ToolDescription {
+        ToolDescription {
+            name: "list_mcp_resources".to_string(),
+            description: "List MCP resources available from connected servers.".to_string(),
+            parameters_schema: serde_json::json!({
+                "type": "object",
+                "properties": {},
+                "required": []
+            }),
+        }
+    }
+
+    async fn execute(&self, params: Value) -> Result<ExecutionResult, ToolError> {
+        validate_noop_params(params)?;
+
+        let resources = self.manager.list_resources();
+        let stdout = if resources.is_empty() {
+            "(no MCP resources)".to_string()
+        } else {
+            resources
+                .into_iter()
+                .map(|item| {
+                    let mut line = format!("{} {}", item.server_name, item.uri);
+                    if !item.name.is_empty() {
+                        line.push_str(&format!(" | {}", item.name));
+                    }
+                    if !item.description.is_empty() {
+                        line.push_str(&format!(" | {}", item.description));
+                    }
+                    line
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+
+        Ok(ExecutionResult {
+            stdout,
+            stderr: String::new(),
+            exit_code: 0,
+        })
+    }
+}
+
+pub struct ReadMcpResourceTool {
+    manager: Arc<McpClientManager>,
+}
+
+impl ReadMcpResourceTool {
+    #[must_use]
+    pub fn new(manager: Arc<McpClientManager>) -> Self {
+        Self { manager }
+    }
+}
+
+#[derive(Deserialize)]
+struct ReadMcpResourceParams {
+    server: String,
+    uri: String,
+}
+
+#[async_trait]
+impl ToolExecutor for ReadMcpResourceTool {
+    fn description(&self) -> ToolDescription {
+        ToolDescription {
+            name: "read_mcp_resource".to_string(),
+            description: "Read an MCP resource by server and URI.".to_string(),
+            parameters_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "server": {
+                        "type": "string",
+                        "description": "MCP server name"
+                    },
+                    "uri": {
+                        "type": "string",
+                        "description": "Resource URI"
+                    }
+                },
+                "required": ["server", "uri"]
+            }),
+        }
+    }
+
+    async fn execute(&self, params: Value) -> Result<ExecutionResult, ToolError> {
+        let parsed: ReadMcpResourceParams = serde_json::from_value(params).map_err(|err| {
+            ToolError::InvalidParams(format!("invalid read_mcp_resource arguments: {err}"))
+        })?;
+
+        let stdout = self
+            .manager
+            .read_resource(&parsed.server, &parsed.uri)
+            .await?;
+
+        Ok(ExecutionResult {
+            stdout,
+            stderr: String::new(),
+            exit_code: 0,
+        })
+    }
+}
+
+fn validate_noop_params(params: Value) -> Result<(), ToolError> {
+    match params {
+        Value::Null | Value::Object(_) => Ok(()),
+        other => Err(ToolError::InvalidParams(format!(
+            "expected object parameters, got {}",
+            json_type_name(&other)
+        ))),
+    }
+}
+
+fn json_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}

--- a/crates/mcp/src/types.rs
+++ b/crates/mcp/src/types.rs
@@ -37,6 +37,8 @@ pub struct McpStdioServerConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct McpHttpServerConfig {
     pub url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bearer_token: Option<String>,
     #[serde(default)]
     pub headers: HashMap<String, String>,
 }
@@ -44,6 +46,8 @@ pub struct McpHttpServerConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct McpWebSocketServerConfig {
     pub url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bearer_token: Option<String>,
     #[serde(default)]
     pub headers: HashMap<String, String>,
 }
@@ -207,6 +211,7 @@ mod tests {
         assert_eq!(
             McpServerConfig::Http(McpHttpServerConfig {
                 url: "https://example.com".into(),
+                bearer_token: None,
                 headers: HashMap::new(),
             })
             .transport(),
@@ -215,6 +220,7 @@ mod tests {
         assert_eq!(
             McpServerConfig::Ws(McpWebSocketServerConfig {
                 url: "wss://example.com".into(),
+                bearer_token: None,
                 headers: HashMap::new(),
             })
             .transport(),

--- a/crates/mcp/src/types.rs
+++ b/crates/mcp/src/types.rs
@@ -88,6 +88,16 @@ pub struct McpConnectionStatus {
     pub resources: Vec<McpResourceInfo>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct McpConnectionSnapshot {
+    pub name: String,
+    pub state: McpConnectionState,
+    pub detail: String,
+    pub transport: String,
+    pub tool_count: usize,
+    pub resource_count: usize,
+}
+
 impl McpConnectionStatus {
     #[must_use]
     pub fn pending(name: impl Into<String>, transport: impl Into<String>) -> Self {
@@ -131,6 +141,18 @@ impl McpConnectionStatus {
             transport: transport.into(),
             tools: Vec::new(),
             resources: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn snapshot(&self) -> McpConnectionSnapshot {
+        McpConnectionSnapshot {
+            name: self.name.clone(),
+            state: self.state.clone(),
+            detail: self.detail.clone(),
+            transport: self.transport.clone(),
+            tool_count: self.tools.len(),
+            resource_count: self.resources.len(),
         }
     }
 }
@@ -243,5 +265,32 @@ mod tests {
         assert_eq!(failed.transport, "stdio");
         assert!(failed.tools.is_empty());
         assert!(failed.resources.is_empty());
+    }
+
+    #[test]
+    fn connection_status_snapshot_reports_counts() {
+        let status = McpConnectionStatus::connected(
+            "fixture",
+            "stdio",
+            vec![McpToolInfo {
+                server_name: "fixture".into(),
+                name: "hello".into(),
+                description: String::new(),
+                input_schema: Map::new(),
+            }],
+            vec![McpResourceInfo {
+                server_name: "fixture".into(),
+                name: "Fixture Readme".into(),
+                uri: "fixture://readme".into(),
+                description: String::new(),
+            }],
+        );
+
+        let snapshot = status.snapshot();
+        assert_eq!(snapshot.name, "fixture");
+        assert_eq!(snapshot.state, McpConnectionState::Connected);
+        assert_eq!(snapshot.transport, "stdio");
+        assert_eq!(snapshot.tool_count, 1);
+        assert_eq!(snapshot.resource_count, 1);
     }
 }

--- a/crates/mcp/tests/remote_transports.rs
+++ b/crates/mcp/tests/remote_transports.rs
@@ -1,0 +1,464 @@
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::{
+    body::Bytes,
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    response::IntoResponse,
+    routing::post,
+    Router,
+};
+use futures_util::{SinkExt, StreamExt};
+use lattice_mcp::{
+    McpClientManager, McpConnectionState, McpHttpServerConfig, McpServerConfig,
+    McpWebSocketServerConfig,
+};
+use serde_json::{json, Value};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::Notify;
+use tokio_tungstenite::{
+    accept_hdr_async,
+    tungstenite::{
+        handshake::server::{Request as WsRequest, Response as WsResponse},
+        Message,
+    },
+};
+
+#[derive(Clone, Default)]
+struct ManualMcpState {
+    expected_auth: Option<String>,
+    expected_custom_header: Option<(String, String)>,
+    initialize_seen: Arc<Notify>,
+}
+
+impl ManualMcpState {
+    fn expect_bearer_and_header(token: &str, name: &str, value: &str) -> Self {
+        Self {
+            expected_auth: Some(format!("Bearer {token}")),
+            expected_custom_header: Some((name.to_string(), value.to_string())),
+            initialize_seen: Arc::new(Notify::new()),
+        }
+    }
+
+    fn validate_headers(&self, headers: &HeaderMap) -> Result<(), String> {
+        if let Some(expected_auth) = &self.expected_auth {
+            let actual = headers
+                .get("authorization")
+                .and_then(|value| value.to_str().ok())
+                .ok_or_else(|| "missing authorization header".to_string())?;
+            if actual != expected_auth {
+                return Err(format!(
+                    "unexpected authorization header: expected '{expected_auth}', got '{actual}'"
+                ));
+            }
+        }
+
+        if let Some((name, expected_value)) = &self.expected_custom_header {
+            let actual = headers
+                .get(name)
+                .and_then(|value| value.to_str().ok())
+                .ok_or_else(|| format!("missing custom header '{name}'"))?;
+            if actual != expected_value {
+                return Err(format!(
+                    "unexpected custom header for '{name}': expected '{expected_value}', got '{actual}'"
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn initialize_result() -> Value {
+    json!({
+        "protocolVersion": "2025-03-26",
+        "capabilities": {
+            "tools": {},
+            "resources": {}
+        },
+        "serverInfo": {
+            "name": "fixture-remote",
+            "version": "1.0.0"
+        }
+    })
+}
+
+fn tools_result() -> Value {
+    json!({
+        "tools": [
+            {
+                "name": "hello",
+                "description": "fixture remote hello",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" }
+                    },
+                    "required": ["name"]
+                }
+            }
+        ]
+    })
+}
+
+fn resources_result() -> Value {
+    json!({
+        "resources": [
+            {
+                "uri": "fixture://readme",
+                "name": "Fixture Readme",
+                "description": "Fixture resource"
+            }
+        ]
+    })
+}
+
+fn response_for_body(body: &Value) -> Option<Value> {
+    let method = body.get("method")?.as_str()?;
+    let id = body.get("id").cloned();
+    match method {
+        "initialize" => Some(json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": initialize_result()
+        })),
+        "tools/list" => Some(json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": tools_result()
+        })),
+        "resources/list" => Some(json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": resources_result()
+        })),
+        _ => None,
+    }
+}
+
+async fn manual_http_mcp_handler(
+    State(state): State<ManualMcpState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> impl IntoResponse {
+    if let Err(err) = state.validate_headers(&headers) {
+        return (
+            StatusCode::UNAUTHORIZED,
+            [(axum::http::header::CONTENT_TYPE, "text/plain")],
+            err,
+        )
+            .into_response();
+    }
+
+    let Ok(body) = serde_json::from_slice::<Value>(&body) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            [(axum::http::header::CONTENT_TYPE, "text/plain")],
+            "invalid JSON body".to_string(),
+        )
+            .into_response();
+    };
+
+    match body.get("method").and_then(Value::as_str) {
+        Some("initialize") => {
+            state.initialize_seen.notify_one();
+            (
+                StatusCode::OK,
+                [
+                    (axum::http::header::CONTENT_TYPE, "application/json"),
+                    (
+                        axum::http::HeaderName::from_static("mcp-session-id"),
+                        "fixture-http-session",
+                    ),
+                ],
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": body.get("id"),
+                    "result": initialize_result()
+                })
+                .to_string(),
+            )
+                .into_response()
+        }
+        Some("notifications/initialized") => (
+            StatusCode::ACCEPTED,
+            [
+                (axum::http::header::CONTENT_TYPE, "application/json"),
+                (
+                    axum::http::HeaderName::from_static("mcp-session-id"),
+                    "fixture-http-session",
+                ),
+            ],
+            String::new(),
+        )
+            .into_response(),
+        Some("tools/list") | Some("resources/list") => (
+            StatusCode::OK,
+            [
+                (axum::http::header::CONTENT_TYPE, "application/json"),
+                (
+                    axum::http::HeaderName::from_static("mcp-session-id"),
+                    "fixture-http-session",
+                ),
+            ],
+            response_for_body(&body)
+                .expect("tool/resource response should exist")
+                .to_string(),
+        )
+            .into_response(),
+        Some(other) => (
+            StatusCode::BAD_REQUEST,
+            [(axum::http::header::CONTENT_TYPE, "text/plain")],
+            format!("unexpected MCP method: {other}"),
+        )
+            .into_response(),
+        None => (
+            StatusCode::BAD_REQUEST,
+            [(axum::http::header::CONTENT_TYPE, "text/plain")],
+            "missing MCP method".to_string(),
+        )
+            .into_response(),
+    }
+}
+
+async fn spawn_http_mcp_server(state: ManualMcpState) -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind local HTTP MCP listener");
+    let addr = listener.local_addr().expect("resolve bound local address");
+    let app = Router::new()
+        .route("/mcp", post(manual_http_mcp_handler))
+        .with_state(state);
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("serve HTTP MCP listener");
+    });
+    (addr, handle)
+}
+
+#[allow(clippy::result_large_err)]
+async fn run_manual_ws_mcp_connection(
+    stream: TcpStream,
+    state: ManualMcpState,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let state_for_callback = state.clone();
+    let callback = move |request: &WsRequest, response: WsResponse| {
+        let mut headers = HeaderMap::new();
+        for (name, value) in request.headers() {
+            headers.insert(name.clone(), value.clone());
+        }
+        state_for_callback
+            .validate_headers(&headers)
+            .map_err(|message| {
+                let mut error_response = http::Response::new(Some(message));
+                *error_response.status_mut() = StatusCode::UNAUTHORIZED;
+                error_response
+            })?;
+        Ok(response)
+    };
+
+    let mut websocket = accept_hdr_async(stream, callback)
+        .await
+        .map_err(|err| format!("accept websocket handshake: {err}"))?;
+
+    while let Some(message) = websocket.next().await {
+        let message = message?;
+        if !message.is_text() && !message.is_binary() {
+            continue;
+        }
+
+        let payload = if message.is_text() {
+            message.into_text()?.to_string()
+        } else {
+            String::from_utf8(message.into_data().to_vec())?
+        };
+        let body: Value = serde_json::from_str(&payload)?;
+
+        match body.get("method").and_then(Value::as_str) {
+            Some("initialize") => {
+                state.initialize_seen.notify_one();
+                websocket
+                    .send(Message::text(
+                        json!({
+                            "jsonrpc": "2.0",
+                            "id": body.get("id"),
+                            "result": initialize_result()
+                        })
+                        .to_string(),
+                    ))
+                    .await?;
+            }
+            Some("notifications/initialized") => {}
+            Some("tools/list") | Some("resources/list") => {
+                websocket
+                    .send(Message::text(
+                        response_for_body(&body)
+                            .expect("tool/resource response should exist")
+                            .to_string(),
+                    ))
+                    .await?;
+            }
+            Some(other) => {
+                websocket
+                    .send(Message::text(
+                        json!({
+                            "jsonrpc": "2.0",
+                            "id": body.get("id"),
+                            "error": {
+                                "code": -32601,
+                                "message": format!("unexpected MCP method: {other}")
+                            }
+                        })
+                        .to_string(),
+                    ))
+                    .await?;
+            }
+            None => break,
+        }
+    }
+
+    Ok(())
+}
+
+async fn spawn_ws_mcp_server(state: ManualMcpState) -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind local websocket MCP listener");
+    let addr = listener.local_addr().expect("resolve bound local address");
+    let handle = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.expect("accept websocket client");
+        run_manual_ws_mcp_connection(stream, state)
+            .await
+            .expect("serve websocket MCP session");
+    });
+    (addr, handle)
+}
+
+#[tokio::test]
+async fn http_remote_connects_and_discovers_capabilities() {
+    let state = ManualMcpState::expect_bearer_and_header("http-token", "x-lattice-test", "http");
+    let notified = state.initialize_seen.clone();
+    let (addr, server_handle) = spawn_http_mcp_server(state).await;
+
+    let mut headers = HashMap::new();
+    headers.insert("x-lattice-test".to_string(), "http".to_string());
+
+    let mut configs = HashMap::new();
+    configs.insert(
+        "http-remote".to_string(),
+        McpServerConfig::Http(McpHttpServerConfig {
+            url: format!("http://{addr}/mcp"),
+            bearer_token: Some("http-token".to_string()),
+            headers,
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+
+    tokio::time::timeout(std::time::Duration::from_secs(5), notified.notified())
+        .await
+        .expect("HTTP initialize request should arrive");
+
+    let statuses = manager.list_statuses();
+    assert_eq!(statuses.len(), 1);
+    assert_eq!(statuses[0].name, "http-remote");
+    assert_eq!(statuses[0].state, McpConnectionState::Connected);
+    assert_eq!(statuses[0].transport, "http");
+    assert_eq!(statuses[0].tools.len(), 1);
+    assert_eq!(statuses[0].tools[0].name, "hello");
+    assert_eq!(statuses[0].resources.len(), 1);
+    assert_eq!(statuses[0].resources[0].uri, "fixture://readme");
+
+    manager.close().await;
+    server_handle.abort();
+}
+
+#[tokio::test]
+async fn websocket_remote_connects_and_discovers_capabilities() {
+    let state = ManualMcpState::expect_bearer_and_header("ws-token", "x-lattice-test", "ws");
+    let notified = state.initialize_seen.clone();
+    let (addr, server_handle) = spawn_ws_mcp_server(state).await;
+
+    let mut headers = HashMap::new();
+    headers.insert("x-lattice-test".to_string(), "ws".to_string());
+
+    let mut configs = HashMap::new();
+    configs.insert(
+        "ws-remote".to_string(),
+        McpServerConfig::Ws(McpWebSocketServerConfig {
+            url: format!("ws://{addr}/mcp"),
+            bearer_token: Some("ws-token".to_string()),
+            headers,
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+
+    tokio::time::timeout(std::time::Duration::from_secs(5), notified.notified())
+        .await
+        .expect("websocket initialize request should arrive");
+
+    let statuses = manager.list_statuses();
+    assert_eq!(statuses.len(), 1);
+    assert_eq!(statuses[0].name, "ws-remote");
+    assert_eq!(statuses[0].state, McpConnectionState::Connected);
+    assert_eq!(statuses[0].transport, "ws");
+    assert_eq!(statuses[0].tools.len(), 1);
+    assert_eq!(statuses[0].tools[0].name, "hello");
+    assert_eq!(statuses[0].resources.len(), 1);
+    assert_eq!(statuses[0].resources[0].uri, "fixture://readme");
+
+    manager.close().await;
+    server_handle.abort();
+}
+
+#[tokio::test]
+async fn bearer_token_conflicts_with_explicit_authorization_header() {
+    let mut http_headers = HashMap::new();
+    http_headers.insert(
+        "Authorization".to_string(),
+        "Bearer explicit-http".to_string(),
+    );
+    let mut ws_headers = HashMap::new();
+    ws_headers.insert(
+        "authorization".to_string(),
+        "Bearer explicit-ws".to_string(),
+    );
+
+    let mut configs = HashMap::new();
+    configs.insert(
+        "http-remote".to_string(),
+        McpServerConfig::Http(McpHttpServerConfig {
+            url: "http://127.0.0.1:1/mcp".to_string(),
+            bearer_token: Some("http-token".to_string()),
+            headers: http_headers,
+        }),
+    );
+    configs.insert(
+        "ws-remote".to_string(),
+        McpServerConfig::Ws(McpWebSocketServerConfig {
+            url: "ws://127.0.0.1:1/mcp".to_string(),
+            bearer_token: Some("ws-token".to_string()),
+            headers: ws_headers,
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+
+    let statuses = manager.list_statuses();
+    assert_eq!(statuses.len(), 2);
+    assert_eq!(statuses[0].state, McpConnectionState::Failed);
+    assert!(statuses[0]
+        .detail
+        .contains("authorization header must not be set when bearer_token is configured"));
+    assert_eq!(statuses[1].state, McpConnectionState::Failed);
+    assert!(statuses[1]
+        .detail
+        .contains("authorization header must not be set when bearer_token is configured"));
+}

--- a/crates/mcp/tests/stdio_flow.rs
+++ b/crates/mcp/tests/stdio_flow.rs
@@ -1,18 +1,22 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use lattice_core::ToolExecutor;
 use lattice_mcp::{
-    mcp_tool_name, ListMcpResourcesTool, McpClientManager, McpConnectionState, McpHttpServerConfig,
-    McpServerConfig, McpStdioServerConfig, McpToolAdapter, McpWebSocketServerConfig,
-    ReadMcpResourceTool,
+    load_mcp_manager_from_env, load_mcp_server_configs_from_path, mcp_tool_name,
+    register_mcp_tools, ListMcpResourcesTool, McpClientManager, McpConnectionState,
+    McpHttpServerConfig, McpServerConfig, McpStdioServerConfig, McpToolAdapter,
+    McpWebSocketServerConfig, ReadMcpResourceTool, LATTICE_MCP_CONFIG_ENV,
 };
 use lattice_tools::ToolSet;
 use rmcp::{
     model::ReadResourceRequestParams, service::RoleClient, transport::TokioChildProcess, ServiceExt,
 };
 use tokio::process::Command;
+
+static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 fn fixture_binary(name: &str) -> String {
     let key = format!("CARGO_BIN_EXE_{name}");
@@ -37,6 +41,25 @@ async fn connect_fixture_client(
     ().serve(transport)
         .await
         .expect("fixture client should connect")
+}
+
+fn write_temp_mcp_config(command: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("lattice-mcp-{unique}.json"));
+    let json = serde_json::json!({
+        "mcpServers": {
+            "fixture": {
+                "type": "stdio",
+                "command": command,
+                "args": []
+            }
+        }
+    });
+    std::fs::write(&path, serde_json::to_vec(&json).unwrap()).unwrap();
+    path
 }
 
 #[tokio::test]
@@ -396,6 +419,46 @@ async fn manager_can_call_mcp_tool() {
         .unwrap();
     assert_eq!(output.output, "fixture-hello:lattice");
     assert_eq!(output.structured_content, None);
+}
+
+#[test]
+fn load_mcp_server_configs_from_path_parses_json_file() {
+    let path = write_temp_mcp_config("fixture-command");
+    let configs = load_mcp_server_configs_from_path(&path).unwrap();
+    std::fs::remove_file(path).ok();
+
+    let Some(McpServerConfig::Stdio(config)) = configs.get("fixture") else {
+        panic!("expected stdio fixture config");
+    };
+    assert_eq!(config.command, "fixture-command");
+}
+
+#[tokio::test]
+async fn load_mcp_manager_from_env_and_register_mcp_tools() {
+    let _guard = ENV_LOCK.lock().await;
+    let path = write_temp_mcp_config(&fixture_binary("fixture_mcp_server"));
+    unsafe {
+        std::env::set_var(LATTICE_MCP_CONFIG_ENV, &path);
+    }
+
+    let manager = load_mcp_manager_from_env()
+        .await
+        .unwrap()
+        .expect("manager should load from env config");
+    let snapshots = manager.list_status_snapshots();
+    assert_eq!(snapshots.len(), 1);
+    assert_eq!(snapshots[0].state, McpConnectionState::Connected);
+
+    let mut toolset = ToolSet::new();
+    register_mcp_tools(&mut toolset, manager).unwrap();
+    assert!(toolset.contains("list_mcp_resources"));
+    assert!(toolset.contains("read_mcp_resource"));
+    assert!(toolset.contains(&mcp_tool_name("fixture", "hello")));
+
+    unsafe {
+        std::env::remove_var(LATTICE_MCP_CONFIG_ENV);
+    }
+    std::fs::remove_file(path).ok();
 }
 
 #[tokio::test]

--- a/crates/mcp/tests/stdio_flow.rs
+++ b/crates/mcp/tests/stdio_flow.rs
@@ -78,6 +78,7 @@ async fn new_manager_starts_all_servers_pending() {
         "remote".to_string(),
         McpServerConfig::Http(McpHttpServerConfig {
             url: "https://example.com/mcp".to_string(),
+            bearer_token: None,
             headers: HashMap::new(),
         }),
     );
@@ -287,12 +288,13 @@ async fn reconnect_all_recovers_failed_stdio_session() {
 }
 
 #[tokio::test]
-async fn connect_all_marks_unsupported_http_and_ws_transports_failed() {
+async fn connect_all_marks_unreachable_http_and_ws_transports_failed() {
     let mut configs = HashMap::new();
     configs.insert(
         "http-remote".to_string(),
         McpServerConfig::Http(McpHttpServerConfig {
             url: "https://example.com/mcp".to_string(),
+            bearer_token: None,
             headers: HashMap::new(),
         }),
     );
@@ -300,6 +302,7 @@ async fn connect_all_marks_unsupported_http_and_ws_transports_failed() {
         "ws-remote".to_string(),
         McpServerConfig::Ws(McpWebSocketServerConfig {
             url: "wss://example.com/mcp".to_string(),
+            bearer_token: None,
             headers: HashMap::new(),
         }),
     );
@@ -312,14 +315,14 @@ async fn connect_all_marks_unsupported_http_and_ws_transports_failed() {
     assert_eq!(statuses[0].name, "http-remote");
     assert_eq!(statuses[0].state, McpConnectionState::Failed);
     assert_eq!(statuses[0].transport, "http");
-    assert!(statuses[0].detail.contains("unsupported MCP transport"));
+    assert!(!statuses[0].detail.is_empty());
     assert!(statuses[0].tools.is_empty());
     assert!(statuses[0].resources.is_empty());
 
     assert_eq!(statuses[1].name, "ws-remote");
     assert_eq!(statuses[1].state, McpConnectionState::Failed);
     assert_eq!(statuses[1].transport, "ws");
-    assert!(statuses[1].detail.contains("unsupported MCP transport"));
+    assert!(!statuses[1].detail.is_empty());
     assert!(statuses[1].tools.is_empty());
     assert!(statuses[1].resources.is_empty());
 }
@@ -340,6 +343,7 @@ async fn list_statuses_tools_and_resources_are_sorted_and_aggregated() {
         "a-http".to_string(),
         McpServerConfig::Http(McpHttpServerConfig {
             url: "https://example.com/mcp".to_string(),
+            bearer_token: None,
             headers: HashMap::new(),
         }),
     );
@@ -524,6 +528,7 @@ async fn manager_connection_snapshots_include_counts() {
         "http-remote".to_string(),
         McpServerConfig::Http(McpHttpServerConfig {
             url: "https://example.com/mcp".to_string(),
+            bearer_token: None,
             headers: HashMap::new(),
         }),
     );

--- a/crates/mcp/tests/stdio_flow.rs
+++ b/crates/mcp/tests/stdio_flow.rs
@@ -4,8 +4,9 @@ use std::sync::Arc;
 
 use lattice_core::ToolExecutor;
 use lattice_mcp::{
-    mcp_tool_name, McpClientManager, McpConnectionState, McpHttpServerConfig, McpServerConfig,
-    McpStdioServerConfig, McpToolAdapter, McpWebSocketServerConfig,
+    mcp_tool_name, ListMcpResourcesTool, McpClientManager, McpConnectionState, McpHttpServerConfig,
+    McpServerConfig, McpStdioServerConfig, McpToolAdapter, McpWebSocketServerConfig,
+    ReadMcpResourceTool,
 };
 use lattice_tools::ToolSet;
 use rmcp::{
@@ -398,6 +399,87 @@ async fn manager_can_call_mcp_tool() {
 }
 
 #[tokio::test]
+async fn manager_can_read_mcp_resource() {
+    let mut configs = HashMap::new();
+    configs.insert(
+        "fixture".to_string(),
+        McpServerConfig::Stdio(McpStdioServerConfig {
+            command: fixture_binary("fixture_mcp_server"),
+            args: vec![],
+            env: None,
+            cwd: None,
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+
+    let output = manager
+        .read_resource("fixture", "fixture://readme")
+        .await
+        .unwrap();
+    assert_eq!(output, "fixture resource contents");
+}
+
+#[tokio::test]
+async fn manager_reports_missing_mcp_resource() {
+    let mut configs = HashMap::new();
+    configs.insert(
+        "fixture".to_string(),
+        McpServerConfig::Stdio(McpStdioServerConfig {
+            command: fixture_binary("fixture_mcp_server"),
+            args: vec![],
+            env: None,
+            cwd: None,
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+
+    let err = manager
+        .read_resource("fixture", "fixture://missing")
+        .await
+        .unwrap_err();
+    assert!(matches!(err, lattice_core::ToolError::NotFound(_)));
+    assert!(err.to_string().contains("fixture://missing"));
+}
+
+#[tokio::test]
+async fn manager_connection_snapshots_include_counts() {
+    let mut configs = HashMap::new();
+    configs.insert(
+        "fixture".to_string(),
+        McpServerConfig::Stdio(McpStdioServerConfig {
+            command: fixture_binary("fixture_mcp_server"),
+            args: vec![],
+            env: None,
+            cwd: None,
+        }),
+    );
+    configs.insert(
+        "http-remote".to_string(),
+        McpServerConfig::Http(McpHttpServerConfig {
+            url: "https://example.com/mcp".to_string(),
+            headers: HashMap::new(),
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+
+    let snapshots = manager.list_status_snapshots();
+    assert_eq!(snapshots.len(), 2);
+    assert_eq!(snapshots[0].name, "fixture");
+    assert_eq!(snapshots[0].tool_count, 2);
+    assert_eq!(snapshots[0].resource_count, 1);
+    assert_eq!(snapshots[1].name, "http-remote");
+    assert_eq!(snapshots[1].tool_count, 0);
+    assert_eq!(snapshots[1].resource_count, 0);
+    assert_eq!(snapshots[1].state, McpConnectionState::Failed);
+}
+
+#[tokio::test]
 async fn manager_rejects_non_object_tool_arguments() {
     let mut configs = HashMap::new();
     configs.insert(
@@ -478,4 +560,91 @@ async fn mcp_tool_adapter_registers_into_toolset_and_executes() {
         .await
         .unwrap();
     assert_eq!(result.stdout, "fixture-hello:bridge");
+}
+
+#[tokio::test]
+async fn mcp_resource_tools_register_into_toolset_and_execute() {
+    let mut configs = HashMap::new();
+    configs.insert(
+        "fixture".to_string(),
+        McpServerConfig::Stdio(McpStdioServerConfig {
+            command: fixture_binary("fixture_mcp_server"),
+            args: vec![],
+            env: None,
+            cwd: None,
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+    let manager = Arc::new(manager);
+
+    let mut set = ToolSet::new();
+    set.register(ListMcpResourcesTool::new(manager.clone()))
+        .unwrap();
+    set.register(ReadMcpResourceTool::new(manager.clone()))
+        .unwrap();
+
+    let listed = set
+        .execute("list_mcp_resources", serde_json::json!({}))
+        .await
+        .unwrap();
+    assert!(listed.stdout.contains("fixture fixture://readme"));
+
+    let read = set
+        .execute(
+            "read_mcp_resource",
+            serde_json::json!({
+                "server": "fixture",
+                "uri": "fixture://readme"
+            }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(read.stdout, "fixture resource contents");
+}
+
+#[tokio::test]
+async fn list_mcp_resources_handles_empty_servers() {
+    let mut configs = HashMap::new();
+    configs.insert(
+        "fixture".to_string(),
+        McpServerConfig::Stdio(McpStdioServerConfig {
+            command: fixture_binary("fixture_mcp_tools_only_server"),
+            args: vec![],
+            env: None,
+            cwd: None,
+        }),
+    );
+
+    let mut manager = McpClientManager::new(configs);
+    manager.connect_all().await;
+    let tool = ListMcpResourcesTool::new(Arc::new(manager));
+
+    let result = tool.execute(serde_json::json!({})).await.unwrap();
+    assert_eq!(result.stdout, "(no MCP resources)");
+}
+
+#[tokio::test]
+async fn list_mcp_resources_rejects_non_object_params() {
+    let manager = Arc::new(McpClientManager::new(HashMap::new()));
+    let tool = ListMcpResourcesTool::new(manager);
+
+    let err = tool.execute(serde_json::json!(["bad"])).await.unwrap_err();
+    assert!(matches!(err, lattice_core::ToolError::InvalidParams(_)));
+}
+
+#[tokio::test]
+async fn read_mcp_resource_rejects_invalid_params() {
+    let manager = Arc::new(McpClientManager::new(HashMap::new()));
+    let tool = ReadMcpResourceTool::new(manager);
+
+    let err = tool
+        .execute(serde_json::json!({ "server": 1, "uri": true }))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, lattice_core::ToolError::InvalidParams(_)));
+    assert!(err
+        .to_string()
+        .contains("invalid read_mcp_resource arguments"));
 }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -19,6 +19,7 @@ lattice-runtime = { path = "../runtime" }
 lattice-store-memory = { path = "../store-memory" }
 lattice-sandbox-local = { path = "../sandbox-local" }
 lattice-tools = { path = "../tools" }
+lattice-mcp = { path = "../mcp" }
 lattice-llm-protocol = { path = "../llm-protocol", optional = true }
 lattice-llm-anthropic = { path = "../llm-anthropic", optional = true }
 lattice-llm-openai = { path = "../llm-openai", optional = true }

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -13,6 +13,7 @@ use axum::{
 };
 use chrono::Utc;
 use lattice_core::{Actor, EventFilter, EventId, SessionId};
+use lattice_mcp::McpConnectionState;
 use serde::Deserialize;
 
 use crate::api::types::*;
@@ -53,6 +54,7 @@ pub fn v1_routes() -> Router<Arc<AppState>> {
     Router::new()
         .route("/sessions", post(create_session).get(list_sessions))
         .route("/sessions/{id}", get(get_session).delete(delete_session))
+        .route("/mcp", get(get_mcp_status))
         .route("/sessions/{id}/events", get(get_events))
         .route("/sessions/{id}/stream", get(session_stream))
         .route(
@@ -61,6 +63,63 @@ pub fn v1_routes() -> Router<Arc<AppState>> {
         )
         .route("/sessions/{id}/run", post(trigger_run))
         .route("/sessions/{id}/status", get(get_status))
+}
+
+/// GET /v1/mcp - returns MCP connection status and discovered capabilities.
+async fn get_mcp_status(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<McpStatusResponse>, AppError> {
+    let statuses = state
+        .mcp_manager
+        .as_ref()
+        .map(|manager| manager.list_statuses())
+        .unwrap_or_default();
+
+    let connected_count = statuses
+        .iter()
+        .filter(|status| status.state == McpConnectionState::Connected)
+        .count();
+    let failed_count = statuses
+        .iter()
+        .filter(|status| status.state == McpConnectionState::Failed)
+        .count();
+
+    Ok(Json(McpStatusResponse {
+        enabled: state.mcp_manager.is_some(),
+        server_count: statuses.len(),
+        connected_count,
+        failed_count,
+        servers: statuses
+            .into_iter()
+            .map(|status| McpServerStatusResponse {
+                name: status.name,
+                state: status.state,
+                transport: status.transport,
+                detail: status.detail,
+                tool_count: status.tools.len(),
+                resource_count: status.resources.len(),
+                tools: status
+                    .tools
+                    .into_iter()
+                    .map(|tool| McpToolSummary {
+                        server_name: tool.server_name,
+                        name: tool.name,
+                        description: tool.description,
+                    })
+                    .collect(),
+                resources: status
+                    .resources
+                    .into_iter()
+                    .map(|resource| McpResourceSummary {
+                        server_name: resource.server_name,
+                        name: resource.name,
+                        uri: resource.uri,
+                        description: resource.description,
+                    })
+                    .collect(),
+            })
+            .collect(),
+    }))
 }
 
 /// DELETE /v1/sessions/:id — deletes a session and all of its events.

--- a/crates/server/src/api/types.rs
+++ b/crates/server/src/api/types.rs
@@ -2,6 +2,7 @@
 
 use chrono::{DateTime, Utc};
 use lattice_core::{Actor, Event, EventId, SessionId};
+use lattice_mcp::McpConnectionState;
 use serde::{Deserialize, Serialize};
 
 /// Optional metadata when creating a session.
@@ -231,4 +232,68 @@ pub struct LatestEventInfo {
     pub payload_type: String,
     /// When the event occurred.
     pub timestamp: DateTime<Utc>,
+}
+
+/// Response for GET /v1/mcp.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpStatusResponse {
+    /// Whether MCP is configured for this server process.
+    pub enabled: bool,
+    /// Total number of configured MCP servers.
+    pub server_count: usize,
+    /// Number of connected MCP servers.
+    pub connected_count: usize,
+    /// Number of failed MCP servers.
+    pub failed_count: usize,
+    /// Detailed status for each MCP server.
+    pub servers: Vec<McpServerStatusResponse>,
+}
+
+/// Detailed status for a single MCP server.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpServerStatusResponse {
+    /// Server name from MCP config.
+    pub name: String,
+    /// Connection state.
+    pub state: McpConnectionState,
+    /// Transport name (e.g. stdio/http/ws).
+    pub transport: String,
+    /// Error or status detail, if any.
+    pub detail: String,
+    /// Number of discovered tools.
+    pub tool_count: usize,
+    /// Number of discovered resources.
+    pub resource_count: usize,
+    /// Tool summaries.
+    pub tools: Vec<McpToolSummary>,
+    /// Resource summaries.
+    pub resources: Vec<McpResourceSummary>,
+}
+
+/// Tool summary for MCP status responses.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpToolSummary {
+    /// Parent MCP server name.
+    pub server_name: String,
+    /// Tool name.
+    pub name: String,
+    /// Optional human-readable description.
+    pub description: String,
+}
+
+/// Resource summary for MCP status responses.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpResourceSummary {
+    /// Parent MCP server name.
+    pub server_name: String,
+    /// Resource display name.
+    pub name: String,
+    /// Resource URI.
+    pub uri: String,
+    /// Optional human-readable description.
+    pub description: String,
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -445,6 +445,7 @@ mod tests {
         let html = String::from_utf8(body.to_vec()).unwrap();
         assert!(html.contains("Lattice Console"));
         assert!(html.contains("/ui/app.js"));
+        assert!(html.contains("mcp-panel"));
     }
 
     #[tokio::test]
@@ -498,6 +499,7 @@ mod tests {
         assert!(js.contains("loadSessions"));
         assert!(js.contains("sendMessage"));
         assert!(js.contains("deleteSession"));
+        assert!(js.contains("loadMcpStatus"));
     }
 
     #[tokio::test]
@@ -662,6 +664,85 @@ mod tests {
         assert_eq!(json["mcp_servers"][0]["state"], "failed");
         assert_eq!(json["mcp_servers"][0]["tool_count"], 0);
         assert_eq!(json["mcp_servers"][0]["resource_count"], 0);
+    }
+
+    #[tokio::test]
+    async fn mcp_status_route_reports_disabled_when_unconfigured() {
+        let app = make_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/mcp")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 16)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["enabled"], false);
+        assert_eq!(json["serverCount"], 0);
+        assert_eq!(json["connectedCount"], 0);
+        assert_eq!(json["failedCount"], 0);
+        assert!(json["servers"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn mcp_status_route_reports_server_details() {
+        let mut configs = std::collections::HashMap::new();
+        configs.insert(
+            "http-remote".to_string(),
+            lattice_mcp::McpServerConfig::Http(lattice_mcp::McpHttpServerConfig {
+                url: "https://example.com/mcp".to_string(),
+                headers: std::collections::HashMap::new(),
+            }),
+        );
+        let mut manager = lattice_mcp::McpClientManager::new(configs);
+        manager.connect_all().await;
+
+        let state = new_state_with_mcp_components(
+            Arc::new(lattice_store_memory::MemoryStore::new()),
+            Arc::new(TestFactory),
+            Arc::new(ToolSet::new()),
+            Some(Arc::new(manager)),
+        );
+        let app = router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/mcp")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 16)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["enabled"], true);
+        assert_eq!(json["serverCount"], 1);
+        assert_eq!(json["connectedCount"], 0);
+        assert_eq!(json["failedCount"], 1);
+        assert_eq!(json["servers"][0]["name"], "http-remote");
+        assert_eq!(json["servers"][0]["transport"], "http");
+        assert_eq!(json["servers"][0]["state"], "failed");
+        assert!(json["servers"][0]["detail"]
+            .as_str()
+            .unwrap()
+            .contains("unsupported"));
+        assert!(json["servers"][0]["tools"].as_array().unwrap().is_empty());
+        assert!(json["servers"][0]["resources"]
+            .as_array()
+            .unwrap()
+            .is_empty());
     }
 
     #[tokio::test]

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -699,6 +699,7 @@ mod tests {
             "http-remote".to_string(),
             lattice_mcp::McpServerConfig::Http(lattice_mcp::McpHttpServerConfig {
                 url: "https://example.com/mcp".to_string(),
+                bearer_token: None,
                 headers: std::collections::HashMap::new(),
             }),
         );
@@ -735,10 +736,7 @@ mod tests {
         assert_eq!(json["servers"][0]["name"], "http-remote");
         assert_eq!(json["servers"][0]["transport"], "http");
         assert_eq!(json["servers"][0]["state"], "failed");
-        assert!(json["servers"][0]["detail"]
-            .as_str()
-            .unwrap()
-            .contains("unsupported"));
+        assert!(!json["servers"][0]["detail"].as_str().unwrap().is_empty());
         assert!(json["servers"][0]["tools"].as_array().unwrap().is_empty());
         assert!(json["servers"][0]["resources"]
             .as_array()

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -630,6 +630,7 @@ mod tests {
             "http-remote".to_string(),
             lattice_mcp::McpServerConfig::Http(lattice_mcp::McpHttpServerConfig {
                 url: "https://example.com/mcp".to_string(),
+                bearer_token: None,
                 headers: std::collections::HashMap::new(),
             }),
         );

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -16,6 +16,9 @@ use axum::{extract::State, http::StatusCode, response::IntoResponse, routing::ge
 use chrono::{DateTime, Utc};
 pub use lattice_core::SessionId;
 use lattice_core::{LLMClient, Sandbox};
+use lattice_mcp::{
+    load_mcp_manager_from_env, register_mcp_tools, McpClientManager, McpConnectionSnapshot,
+};
 use lattice_runtime::ControlLoop;
 use lattice_sandbox_local::LocalSandbox;
 use lattice_tools::ToolSet;
@@ -38,6 +41,8 @@ pub struct AppState {
     pub llm_factory: Arc<dyn LlmClientFactory>,
     /// Tool registry used by agent runs.
     pub tools: Arc<ToolSet>,
+    /// Optional MCP manager backing registered MCP tools.
+    pub mcp_manager: Option<Arc<McpClientManager>>,
     /// Active ControlLoop task handles.
     pub active_runs: Arc<RwLock<HashMap<SessionId, RunHandle>>>,
     /// Server start time (for uptime reporting).
@@ -243,6 +248,8 @@ pub struct HealthResponse {
     pub uptime_seconds: i64,
     /// Which LLM providers are compiled in.
     pub features: serde_json::Value,
+    /// Current MCP server connection snapshots.
+    pub mcp_servers: Vec<McpConnectionSnapshot>,
 }
 
 /// Returns which LLM providers are enabled at compile time.
@@ -264,6 +271,11 @@ async fn health_check(State(state): State<Arc<AppState>>) -> impl IntoResponse {
         version: env!("CARGO_PKG_VERSION"),
         uptime_seconds: uptime,
         features: enabled_features(),
+        mcp_servers: state
+            .mcp_manager
+            .as_ref()
+            .map(|manager| manager.list_status_snapshots())
+            .unwrap_or_default(),
     };
 
     (StatusCode::OK, Json(response))
@@ -290,11 +302,31 @@ fn app(state: AppState) -> Router {
 /// Creates a new AppState with the given session store.
 pub fn new_state(store: Arc<dyn lattice_core::SessionStore>) -> AppState {
     let sandbox: Arc<dyn Sandbox> = Arc::new(LocalSandbox::new());
-    new_state_with_components(
+    new_state_with_mcp_components(
         store,
         Arc::new(EnvLlmClientFactory),
         Arc::new(ToolSet::with_defaults(sandbox)),
+        None,
     )
+}
+
+/// Creates a new AppState using environment-backed MCP configuration when present.
+pub async fn new_state_from_env(
+    store: Arc<dyn lattice_core::SessionStore>,
+) -> Result<AppState, String> {
+    let sandbox: Arc<dyn Sandbox> = Arc::new(LocalSandbox::new());
+    let mut tools = ToolSet::with_defaults(sandbox);
+    let mcp_manager = load_mcp_manager_from_env().await?;
+    if let Some(manager) = &mcp_manager {
+        register_mcp_tools(&mut tools, Arc::clone(manager)).map_err(|err| err.to_string())?;
+    }
+
+    Ok(new_state_with_mcp_components(
+        store,
+        Arc::new(EnvLlmClientFactory),
+        Arc::new(tools),
+        mcp_manager,
+    ))
 }
 
 /// Creates a new AppState with injectable runtime components.
@@ -302,6 +334,16 @@ pub fn new_state_with_components(
     store: Arc<dyn lattice_core::SessionStore>,
     llm_factory: Arc<dyn LlmClientFactory>,
     tools: Arc<ToolSet>,
+) -> AppState {
+    new_state_with_mcp_components(store, llm_factory, tools, None)
+}
+
+/// Creates a new AppState with injectable runtime components and optional MCP manager.
+pub fn new_state_with_mcp_components(
+    store: Arc<dyn lattice_core::SessionStore>,
+    llm_factory: Arc<dyn LlmClientFactory>,
+    tools: Arc<ToolSet>,
+    mcp_manager: Option<Arc<McpClientManager>>,
 ) -> AppState {
     let event_hub = Arc::new(EventHub::new());
     let store: Arc<dyn lattice_core::SessionStore> =
@@ -312,6 +354,7 @@ pub fn new_state_with_components(
         event_hub,
         llm_factory,
         tools,
+        mcp_manager,
         active_runs: Arc::new(RwLock::new(HashMap::new())),
         started_at: Utc::now(),
         sessions: Arc::new(RwLock::new(Vec::new())),
@@ -481,6 +524,7 @@ mod tests {
         assert!(json["features"].is_object());
         assert!(json["features"]["anthropic"].is_boolean());
         assert!(json["features"]["openai"].is_boolean());
+        assert!(json["mcp_servers"].is_array());
     }
 
     #[tokio::test]
@@ -568,12 +612,56 @@ mod tests {
             new_state_with_components(store, Arc::new(TestFactory), Arc::new(ToolSet::new()));
 
         assert_eq!(state.tools.len(), 0);
+        assert!(state.mcp_manager.is_none());
         let client = state.llm_factory.create(None, None).unwrap();
         let decision = client.decide(&[], &[], "").await.unwrap();
         match decision {
             Decision::FinalAnswer { answer } => assert_eq!(answer, "done"),
             _ => panic!("expected final answer"),
         }
+    }
+
+    #[tokio::test]
+    async fn health_reports_mcp_server_snapshots() {
+        let mut configs = std::collections::HashMap::new();
+        configs.insert(
+            "http-remote".to_string(),
+            lattice_mcp::McpServerConfig::Http(lattice_mcp::McpHttpServerConfig {
+                url: "https://example.com/mcp".to_string(),
+                headers: std::collections::HashMap::new(),
+            }),
+        );
+        let mut manager = lattice_mcp::McpClientManager::new(configs);
+        manager.connect_all().await;
+
+        let state = new_state_with_mcp_components(
+            Arc::new(lattice_store_memory::MemoryStore::new()),
+            Arc::new(TestFactory),
+            Arc::new(ToolSet::new()),
+            Some(Arc::new(manager)),
+        );
+        let app = router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 16)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["mcp_servers"].as_array().unwrap().len(), 1);
+        assert_eq!(json["mcp_servers"][0]["name"], "http-remote");
+        assert_eq!(json["mcp_servers"][0]["state"], "failed");
+        assert_eq!(json["mcp_servers"][0]["tool_count"], 0);
+        assert_eq!(json["mcp_servers"][0]["resource_count"], 0);
     }
 
     #[tokio::test]

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -4,7 +4,7 @@ use std::env;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use lattice_server::{new_state, router};
+use lattice_server::{new_state_from_env, router};
 use tracing::info;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
@@ -29,7 +29,35 @@ async fn main() -> anyhow::Result<()> {
         Arc::new(lattice_store_memory::MemoryStore::new());
 
     // Build router and state.
-    let state = new_state(store);
+    let state = new_state_from_env(store)
+        .await
+        .map_err(anyhow::Error::msg)?;
+    if let Some(manager) = &state.mcp_manager {
+        for snapshot in manager.list_status_snapshots() {
+            match snapshot.state {
+                lattice_mcp::McpConnectionState::Connected => {
+                    info!(
+                        server = %snapshot.name,
+                        transport = %snapshot.transport,
+                        tool_count = snapshot.tool_count,
+                        resource_count = snapshot.resource_count,
+                        "MCP server connected"
+                    );
+                }
+                lattice_mcp::McpConnectionState::Failed => {
+                    tracing::warn!(
+                        server = %snapshot.name,
+                        transport = %snapshot.transport,
+                        detail = %snapshot.detail,
+                        "MCP server failed to connect"
+                    );
+                }
+                lattice_mcp::McpConnectionState::Pending => {
+                    info!(server = %snapshot.name, "MCP server pending");
+                }
+            }
+        }
+    }
     let app = router(state);
 
     // Print startup banner.

--- a/crates/server/src/ui/app.css
+++ b/crates/server/src/ui/app.css
@@ -106,6 +106,12 @@ textarea {
   gap: 12px;
 }
 
+.panel-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .eyebrow {
   margin: 0 0 4px;
   color: var(--text-muted);
@@ -338,9 +344,19 @@ button:focus-visible {
   color: var(--success);
 }
 
+.status-chip.connected {
+  background: #e7f6ec;
+  color: var(--success);
+}
+
 .status-chip.failed {
   background: #fdecea;
   color: var(--danger);
+}
+
+.status-chip.pending {
+  background: #fff0dc;
+  color: var(--warning);
 }
 
 .status-summary {
@@ -367,6 +383,85 @@ button:focus-visible {
   display: flex;
   flex-direction: column;
   gap: 10px;
+}
+
+.mcp-list {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.mcp-server-card {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface-muted);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.mcp-server-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.mcp-server-name,
+.mcp-server-meta,
+.mcp-server-detail,
+.mcp-detail-label {
+  margin: 0;
+}
+
+.mcp-server-name {
+  font-weight: 600;
+}
+
+.mcp-server-meta,
+.mcp-server-detail,
+.mcp-detail-label {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.mcp-server-summary {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px 12px;
+}
+
+.mcp-server-summary div {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.mcp-server-summary dt {
+  color: var(--text-muted);
+}
+
+.mcp-server-summary dd {
+  margin: 0;
+}
+
+.mcp-server-details {
+  border-top: 1px solid var(--border);
+  padding-top: 10px;
+}
+
+.mcp-server-details summary {
+  cursor: pointer;
+  color: var(--text);
+}
+
+.mcp-detail-section {
+  margin-top: 10px;
 }
 
 .event-item {

--- a/crates/server/src/ui/app.js
+++ b/crates/server/src/ui/app.js
@@ -6,17 +6,22 @@ const state = {
   currentMessages: [],
   currentEvents: [],
   currentStatus: null,
+  currentMcpStatus: null,
 };
 
 const el = {
   createSessionBtn: document.getElementById("create-session-btn"),
   refreshSessionsBtn: document.getElementById("refresh-sessions-btn"),
   refreshDetailBtn: document.getElementById("refresh-detail-btn"),
+  refreshMcpBtn: document.getElementById("refresh-mcp-btn"),
   sessionName: document.getElementById("session-name"),
   sessionList: document.getElementById("session-list"),
   activeSessionLabel: document.getElementById("active-session-label"),
   statusChip: document.getElementById("status-chip"),
   statusSummary: document.getElementById("status-summary"),
+  mcpSummary: document.getElementById("mcp-summary"),
+  mcpList: document.getElementById("mcp-list"),
+  mcpCountBadge: document.getElementById("mcp-count-badge"),
   messageList: document.getElementById("message-list"),
   eventList: document.getElementById("event-list"),
   eventCountBadge: document.getElementById("event-count-badge"),
@@ -98,10 +103,10 @@ function renderSessions(sessions) {
     const label = sessionTitle(session);
     button.innerHTML = `
       <div class="session-card-header">
-        <p class="session-title">${label.title}</p>
+        <p class="session-title">${escapeHtml(label.title)}</p>
         <span class="session-delete" data-session-id="${session.sessionId}" title="删除会话" aria-label="删除会话">×</span>
       </div>
-      <p class="session-meta">${label.meta}</p>
+      <p class="session-meta">${escapeHtml(label.meta)}</p>
     `;
     button.addEventListener("click", () => selectSession(session.sessionId));
     button.querySelector(".session-delete").addEventListener("click", (event) => {
@@ -147,7 +152,7 @@ function renderMessages(messages) {
     const item = document.createElement("article");
     item.className = `message-item ${message.role}`;
     item.innerHTML = `
-      <p class="message-meta">${message.role} · ${formatTime(message.timestamp)}</p>
+      <p class="message-meta">${escapeHtml(message.role)} · ${formatTime(message.timestamp)}</p>
       <pre class="message-content">${escapeHtml(message.content)}</pre>
     `;
     el.messageList.appendChild(item);
@@ -173,7 +178,7 @@ function renderEvents(events) {
       item.className = "event-item";
       item.innerHTML = `
         <header>
-          <p class="event-title">${event.payload.type} · ${event.actor}</p>
+          <p class="event-title">${escapeHtml(event.payload.type)} · ${escapeHtml(event.actor)}</p>
           <span class="event-time">${formatTime(event.timestamp)}</span>
         </header>
         <pre class="event-body">${escapeHtml(summarizePayload(event.payload))}</pre>
@@ -188,16 +193,85 @@ function renderStatus(status) {
     ? `${status.latestEvent.payloadType} · ${status.latestEvent.actor}`
     : "-";
   el.statusSummary.innerHTML = `
-    <div><dt>会话</dt><dd>${state.selectedSessionId || "-"}</dd></div>
-    <div><dt>开始时间</dt><dd>${formatTime(status?.runStartedAt)}</dd></div>
-    <div><dt>结束时间</dt><dd>${formatTime(status?.runCompletedAt)}</dd></div>
+    <div><dt>会话</dt><dd>${escapeHtml(state.selectedSessionId || "-")}</dd></div>
+    <div><dt>开始时间</dt><dd>${escapeHtml(formatTime(status?.runStartedAt))}</dd></div>
+    <div><dt>结束时间</dt><dd>${escapeHtml(formatTime(status?.runCompletedAt))}</dd></div>
     <div><dt>事件数</dt><dd>${status?.eventCount ?? 0}</dd></div>
-    <div><dt>最新事件</dt><dd>${latest}</dd></div>
+    <div><dt>最新事件</dt><dd>${escapeHtml(latest)}</dd></div>
   `;
 }
 
+function renderMcpStatus(mcpStatus) {
+  const enabled = Boolean(mcpStatus?.enabled);
+  const connectedCount = mcpStatus?.connectedCount ?? 0;
+  const failedCount = mcpStatus?.failedCount ?? 0;
+  const serverCount = mcpStatus?.serverCount ?? 0;
+  const servers = mcpStatus?.servers || [];
+
+  el.mcpCountBadge.textContent = String(serverCount);
+  el.mcpSummary.innerHTML = `
+    <div><dt>启用</dt><dd>${enabled ? "true" : "false"}</dd></div>
+    <div><dt>已连接</dt><dd>${connectedCount}</dd></div>
+    <div><dt>失败</dt><dd>${failedCount}</dd></div>
+    <div><dt>总数</dt><dd>${serverCount}</dd></div>
+  `;
+
+  if (!enabled) {
+    el.mcpList.className = "mcp-list empty-state";
+    el.mcpList.textContent = "当前未配置 MCP server。";
+    return;
+  }
+
+  if (!servers.length) {
+    el.mcpList.className = "mcp-list empty-state";
+    el.mcpList.textContent = "MCP 已启用，但当前没有可用 server。";
+    return;
+  }
+
+  el.mcpList.className = "mcp-list";
+  el.mcpList.innerHTML = "";
+
+  servers.forEach((server) => {
+    const item = document.createElement("article");
+    item.className = "mcp-server-card";
+    const detail = server.detail?.trim() || "OK";
+    const tools = server.tools?.length
+      ? server.tools.map((tool) => tool.name).join(", ")
+      : "无";
+    const resources = server.resources?.length
+      ? server.resources.map((resource) => resource.uri).join(", ")
+      : "无";
+    item.innerHTML = `
+      <header class="mcp-server-header">
+        <div>
+          <p class="mcp-server-name">${escapeHtml(server.name)}</p>
+          <p class="mcp-server-meta">${escapeHtml(server.transport)} · ${escapeHtml(server.state)}</p>
+        </div>
+        <span class="status-chip ${escapeHtml(server.state)}">${escapeHtml(server.state)}</span>
+      </header>
+      <dl class="mcp-server-summary">
+        <div><dt>Tools</dt><dd>${server.toolCount}</dd></div>
+        <div><dt>Resources</dt><dd>${server.resourceCount}</dd></div>
+      </dl>
+      <p class="mcp-server-detail">${escapeHtml(detail)}</p>
+      <details class="mcp-server-details">
+        <summary>能力清单</summary>
+        <div class="mcp-detail-section">
+          <p class="mcp-detail-label">Tools</p>
+          <pre class="event-body">${escapeHtml(tools)}</pre>
+        </div>
+        <div class="mcp-detail-section">
+          <p class="mcp-detail-label">Resources</p>
+          <pre class="event-body">${escapeHtml(resources)}</pre>
+        </div>
+      </details>
+    `;
+    el.mcpList.appendChild(item);
+  });
+}
+
 function escapeHtml(value) {
-  return value
+  return String(value)
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")
     .replaceAll(">", "&gt;");
@@ -380,6 +454,12 @@ async function loadCurrentSession() {
   await openSessionStream();
 }
 
+async function loadMcpStatus() {
+  const status = await api("/v1/mcp");
+  state.currentMcpStatus = status;
+  renderMcpStatus(status);
+}
+
 async function selectSession(sessionId) {
   if (sessionId === state.selectedSessionId && state.stream) {
     return;
@@ -493,9 +573,10 @@ async function sendMessage(event) {
 el.createSessionBtn.addEventListener("click", createSession);
 el.refreshSessionsBtn.addEventListener("click", () => loadSessions().catch((error) => showToast(error.message, true)));
 el.refreshDetailBtn.addEventListener("click", () => loadCurrentSession().catch((error) => showToast(error.message, true)));
+el.refreshMcpBtn.addEventListener("click", () => loadMcpStatus().catch((error) => showToast(error.message, true)));
 el.messageForm.addEventListener("submit", sendMessage);
 
-loadSessions(true)
+Promise.all([loadSessions(true), loadMcpStatus()])
   .then(() => loadCurrentSession())
   .catch((error) => showToast(error.message, true));
 

--- a/crates/server/src/ui/index.html
+++ b/crates/server/src/ui/index.html
@@ -29,7 +29,12 @@
         <div class="panel stack-sm">
           <div class="panel-title-row">
             <h2>会话列表</h2>
-            <button id="refresh-sessions-btn" class="ghost-button icon-button" type="button" title="刷新会话列表">
+            <button
+              id="refresh-sessions-btn"
+              class="ghost-button icon-button"
+              type="button"
+              title="刷新会话列表"
+            >
               ↻
             </button>
           </div>
@@ -93,7 +98,12 @@
           <div class="panel stack-sm">
             <div class="panel-title-row">
               <h2>运行状态</h2>
-              <button id="refresh-detail-btn" class="ghost-button icon-button" type="button" title="刷新当前会话">
+              <button
+                id="refresh-detail-btn"
+                class="ghost-button icon-button"
+                type="button"
+                title="刷新当前会话"
+              >
                 ↻
               </button>
             </div>
@@ -104,6 +114,32 @@
               <div><dt>事件数</dt><dd>-</dd></div>
               <div><dt>最新事件</dt><dd>-</dd></div>
             </dl>
+          </div>
+
+          <div id="mcp-panel" class="panel panel-fill stack-sm">
+            <div class="panel-title-row">
+              <h2>MCP</h2>
+              <div class="panel-actions">
+                <span id="mcp-count-badge" class="meta-pill">0</span>
+                <button
+                  id="refresh-mcp-btn"
+                  class="ghost-button icon-button"
+                  type="button"
+                  title="刷新 MCP 状态"
+                >
+                  ↻
+                </button>
+              </div>
+            </div>
+            <dl id="mcp-summary" class="status-summary">
+              <div><dt>启用</dt><dd>false</dd></div>
+              <div><dt>已连接</dt><dd>0</dd></div>
+              <div><dt>失败</dt><dd>0</dd></div>
+              <div><dt>总数</dt><dd>0</dd></div>
+            </dl>
+            <div id="mcp-list" class="mcp-list empty-state">
+              当前未配置 MCP server。
+            </div>
           </div>
 
           <div class="panel panel-fill stack-sm">

--- a/examples/real-agent/Cargo.toml
+++ b/examples/real-agent/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 lattice = { path = "../..", features = ["full"] }
+lattice-mcp = { path = "../../crates/mcp" }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/examples/real-agent/src/main.rs
+++ b/examples/real-agent/src/main.rs
@@ -23,7 +23,7 @@ use lattice::runtime::ControlLoop;
 use lattice::sandbox_local::LocalSandbox;
 use lattice::store_memory::MemoryStore;
 use lattice::tools::ToolSet;
-use tracing::info;
+use tracing::{info, warn};
 
 fn main() -> Result<()> {
     // Initialize tracing.
@@ -84,7 +84,38 @@ async fn run(task: String) -> Result<()> {
     // Assemble the agent components.
     let store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
     let sandbox = Arc::new(LocalSandbox::new());
-    let tools = Arc::new(ToolSet::with_defaults(sandbox));
+    let mut tools = ToolSet::with_defaults(sandbox);
+    let mcp_manager = lattice_mcp::load_mcp_manager_from_env()
+        .await
+        .map_err(anyhow::Error::msg)?;
+    if let Some(manager) = &mcp_manager {
+        lattice_mcp::register_mcp_tools(&mut tools, Arc::clone(manager))?;
+        for snapshot in manager.list_status_snapshots() {
+            match snapshot.state {
+                lattice_mcp::McpConnectionState::Connected => {
+                    info!(
+                        server = %snapshot.name,
+                        transport = %snapshot.transport,
+                        tool_count = snapshot.tool_count,
+                        resource_count = snapshot.resource_count,
+                        "MCP server connected"
+                    );
+                }
+                lattice_mcp::McpConnectionState::Failed => {
+                    warn!(
+                        server = %snapshot.name,
+                        transport = %snapshot.transport,
+                        detail = %snapshot.detail,
+                        "MCP server failed to connect"
+                    );
+                }
+                lattice_mcp::McpConnectionState::Pending => {
+                    info!(server = %snapshot.name, "MCP server pending");
+                }
+            }
+        }
+    }
+    let tools = Arc::new(tools);
     let control_loop = ControlLoop::with_options(
         store.clone(),
         llm,


### PR DESCRIPTION
﻿## 说明

这条 PR 用来把 MCP 堆叠分支真正收口到 `main`。

包含内容：

- `#88` MCP resource tools 与状态快照
- `#89` `real-agent` / `lattice-server` 运行时接入 MCP 配置
- `#92` server API / Web Console 的 MCP 可见性
- `#93` 远端 `http` / `ws` transport 与基础认证配置

也就是说，合并后 `main` 将不再只是“有 MCP 基础层和 tool bridge”，而是具备完整的 MCP Client / Host 主链。

## 合并后 main 具备的能力

- 从 `LATTICE_MCP_CONFIG` 加载 MCP 配置
- 支持 `stdio` / `http` / `ws` transport
- 支持 `bearer_token` 与自定义 headers
- 将 MCP tools 注入 `ToolSet`
- 提供 `list_mcp_resources` / `read_mcp_resource`
- `real-agent` / `lattice-server` 启动时自动接入 MCP
- `/health` 与 `/v1/mcp` 暴露 MCP 状态
- Web Console 可查看 MCP server 状态、tools、resources、错误摘要

## 校验

本地已通过：

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p lattice-mcp`
- `cargo test -p lattice-server`

这条 PR 的目标不是新增一块独立功能，而是把已经在堆叠分支里验证通过的 MCP Client 主链收进 `main`。
