### PR TITLE
feat: implement skill system (rebase of #71)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,6 +885,7 @@ dependencies = [
  "lattice-llm-protocol",
  "lattice-runtime",
  "lattice-sandbox-local",
+ "lattice-skill",
  "lattice-store-memory",
  "lattice-tools",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,6 +1028,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "lattice-skill"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "indexmap",
+ "lattice-core",
+ "lattice-runtime",
+ "lattice-store-memory",
+ "lattice-tools",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "lattice-store-memory"
 version = "0.1.0"
 dependencies = [
@@ -1769,6 +1788,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2215,6 +2247,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ members = [
     "crates/runtime",
     "crates/store-memory",
     "crates/sandbox-local",
+    "crates/skill",
     "crates/llm-protocol",
     "crates/llm-anthropic",
     "crates/llm-openai",
@@ -93,3 +94,6 @@ http-body-util = "0.1"
 reqwest = { version = "0.12", features = ["json"] }
 dotenvy = "0.15"
 rmcp = { version = "1.5.0", default-features = false, features = ["client", "server", "macros", "transport-child-process", "transport-io"] }
+serde_yaml = "0.9"
+indexmap = { version = "2", features = ["serde"] }
+tempfile = "3"

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -85,6 +85,7 @@ impl ToolError {
             Self::NotFound(_) => ToolErrorKind::NotFound,
             Self::InvalidParams(_) => ToolErrorKind::InvalidParams,
             Self::ExecutionFailed(_) => ToolErrorKind::ExecutionFailed,
+            Self::MaxDepthExceeded(_) => ToolErrorKind::MaxDepthExceeded,
             Self::Timeout { .. } => ToolErrorKind::Timeout,
             Self::Other(_) => ToolErrorKind::Other,
         }
@@ -174,6 +175,10 @@ mod tests {
         assert_eq!(
             ToolError::ExecutionFailed("segfault".to_string()).kind(),
             ToolErrorKind::ExecutionFailed
+        );
+        assert_eq!(
+            ToolError::MaxDepthExceeded(8).kind(),
+            ToolErrorKind::MaxDepthExceeded
         );
         assert_eq!(
             ToolError::Timeout { timeout_secs: 60 }.kind(),

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -67,6 +67,9 @@ pub enum ToolError {
     /// Tool execution failed.
     #[error("execution failed: {0}")]
     ExecutionFailed(String),
+    /// Maximum skill nesting depth exceeded.
+    #[error("max skill depth {0} exceeded")]
+    MaxDepthExceeded(u32),
     /// Execution timed out.
     #[error("timeout after {timeout_secs}s")]
     Timeout { timeout_secs: u64 },
@@ -146,6 +149,9 @@ mod tests {
 
         let err = ToolError::ExecutionFailed("segfault".to_string());
         assert_eq!(err.to_string(), "execution failed: segfault");
+
+        let err = ToolError::MaxDepthExceeded(8);
+        assert_eq!(err.to_string(), "max skill depth 8 exceeded");
 
         let err = ToolError::Timeout { timeout_secs: 60 };
         assert!(err.to_string().contains("60"));

--- a/crates/core/src/event.rs
+++ b/crates/core/src/event.rs
@@ -37,6 +37,8 @@ pub enum ToolErrorKind {
     InvalidParams,
     /// Tool execution failed after starting.
     ExecutionFailed,
+    /// Skill recursion exceeded the configured depth limit.
+    MaxDepthExceeded,
     /// Tool execution exceeded a timeout.
     Timeout,
     /// Fallback for uncategorized errors.
@@ -50,6 +52,7 @@ impl ToolErrorKind {
             Self::NotFound => "not_found",
             Self::InvalidParams => "invalid_params",
             Self::ExecutionFailed => "execution_failed",
+            Self::MaxDepthExceeded => "max_depth_exceeded",
             Self::Timeout => "timeout",
             Self::Other => "other",
         }

--- a/crates/core/src/event.rs
+++ b/crates/core/src/event.rs
@@ -87,6 +87,16 @@ pub enum EventPayload {
         error: String,
         error_kind: ToolErrorKind,
     },
+    /// A skill was invoked - recorded in the parent session.
+    SkillInvoked {
+        skill_name: String,
+        child_session_id: SessionId,
+    },
+    /// A skill completed - recorded in the parent session.
+    SkillCompleted {
+        skill_name: String,
+        child_session_id: SessionId,
+    },
     /// LLM gave a final answer.
     FinalAnswer { answer: String },
     /// Session state changed.
@@ -146,6 +156,14 @@ mod tests {
             EventPayload::ToolCallError {
                 error: "not found".to_string(),
                 error_kind: ToolErrorKind::NotFound,
+            },
+            EventPayload::SkillInvoked {
+                skill_name: "web-research".to_string(),
+                child_session_id: SessionId::new_v4(),
+            },
+            EventPayload::SkillCompleted {
+                skill_name: "web-research".to_string(),
+                child_session_id: SessionId::new_v4(),
             },
             EventPayload::FinalAnswer {
                 answer: "the answer".to_string(),
@@ -237,5 +255,29 @@ mod tests {
         let json = serde_json::to_string(&payload).unwrap();
         assert!(json.contains(r#""type":"finalAnswer""#));
         assert!(json.contains(r#""answer":"42""#));
+    }
+
+    #[test]
+    fn test_skill_invoked_serde_roundtrip() {
+        let payload = EventPayload::SkillInvoked {
+            skill_name: "web-research".to_string(),
+            child_session_id: SessionId::new_v4(),
+        };
+        let json = serde_json::to_string(&payload).unwrap();
+        let parsed: EventPayload = serde_json::from_str(&json).unwrap();
+        assert_eq!(payload, parsed);
+        assert!(json.contains(r#""type":"skillInvoked""#));
+    }
+
+    #[test]
+    fn test_skill_completed_serde_roundtrip() {
+        let payload = EventPayload::SkillCompleted {
+            skill_name: "web-research".to_string(),
+            child_session_id: SessionId::new_v4(),
+        };
+        let json = serde_json::to_string(&payload).unwrap();
+        let parsed: EventPayload = serde_json::from_str(&json).unwrap();
+        assert_eq!(payload, parsed);
+        assert!(json.contains(r#""type":"skillCompleted""#));
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -39,5 +39,5 @@ pub use event::{Actor, Event, EventId, EventPayload, SessionId, Timestamp, ToolE
 pub use filter::EventFilter;
 pub use llm::{Decision, LLMClient};
 pub use sandbox::{ExecutionResult, Sandbox};
-pub use session::SessionStore;
-pub use tool::{ToolDescription, ToolExecutor};
+pub use session::{ChildSessionInfo, SessionStore};
+pub use tool::{ExecutionContext, ToolDescription, ToolExecutor, MAX_SKILL_DEPTH};

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -1,9 +1,31 @@
 //! Session-related types and the SessionStore trait.
 
+use std::fmt;
+use std::sync::Arc;
+
 use async_trait::async_trait;
 
 use crate::error::StoreError;
-use crate::{Actor, Event, EventFilter, EventId, EventPayload, SessionId};
+use crate::{Actor, Event, EventFilter, EventId, EventPayload, SessionId, Timestamp};
+
+/// Information about a child session.
+#[derive(Clone)]
+pub struct ChildSessionInfo {
+    pub session_id: SessionId,
+    pub store: Arc<dyn SessionStore>,
+    pub skill_name: String,
+    pub created_at: Timestamp,
+}
+
+impl fmt::Debug for ChildSessionInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ChildSessionInfo")
+            .field("session_id", &self.session_id)
+            .field("skill_name", &self.skill_name)
+            .field("created_at", &self.created_at)
+            .finish()
+    }
+}
 
 /// Session store — event log persistence.
 ///
@@ -33,6 +55,19 @@ pub trait SessionStore: Send + Sync {
         session_id: SessionId,
         filter: &EventFilter,
     ) -> Result<Vec<Event>, StoreError>;
+
+    /// Create a child session under the given parent.
+    async fn create_child_session(
+        &self,
+        parent_session_id: SessionId,
+        skill_name: &str,
+    ) -> Result<(SessionId, Arc<dyn SessionStore>), StoreError>;
+
+    /// List all child sessions for a given parent.
+    async fn child_sessions(
+        &self,
+        parent_session_id: SessionId,
+    ) -> Result<Vec<ChildSessionInfo>, StoreError>;
 
     /// Get the latest event id for a session.
     async fn latest_event_id(&self, session_id: SessionId) -> Result<Option<EventId>, StoreError>;

--- a/crates/core/src/tool.rs
+++ b/crates/core/src/tool.rs
@@ -81,6 +81,10 @@ mod tests {
             Ok(SessionId::new_v4())
         }
 
+        async fn delete_session(&self, _session_id: SessionId) -> Result<(), StoreError> {
+            Ok(())
+        }
+
         async fn append_event(
             &self,
             _session_id: SessionId,

--- a/crates/core/src/tool.rs
+++ b/crates/core/src/tool.rs
@@ -1,10 +1,14 @@
 //! Tool-related types and the ToolExecutor trait.
 
+use std::fmt;
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 use crate::error::ToolError;
 use crate::sandbox::ExecutionResult;
+use crate::{EventId, SessionId, SessionStore};
 
 /// Tool description injected to the LLM.
 ///
@@ -19,6 +23,32 @@ pub struct ToolDescription {
     pub parameters_schema: serde_json::Value,
 }
 
+/// Maximum allowed skill nesting depth.
+pub const MAX_SKILL_DEPTH: u32 = 8;
+
+/// Execution context passed to every tool invocation by the ControlLoop.
+#[derive(Clone)]
+pub struct ExecutionContext {
+    /// The session this tool call belongs to.
+    pub session_id: SessionId,
+    /// The event id of the `ToolCallRequested` event that triggered this execution.
+    pub trigger_event_id: EventId,
+    /// The session store for reading and writing correlated events.
+    pub store: Arc<dyn SessionStore>,
+    /// Nesting depth: 0 for the top-level agent, 1 for direct skill children, etc.
+    pub depth: u32,
+}
+
+impl fmt::Debug for ExecutionContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ExecutionContext")
+            .field("session_id", &self.session_id)
+            .field("trigger_event_id", &self.trigger_event_id)
+            .field("depth", &self.depth)
+            .finish()
+    }
+}
+
 /// A tool that can be executed by the agent.
 ///
 /// Implementations can be in-process (file read, HTTP fetch) or delegate
@@ -30,12 +60,67 @@ pub trait ToolExecutor: Send + Sync {
     fn description(&self) -> ToolDescription;
 
     /// Execute the tool with the given parameters.
-    async fn execute(&self, params: serde_json::Value) -> Result<ExecutionResult, ToolError>;
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &ExecutionContext,
+    ) -> Result<ExecutionResult, ToolError>;
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{Actor, ChildSessionInfo, Event, EventFilter, EventPayload, SessionId, StoreError};
+    use async_trait::async_trait;
+
+    struct MockStore;
+
+    #[async_trait]
+    impl SessionStore for MockStore {
+        async fn create_session(&self) -> Result<SessionId, StoreError> {
+            Ok(SessionId::new_v4())
+        }
+
+        async fn append_event(
+            &self,
+            _session_id: SessionId,
+            _payload: EventPayload,
+            _actor: Actor,
+            _parent_event_id: Option<crate::EventId>,
+        ) -> Result<crate::EventId, StoreError> {
+            Ok(crate::EventId::new_v4())
+        }
+
+        async fn get_events(
+            &self,
+            _session_id: SessionId,
+            _filter: &EventFilter,
+        ) -> Result<Vec<Event>, StoreError> {
+            Ok(Vec::new())
+        }
+
+        async fn create_child_session(
+            &self,
+            _parent_session_id: SessionId,
+            _skill_name: &str,
+        ) -> Result<(SessionId, Arc<dyn SessionStore>), StoreError> {
+            Ok((SessionId::new_v4(), Arc::new(MockStore)))
+        }
+
+        async fn child_sessions(
+            &self,
+            _parent_session_id: SessionId,
+        ) -> Result<Vec<ChildSessionInfo>, StoreError> {
+            Ok(Vec::new())
+        }
+
+        async fn latest_event_id(
+            &self,
+            _session_id: SessionId,
+        ) -> Result<Option<crate::EventId>, StoreError> {
+            Ok(None)
+        }
+    }
 
     #[test]
     fn test_tool_description_serde_roundtrip() {
@@ -74,5 +159,23 @@ mod tests {
         assert!(json.contains(r#""name":"echo""#));
         assert!(json.contains(r#""description":"Echo back"#));
         assert!(json.contains(r#""type":"object""#));
+    }
+
+    #[test]
+    fn execution_context_clone() {
+        let ctx = ExecutionContext {
+            session_id: SessionId::new_v4(),
+            trigger_event_id: crate::EventId::new_v4(),
+            store: Arc::new(MockStore),
+            depth: 3,
+        };
+        let cloned = ctx.clone();
+        assert_eq!(cloned.depth, 3);
+        assert_eq!(cloned.session_id, ctx.session_id);
+    }
+
+    #[test]
+    fn max_skill_depth_value() {
+        assert_eq!(MAX_SKILL_DEPTH, 8);
     }
 }

--- a/crates/llm-protocol/src/convert.rs
+++ b/crates/llm-protocol/src/convert.rs
@@ -8,7 +8,8 @@ use crate::request::ToolSpec;
 /// Convert a sequence of Lattice events into LLM conversation messages.
 ///
 /// Maps each relevant event payload to the appropriate message role and
-/// content block. Events like `SessionCreated` and `StateChange` are
+/// content block. Events like `SessionCreated`, skill lifecycle, and
+/// `StateChange` are
 /// skipped as they carry no conversational content.
 pub fn events_to_messages(events: &[Event]) -> Vec<Message> {
     let mut messages: Vec<Message> = Vec::new();
@@ -91,8 +92,12 @@ pub fn events_to_messages(events: &[Event]) -> Vec<Message> {
             EventPayload::FinalAnswer { answer } => {
                 messages.push(Message::text(Role::Assistant, answer.clone()));
             }
-            // SessionCreated and StateChange carry no conversational content.
-            EventPayload::SessionCreated | EventPayload::StateChange { .. } => {}
+            // SessionCreated, skill lifecycle, and StateChange carry no
+            // conversational content.
+            EventPayload::SessionCreated
+            | EventPayload::SkillInvoked { .. }
+            | EventPayload::SkillCompleted { .. }
+            | EventPayload::StateChange { .. } => {}
         }
         i += 1;
     }
@@ -178,6 +183,27 @@ mod tests {
             make_event(EventPayload::SessionCreated),
             make_event(EventPayload::UserMessage {
                 content: "hi".into(),
+            }),
+        ];
+        let messages = events_to_messages(&events);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].role, Role::User);
+    }
+
+    #[test]
+    fn test_skill_lifecycle_events_skipped() {
+        let child_session_id = SessionId::new_v4();
+        let events = vec![
+            make_event(EventPayload::SkillInvoked {
+                skill_name: "research".into(),
+                child_session_id,
+            }),
+            make_event(EventPayload::UserMessage {
+                content: "hi".into(),
+            }),
+            make_event(EventPayload::SkillCompleted {
+                skill_name: "research".into(),
+                child_session_id,
             }),
         ];
         let messages = events_to_messages(&events);

--- a/crates/mcp/src/resource_tools.rs
+++ b/crates/mcp/src/resource_tools.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use lattice_core::{ExecutionResult, ToolDescription, ToolError, ToolExecutor};
+use lattice_core::{ExecutionContext, ExecutionResult, ToolDescription, ToolError, ToolExecutor};
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -32,7 +32,11 @@ impl ToolExecutor for ListMcpResourcesTool {
         }
     }
 
-    async fn execute(&self, params: Value) -> Result<ExecutionResult, ToolError> {
+    async fn execute(
+        &self,
+        params: Value,
+        _ctx: &ExecutionContext,
+    ) -> Result<ExecutionResult, ToolError> {
         validate_noop_params(params)?;
 
         let resources = self.manager.list_resources();
@@ -103,7 +107,11 @@ impl ToolExecutor for ReadMcpResourceTool {
         }
     }
 
-    async fn execute(&self, params: Value) -> Result<ExecutionResult, ToolError> {
+    async fn execute(
+        &self,
+        params: Value,
+        _ctx: &ExecutionContext,
+    ) -> Result<ExecutionResult, ToolError> {
         let parsed: ReadMcpResourceParams = serde_json::from_value(params).map_err(|err| {
             ToolError::InvalidParams(format!("invalid read_mcp_resource arguments: {err}"))
         })?;

--- a/crates/mcp/src/tool_adapter.rs
+++ b/crates/mcp/src/tool_adapter.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use lattice_core::{ExecutionResult, ToolDescription, ToolError, ToolExecutor};
+use lattice_core::{ExecutionContext, ExecutionResult, ToolDescription, ToolError, ToolExecutor};
 use serde_json::Value;
 
 use crate::{McpClientManager, McpToolInfo};
@@ -49,7 +49,11 @@ impl ToolExecutor for McpToolAdapter {
         }
     }
 
-    async fn execute(&self, params: Value) -> Result<ExecutionResult, ToolError> {
+    async fn execute(
+        &self,
+        params: Value,
+        _ctx: &ExecutionContext,
+    ) -> Result<ExecutionResult, ToolError> {
         let output = self
             .manager
             .call_tool(&self.tool_info.server_name, &self.tool_info.name, params)

--- a/crates/mcp/tests/stdio_flow.rs
+++ b/crates/mcp/tests/stdio_flow.rs
@@ -720,7 +720,11 @@ async fn mcp_resource_tools_register_into_toolset_and_execute() {
         .unwrap();
 
     let listed = set
-        .execute("list_mcp_resources", serde_json::json!({}))
+        .execute(
+            "list_mcp_resources",
+            serde_json::json!({}),
+            &mock_execution_context(),
+        )
         .await
         .unwrap();
     assert!(listed.stdout.contains("fixture fixture://readme"));
@@ -732,6 +736,7 @@ async fn mcp_resource_tools_register_into_toolset_and_execute() {
                 "server": "fixture",
                 "uri": "fixture://readme"
             }),
+            &mock_execution_context(),
         )
         .await
         .unwrap();
@@ -755,7 +760,10 @@ async fn list_mcp_resources_handles_empty_servers() {
     manager.connect_all().await;
     let tool = ListMcpResourcesTool::new(Arc::new(manager));
 
-    let result = tool.execute(serde_json::json!({})).await.unwrap();
+    let result = tool
+        .execute(serde_json::json!({}), &mock_execution_context())
+        .await
+        .unwrap();
     assert_eq!(result.stdout, "(no MCP resources)");
 }
 
@@ -764,7 +772,10 @@ async fn list_mcp_resources_rejects_non_object_params() {
     let manager = Arc::new(McpClientManager::new(HashMap::new()));
     let tool = ListMcpResourcesTool::new(manager);
 
-    let err = tool.execute(serde_json::json!(["bad"])).await.unwrap_err();
+    let err = tool
+        .execute(serde_json::json!(["bad"]), &mock_execution_context())
+        .await
+        .unwrap_err();
     assert!(matches!(err, lattice_core::ToolError::InvalidParams(_)));
 }
 
@@ -774,7 +785,10 @@ async fn read_mcp_resource_rejects_invalid_params() {
     let tool = ReadMcpResourceTool::new(manager);
 
     let err = tool
-        .execute(serde_json::json!({ "server": 1, "uri": true }))
+        .execute(
+            serde_json::json!({ "server": 1, "uri": true }),
+            &mock_execution_context(),
+        )
         .await
         .unwrap_err();
     assert!(matches!(err, lattice_core::ToolError::InvalidParams(_)));

--- a/crates/mcp/tests/stdio_flow.rs
+++ b/crates/mcp/tests/stdio_flow.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use lattice_core::ToolExecutor;
+use lattice_core::{ExecutionContext, SessionStore, ToolExecutor};
 use lattice_mcp::{
     load_mcp_manager_from_env, load_mcp_server_configs_from_path, mcp_tool_name,
     register_mcp_tools, ListMcpResourcesTool, McpClientManager, McpConnectionState,
@@ -17,6 +17,71 @@ use rmcp::{
 use tokio::process::Command;
 
 static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+fn mock_execution_context() -> ExecutionContext {
+    use async_trait::async_trait;
+    use lattice_core::{Actor, Event, EventFilter, EventId, EventPayload, SessionId, StoreError};
+
+    struct MockStore;
+
+    #[async_trait]
+    impl SessionStore for MockStore {
+        async fn create_session(&self) -> Result<SessionId, StoreError> {
+            Ok(SessionId::new_v4())
+        }
+
+        async fn delete_session(&self, _session_id: SessionId) -> Result<(), StoreError> {
+            Ok(())
+        }
+
+        async fn append_event(
+            &self,
+            _session_id: SessionId,
+            _payload: EventPayload,
+            _actor: Actor,
+            _parent_event_id: Option<EventId>,
+        ) -> Result<EventId, StoreError> {
+            Ok(EventId::new_v4())
+        }
+
+        async fn get_events(
+            &self,
+            _session_id: SessionId,
+            _filter: &EventFilter,
+        ) -> Result<Vec<Event>, StoreError> {
+            Ok(Vec::new())
+        }
+
+        async fn create_child_session(
+            &self,
+            _parent_session_id: SessionId,
+            _skill_name: &str,
+        ) -> Result<(SessionId, Arc<dyn SessionStore>), StoreError> {
+            Ok((SessionId::new_v4(), Arc::new(MockStore)))
+        }
+
+        async fn child_sessions(
+            &self,
+            _parent_session_id: SessionId,
+        ) -> Result<Vec<lattice_core::ChildSessionInfo>, StoreError> {
+            Ok(Vec::new())
+        }
+
+        async fn latest_event_id(
+            &self,
+            _session_id: SessionId,
+        ) -> Result<Option<EventId>, StoreError> {
+            Ok(None)
+        }
+    }
+
+    ExecutionContext {
+        session_id: SessionId::new_v4(),
+        trigger_event_id: EventId::new_v4(),
+        store: Arc::new(MockStore),
+        depth: 0,
+    }
+}
 
 fn fixture_binary(name: &str) -> String {
     let key = format!("CARGO_BIN_EXE_{name}");
@@ -624,6 +689,7 @@ async fn mcp_tool_adapter_registers_into_toolset_and_executes() {
         .execute(
             &mcp_tool_name("fixture", "hello"),
             serde_json::json!({ "name": "bridge" }),
+            &mock_execution_context(),
         )
         .await
         .unwrap();

--- a/crates/runtime/src/control_loop.rs
+++ b/crates/runtime/src/control_loop.rs
@@ -3,7 +3,8 @@
 use std::sync::Arc;
 
 use lattice_core::{
-    Actor, Decision, Event, EventFilter, EventPayload, LLMClient, SessionId, SessionStore,
+    Actor, Decision, Event, EventFilter, EventPayload, ExecutionContext, LLMClient, SessionId,
+    SessionStore,
 };
 use tracing::{info, instrument, warn};
 
@@ -24,6 +25,87 @@ pub struct ControlLoop {
     tools: Arc<ToolSet>,
     system_prompt: String,
     max_iterations: usize,
+    depth: u32,
+}
+
+/// Fluent builder for [`ControlLoop`].
+pub struct ControlLoopBuilder {
+    store: Option<Arc<dyn SessionStore>>,
+    llm: Option<Arc<dyn LLMClient>>,
+    tools: Option<Arc<ToolSet>>,
+    system_prompt: Option<String>,
+    max_iterations: Option<usize>,
+    depth: Option<u32>,
+}
+
+impl Default for ControlLoopBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ControlLoopBuilder {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            store: None,
+            llm: None,
+            tools: None,
+            system_prompt: None,
+            max_iterations: None,
+            depth: None,
+        }
+    }
+
+    #[must_use]
+    pub fn store(mut self, store: Arc<dyn SessionStore>) -> Self {
+        self.store = Some(store);
+        self
+    }
+
+    #[must_use]
+    pub fn llm(mut self, llm: Arc<dyn LLMClient>) -> Self {
+        self.llm = Some(llm);
+        self
+    }
+
+    #[must_use]
+    pub fn tools(mut self, tools: Arc<ToolSet>) -> Self {
+        self.tools = Some(tools);
+        self
+    }
+
+    #[must_use]
+    pub fn system_prompt(mut self, prompt: impl Into<String>) -> Self {
+        self.system_prompt = Some(prompt.into());
+        self
+    }
+
+    #[must_use]
+    pub fn max_iterations(mut self, max_iterations: usize) -> Self {
+        self.max_iterations = Some(max_iterations);
+        self
+    }
+
+    #[must_use]
+    pub fn depth(mut self, depth: u32) -> Self {
+        self.depth = Some(depth);
+        self
+    }
+
+    #[must_use]
+    pub fn build(self) -> ControlLoop {
+        ControlLoop {
+            store: self.store.expect("store required"),
+            llm: self.llm.expect("llm required"),
+            tools: self.tools.expect("tools required"),
+            system_prompt: self
+                .system_prompt
+                .unwrap_or_else(|| "You are a helpful agent.".to_string()),
+            max_iterations: self.max_iterations.unwrap_or(DEFAULT_MAX_ITERATIONS),
+            depth: self.depth.unwrap_or(0),
+        }
+    }
 }
 
 impl ControlLoop {
@@ -39,6 +121,7 @@ impl ControlLoop {
             tools,
             system_prompt: "You are a helpful agent.".to_string(),
             max_iterations: DEFAULT_MAX_ITERATIONS,
+            depth: 0,
         }
     }
 
@@ -57,7 +140,14 @@ impl ControlLoop {
             tools,
             system_prompt,
             max_iterations,
+            depth: 0,
         }
+    }
+
+    /// Create a builder for configuring a control loop.
+    #[must_use]
+    pub fn builder() -> ControlLoopBuilder {
+        ControlLoopBuilder::new()
     }
 
     /// Get a reference to the session store.
@@ -160,8 +250,103 @@ impl ControlLoop {
                         },
                         parent_event_id: events.last().map(|e| e.event_id),
                     });
-                    self.execute_tool_call(session_id, tool, params, &mut events)
-                        .await?;
+
+                    let parent_id = events.last().map(|e| e.event_id);
+                    let req_event_id = self
+                        .store
+                        .append_event(
+                            session_id,
+                            EventPayload::ToolCallRequested {
+                                tool: tool.clone(),
+                                params: params.clone(),
+                            },
+                            Actor::LLM,
+                            parent_id,
+                        )
+                        .await
+                        .map_err(|e| anyhow::anyhow!("{e}"))?;
+                    events.push(Event {
+                        event_id: req_event_id,
+                        session_id,
+                        timestamp: chrono::Utc::now(),
+                        actor: Actor::LLM,
+                        payload: EventPayload::ToolCallRequested {
+                            tool: tool.clone(),
+                            params: params.clone(),
+                        },
+                        parent_event_id: parent_id,
+                    });
+
+                    let ctx = ExecutionContext {
+                        session_id,
+                        trigger_event_id: req_event_id,
+                        store: Arc::clone(&self.store),
+                        depth: self.depth,
+                    };
+
+                    info!("executing tool: {}", tool);
+                    match self.tools.execute(&tool, params, &ctx).await {
+                        Ok(result) => {
+                            info!("tool execution succeeded: exit_code={}", result.exit_code);
+                            let result_event_id = self
+                                .store
+                                .append_event(
+                                    session_id,
+                                    EventPayload::ToolCallResult {
+                                        stdout: result.stdout.clone(),
+                                        stderr: result.stderr.clone(),
+                                        exit_code: result.exit_code,
+                                    },
+                                    Actor::Sandbox,
+                                    Some(req_event_id),
+                                )
+                                .await
+                                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+                            events.push(Event {
+                                event_id: result_event_id,
+                                session_id,
+                                timestamp: chrono::Utc::now(),
+                                actor: Actor::Sandbox,
+                                payload: EventPayload::ToolCallResult {
+                                    stdout: result.stdout,
+                                    stderr: result.stderr,
+                                    exit_code: result.exit_code,
+                                },
+                                parent_event_id: Some(req_event_id),
+                            });
+                        }
+                        Err(e) => {
+                            warn!("tool execution failed: {}", e);
+                            let error_str = e.to_string();
+                            let error_kind = e.kind();
+                            let error_event_id = self
+                                .store
+                                .append_event(
+                                    session_id,
+                                    EventPayload::ToolCallError {
+                                        error: error_str.clone(),
+                                        error_kind,
+                                    },
+                                    Actor::Sandbox,
+                                    Some(req_event_id),
+                                )
+                                .await
+                                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+                            events.push(Event {
+                                event_id: error_event_id,
+                                session_id,
+                                timestamp: chrono::Utc::now(),
+                                actor: Actor::Sandbox,
+                                payload: EventPayload::ToolCallError {
+                                    error: error_str,
+                                    error_kind,
+                                },
+                                parent_event_id: Some(req_event_id),
+                            });
+                        }
+                    }
                     info!("tool call completed, continuing loop");
                 }
                 Decision::MultiToolCall { calls } => {
@@ -203,8 +388,18 @@ impl ControlLoop {
                     // 2. Execute all tools sequentially, recording results or errors
                     for (call, req_event_id) in calls.iter().zip(request_ids) {
                         info!("executing tool: {}", call.tool);
+                        let ctx = ExecutionContext {
+                            session_id,
+                            trigger_event_id: req_event_id,
+                            store: Arc::clone(&self.store),
+                            depth: self.depth,
+                        };
 
-                        match self.tools.execute(&call.tool, call.params.clone()).await {
+                        match self
+                            .tools
+                            .execute(&call.tool, call.params.clone(), &ctx)
+                            .await
+                        {
                             Ok(result) => {
                                 info!("tool execution succeeded: exit_code={}", result.exit_code);
                                 let result_event_id = self
@@ -423,8 +618,8 @@ mod tests {
 
     use async_trait::async_trait;
     use lattice_core::{
-        Actor, Decision, Event, EventFilter, EventPayload, ExecutionResult, LLMClient, LLMError,
-        SessionId, SessionStore, ToolDescription,
+        Actor, ChildSessionInfo, Decision, Event, EventFilter, EventPayload, ExecutionContext,
+        ExecutionResult, LLMClient, LLMError, SessionId, SessionStore, ToolDescription,
     };
 
     use lattice_core::ToolError;
@@ -513,6 +708,21 @@ mod tests {
             }
             Ok(result)
         }
+        async fn create_child_session(
+            &self,
+            _parent_session_id: SessionId,
+            _skill_name: &str,
+        ) -> Result<(SessionId, Arc<dyn SessionStore>), lattice_core::error::StoreError> {
+            let child = Arc::new(TestStore::new());
+            let child_id = child.create_session().await?;
+            Ok((child_id, child))
+        }
+        async fn child_sessions(
+            &self,
+            _parent_session_id: SessionId,
+        ) -> Result<Vec<ChildSessionInfo>, lattice_core::error::StoreError> {
+            Ok(Vec::new())
+        }
         async fn latest_event_id(
             &self,
             session_id: SessionId,
@@ -583,7 +793,11 @@ mod tests {
             }
         }
 
-        async fn execute(&self, _params: serde_json::Value) -> Result<ExecutionResult, ToolError> {
+        async fn execute(
+            &self,
+            _params: serde_json::Value,
+            _ctx: &ExecutionContext,
+        ) -> Result<ExecutionResult, ToolError> {
             Ok(ExecutionResult {
                 stdout: "ok".to_string(),
                 stderr: String::new(),
@@ -612,6 +826,7 @@ mod tests {
             async fn execute(
                 &self,
                 _params: serde_json::Value,
+                _ctx: &ExecutionContext,
             ) -> Result<ExecutionResult, ToolError> {
                 Ok(ExecutionResult {
                     stdout: "noop executed".into(),
@@ -901,6 +1116,113 @@ mod tests {
         assert_eq!(result, "done");
     }
 
+    #[test]
+    fn builder_default_depth_is_zero() {
+        let loop_ = crate::ControlLoop::builder()
+            .store(Arc::new(TestStore::new()))
+            .llm(Arc::new(TestLLM::new(Decision::FinalAnswer {
+                answer: "x".into(),
+            })))
+            .tools(Arc::new(ToolSet::new()))
+            .build();
+        assert_eq!(loop_.depth, 0);
+    }
+
+    #[test]
+    fn builder_depth_override() {
+        let loop_ = crate::ControlLoop::builder()
+            .store(Arc::new(TestStore::new()))
+            .llm(Arc::new(TestLLM::new(Decision::FinalAnswer {
+                answer: "x".into(),
+            })))
+            .tools(Arc::new(ToolSet::new()))
+            .depth(3)
+            .build();
+        assert_eq!(loop_.depth, 3);
+    }
+
+    #[tokio::test]
+    async fn execution_context_passed_to_tool() {
+        static CAPTURED_CTX: std::sync::OnceLock<ExecutionContext> = std::sync::OnceLock::new();
+
+        struct CapturingTool;
+
+        #[async_trait]
+        impl ToolExecutor for CapturingTool {
+            fn description(&self) -> ToolDescription {
+                ToolDescription {
+                    name: "capture".into(),
+                    description: "captures ctx".into(),
+                    parameters_schema: serde_json::json!({}),
+                }
+            }
+
+            async fn execute(
+                &self,
+                _params: serde_json::Value,
+                ctx: &ExecutionContext,
+            ) -> Result<ExecutionResult, ToolError> {
+                let _ = CAPTURED_CTX.set(ctx.clone());
+                Ok(ExecutionResult {
+                    stdout: "ok".into(),
+                    stderr: String::new(),
+                    exit_code: 0,
+                })
+            }
+        }
+
+        struct TwoStepLLM(Arc<Mutex<bool>>);
+
+        impl TwoStepLLM {
+            fn new() -> Self {
+                Self(Arc::new(Mutex::new(false)))
+            }
+        }
+
+        #[async_trait]
+        impl LLMClient for TwoStepLLM {
+            async fn decide(
+                &self,
+                _history: &[Event],
+                _available_tools: &[ToolDescription],
+                _system_prompt: &str,
+            ) -> Result<Decision, LLMError> {
+                let mut called = self.0.lock().unwrap();
+                if !*called {
+                    *called = true;
+                    Ok(Decision::ToolCall {
+                        tool: "capture".into(),
+                        params: serde_json::json!({}),
+                    })
+                } else {
+                    Ok(Decision::FinalAnswer {
+                        answer: "done".into(),
+                    })
+                }
+            }
+        }
+
+        let session_id = SessionId::new_v4();
+        let store = Arc::new(TestStore::new());
+        insert_test_session(&store, session_id);
+
+        let mut tools = ToolSet::new();
+        tools.register(CapturingTool).unwrap();
+
+        let loop_ = crate::ControlLoop::builder()
+            .store(store)
+            .llm(Arc::new(TwoStepLLM::new()))
+            .tools(Arc::new(tools))
+            .depth(5)
+            .build();
+
+        loop_.run(session_id).await.unwrap();
+
+        let ctx = CAPTURED_CTX.get().expect("ctx was captured");
+        assert_eq!(ctx.depth, 5);
+        assert_eq!(ctx.session_id, session_id);
+    }
+
     #[tokio::test]
     async fn test_store_get_events_error_returns_error_event() {
         let session_id = SessionId::new_v4();
@@ -957,6 +1279,22 @@ mod tests {
                 filter: &EventFilter,
             ) -> Result<Vec<Event>, lattice_core::error::StoreError> {
                 self.inner.get_events(session_id, filter).await
+            }
+            async fn create_child_session(
+                &self,
+                parent_session_id: SessionId,
+                skill_name: &str,
+            ) -> Result<(SessionId, Arc<dyn SessionStore>), lattice_core::error::StoreError>
+            {
+                self.inner
+                    .create_child_session(parent_session_id, skill_name)
+                    .await
+            }
+            async fn child_sessions(
+                &self,
+                parent_session_id: SessionId,
+            ) -> Result<Vec<ChildSessionInfo>, lattice_core::error::StoreError> {
+                self.inner.child_sessions(parent_session_id).await
             }
             async fn latest_event_id(
                 &self,
@@ -1066,6 +1404,24 @@ mod tests {
                 // Increment call counter
                 *self.get_events_call_count.lock().unwrap() += 1;
                 self.inner.get_events(session_id, filter).await
+            }
+
+            async fn create_child_session(
+                &self,
+                parent_session_id: SessionId,
+                skill_name: &str,
+            ) -> Result<(SessionId, Arc<dyn SessionStore>), lattice_core::error::StoreError>
+            {
+                self.inner
+                    .create_child_session(parent_session_id, skill_name)
+                    .await
+            }
+
+            async fn child_sessions(
+                &self,
+                parent_session_id: SessionId,
+            ) -> Result<Vec<ChildSessionInfo>, lattice_core::error::StoreError> {
+                self.inner.child_sessions(parent_session_id).await
             }
 
             async fn latest_event_id(

--- a/crates/runtime/src/control_loop.rs
+++ b/crates/runtime/src/control_loop.rs
@@ -545,7 +545,13 @@ impl ControlLoop {
         });
 
         info!("executing tool: {}", tool);
-        match self.tools.execute(&tool, params).await {
+        let ctx = ExecutionContext {
+            session_id,
+            trigger_event_id: req_event_id,
+            store: Arc::clone(&self.store),
+            depth: self.depth,
+        };
+        match self.tools.execute(&tool, params, &ctx).await {
             Ok(result) => {
                 info!("tool execution succeeded: exit_code={}", result.exit_code);
                 let result_event_id = self

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -26,4 +26,4 @@
 
 mod control_loop;
 
-pub use control_loop::ControlLoop;
+pub use control_loop::{ControlLoop, ControlLoopBuilder};

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -689,6 +689,8 @@ async fn get_status(
             lattice_core::EventPayload::ToolCallResult { .. } => "toolCallResult",
             lattice_core::EventPayload::ToolCallError { .. } => "toolCallError",
             lattice_core::EventPayload::FinalAnswer { .. } => "finalAnswer",
+            lattice_core::EventPayload::SkillInvoked { .. } => "skillInvoked",
+            lattice_core::EventPayload::SkillCompleted { .. } => "skillCompleted",
             lattice_core::EventPayload::StateChange { .. } => "stateChange",
         };
         LatestEventInfo {
@@ -768,6 +770,8 @@ fn payload_type_from_query(event_type: &str) -> Option<&'static str> {
         "toolCallRequested" => Some("toolCallRequested"),
         "toolCallResult" => Some("toolCallResult"),
         "toolCallError" => Some("toolCallError"),
+        "skillInvoked" => Some("skillInvoked"),
+        "skillCompleted" => Some("skillCompleted"),
         "finalAnswer" => Some("finalAnswer"),
         "stateChange" => Some("stateChange"),
         _ => None,

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -548,6 +548,29 @@ mod tests {
             Ok(events)
         }
 
+        async fn create_child_session(
+            &self,
+            parent_session_id: SessionId,
+            _skill_name: &str,
+        ) -> Result<(SessionId, Arc<dyn lattice_core::SessionStore>), StoreError> {
+            if parent_session_id != self.session_id {
+                return Err(StoreError::SessionNotFound(parent_session_id));
+            }
+
+            panic!("create_child_session not used in this test")
+        }
+
+        async fn child_sessions(
+            &self,
+            parent_session_id: SessionId,
+        ) -> Result<Vec<lattice_core::ChildSessionInfo>, StoreError> {
+            if parent_session_id != self.session_id {
+                return Err(StoreError::SessionNotFound(parent_session_id));
+            }
+
+            Ok(Vec::new())
+        }
+
         async fn latest_event_id(
             &self,
             session_id: SessionId,

--- a/crates/server/src/streaming.rs
+++ b/crates/server/src/streaming.rs
@@ -4,7 +4,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use lattice_core::{Actor, Event, EventFilter, EventId, EventPayload, SessionId, SessionStore};
+use lattice_core::{
+    Actor, ChildSessionInfo, Event, EventFilter, EventId, EventPayload, SessionId, SessionStore,
+};
 use tokio::sync::{broadcast, RwLock};
 
 /// Per-session in-process event channels.
@@ -129,6 +131,23 @@ impl SessionStore for NotifyingStore {
         session_id: SessionId,
     ) -> Result<Option<EventId>, lattice_core::StoreError> {
         self.inner.latest_event_id(session_id).await
+    }
+
+    async fn create_child_session(
+        &self,
+        parent_session_id: SessionId,
+        skill_name: &str,
+    ) -> Result<(SessionId, Arc<dyn SessionStore>), lattice_core::StoreError> {
+        self.inner
+            .create_child_session(parent_session_id, skill_name)
+            .await
+    }
+
+    async fn child_sessions(
+        &self,
+        parent_session_id: SessionId,
+    ) -> Result<Vec<ChildSessionInfo>, lattice_core::StoreError> {
+        self.inner.child_sessions(parent_session_id).await
     }
 }
 

--- a/crates/skill/Cargo.toml
+++ b/crates/skill/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "lattice-skill"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+lattice-core = { path = "../core" }
+lattice-tools = { path = "../tools" }
+lattice-runtime = { path = "../runtime" }
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+indexmap = { workspace = true }
+tokio = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+lattice-store-memory = { path = "../store-memory" }
+tempfile = { workspace = true }

--- a/crates/skill/src/definition.rs
+++ b/crates/skill/src/definition.rs
@@ -1,0 +1,133 @@
+//! Skill definition parsed from `SKILL.md`.
+
+use indexmap::IndexMap;
+use serde::Deserialize;
+
+/// Parsed from SKILL.md YAML frontmatter.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SkillDefinition {
+    pub name: String,
+    pub description: String,
+    pub compatibility: Option<String>,
+    #[serde(rename = "allowed-tools")]
+    pub allowed_tools: Option<Vec<String>>,
+    pub metadata: Option<SkillMetadata>,
+    #[serde(rename = "x-lattice")]
+    pub lattice: Option<LatticeExtension>,
+}
+
+/// Standard metadata fields.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SkillMetadata {
+    pub author: Option<String>,
+    pub version: Option<String>,
+    pub tags: Option<Vec<String>>,
+    #[serde(rename = "short-description")]
+    pub short_description: Option<String>,
+}
+
+/// Lattice-specific extensions under the `x-lattice` namespace.
+#[derive(Debug, Clone, Deserialize)]
+pub struct LatticeExtension {
+    pub params: Option<IndexMap<String, ParamSchema>>,
+}
+
+/// Schema for a skill input parameter.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ParamSchema {
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub description: Option<String>,
+    pub required: Option<bool>,
+    pub default: Option<serde_json::Value>,
+}
+
+impl SkillDefinition {
+    /// Validate the definition after parsing.
+    pub fn validate(&self) -> Result<(), SkillValidationError> {
+        if self.name.trim().is_empty() {
+            return Err(SkillValidationError::MissingField("name".into()));
+        }
+        if self.name.len() > 64 {
+            return Err(SkillValidationError::FieldTooLong {
+                field: "name".into(),
+                max: 64,
+                actual: self.name.len(),
+            });
+        }
+        if self.description.trim().is_empty() {
+            return Err(SkillValidationError::MissingField("description".into()));
+        }
+        if self.description.len() > 1024 {
+            return Err(SkillValidationError::FieldTooLong {
+                field: "description".into(),
+                max: 1024,
+                actual: self.description.len(),
+            });
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SkillValidationError {
+    #[error("missing required field: {0}")]
+    MissingField(String),
+    #[error("field '{field}' exceeds max length {max} (got {actual})")]
+    FieldTooLong {
+        field: String,
+        max: usize,
+        actual: usize,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn definition() -> SkillDefinition {
+        SkillDefinition {
+            name: "web-research".into(),
+            description: "Research the web".into(),
+            compatibility: None,
+            allowed_tools: None,
+            metadata: None,
+            lattice: None,
+        }
+    }
+
+    #[test]
+    fn validate_ok() {
+        definition().validate().unwrap();
+    }
+
+    #[test]
+    fn validate_rejects_empty_name() {
+        let mut def = definition();
+        def.name.clear();
+        assert!(matches!(
+            def.validate().unwrap_err(),
+            SkillValidationError::MissingField(field) if field == "name"
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_long_name() {
+        let mut def = definition();
+        def.name = "a".repeat(65);
+        assert!(matches!(
+            def.validate().unwrap_err(),
+            SkillValidationError::FieldTooLong { field, .. } if field == "name"
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_long_description() {
+        let mut def = definition();
+        def.description = "a".repeat(1025);
+        assert!(matches!(
+            def.validate().unwrap_err(),
+            SkillValidationError::FieldTooLong { field, .. } if field == "description"
+        ));
+    }
+}

--- a/crates/skill/src/lib.rs
+++ b/crates/skill/src/lib.rs
@@ -1,0 +1,13 @@
+//! Skill system for Lattice.
+
+mod definition;
+mod loader;
+mod tool;
+mod tool_set;
+
+pub use definition::{
+    LatticeExtension, ParamSchema, SkillDefinition, SkillMetadata, SkillValidationError,
+};
+pub use loader::{parse_skill_md, SkillLoadError, SkillLoader};
+pub use tool::SkillTool;
+pub use tool_set::SkillToolSet;

--- a/crates/skill/src/loader.rs
+++ b/crates/skill/src/loader.rs
@@ -1,0 +1,215 @@
+//! Skill loader scanning `skills/` directories.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use lattice_core::LLMClient;
+use lattice_tools::ToolSet;
+use tracing::warn;
+
+use crate::definition::{SkillDefinition, SkillValidationError};
+use crate::tool::SkillTool;
+
+/// Loads skills from a directory on the filesystem.
+pub struct SkillLoader {
+    skills_dir: PathBuf,
+}
+
+impl SkillLoader {
+    #[must_use]
+    pub fn new(skills_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            skills_dir: skills_dir.into(),
+        }
+    }
+
+    /// Scan `skills_dir`, load every subdirectory containing a `SKILL.md`.
+    pub async fn load_all(
+        &self,
+        parent_tools: Arc<ToolSet>,
+        llm: Arc<dyn LLMClient>,
+    ) -> Vec<SkillTool> {
+        let mut skills = Vec::new();
+        let mut entries = match tokio::fs::read_dir(&self.skills_dir).await {
+            Ok(entries) => entries,
+            Err(error) => {
+                warn!(
+                    "skills directory not found or unreadable: {:?}: {}",
+                    self.skills_dir, error
+                );
+                return skills;
+            }
+        };
+
+        loop {
+            match entries.next_entry().await {
+                Ok(Some(entry)) => {
+                    let path = entry.path();
+                    if !path.is_dir() {
+                        continue;
+                    }
+                    match self
+                        .load_one(&path, Arc::clone(&parent_tools), Arc::clone(&llm))
+                        .await
+                    {
+                        Ok(skill) => skills.push(skill),
+                        Err(error) => warn!("skipping skill at {:?}: {}", path, error),
+                    }
+                }
+                Ok(None) => break,
+                Err(error) => {
+                    warn!(
+                        "error reading skills directory {:?}: {}",
+                        self.skills_dir, error
+                    );
+                    break;
+                }
+            }
+        }
+
+        skills
+    }
+
+    pub async fn load_one(
+        &self,
+        dir: &Path,
+        parent_tools: Arc<ToolSet>,
+        llm: Arc<dyn LLMClient>,
+    ) -> Result<SkillTool, SkillLoadError> {
+        let skill_md_path = dir.join("SKILL.md");
+        let raw = tokio::fs::read_to_string(&skill_md_path)
+            .await
+            .map_err(|error| {
+                if error.kind() == std::io::ErrorKind::NotFound {
+                    SkillLoadError::MissingSkillMd(skill_md_path.clone())
+                } else {
+                    SkillLoadError::Io(error)
+                }
+            })?;
+
+        let (frontmatter, body) = parse_skill_md(&raw)
+            .ok_or_else(|| SkillLoadError::MissingFrontmatter(skill_md_path.clone()))?;
+
+        let definition: SkillDefinition =
+            serde_yaml::from_str(frontmatter).map_err(SkillLoadError::YamlParse)?;
+        definition.validate().map_err(SkillLoadError::Validation)?;
+
+        Ok(SkillTool::new(
+            definition,
+            body.trim().to_string(),
+            parent_tools,
+            llm,
+        ))
+    }
+}
+
+/// Split `"---\nfrontmatter\n---\nbody"` into `(frontmatter, body)`.
+pub fn parse_skill_md(raw: &str) -> Option<(&str, &str)> {
+    let rest = raw.strip_prefix("---\n")?;
+    let end = rest.find("\n---\n")?;
+    Some((&rest[..end], &rest[end + 5..]))
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SkillLoadError {
+    #[error("SKILL.md not found at {0:?}")]
+    MissingSkillMd(PathBuf),
+    #[error("SKILL.md missing YAML frontmatter at {0:?}")]
+    MissingFrontmatter(PathBuf),
+    #[error("validation error: {0}")]
+    Validation(SkillValidationError),
+    #[error("yaml parse error: {0}")]
+    YamlParse(serde_yaml::Error),
+    #[error("io error: {0}")]
+    Io(std::io::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use lattice_core::{Decision, Event, LLMClient, LLMError, ToolDescription, ToolExecutor};
+    use lattice_tools::ToolSet;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    struct StaticLlm;
+
+    #[async_trait]
+    impl LLMClient for StaticLlm {
+        async fn decide(
+            &self,
+            _history: &[Event],
+            _available_tools: &[ToolDescription],
+            _system_prompt: &str,
+        ) -> Result<Decision, LLMError> {
+            Ok(Decision::FinalAnswer {
+                answer: "ok".into(),
+            })
+        }
+    }
+
+    #[test]
+    fn parse_skill_md_splits_frontmatter() {
+        let raw = "---\nname: demo\ndescription: Demo\n---\n# Body";
+        let (frontmatter, body) = parse_skill_md(raw).unwrap();
+        assert!(frontmatter.contains("name: demo"));
+        assert_eq!(body, "# Body");
+    }
+
+    #[test]
+    fn parse_skill_md_missing_frontmatter_returns_none() {
+        assert!(parse_skill_md("# No frontmatter").is_none());
+    }
+
+    #[tokio::test]
+    async fn load_one_missing_skill_md() {
+        let dir = tempdir().unwrap();
+        let loader = SkillLoader::new(dir.path());
+        let result = loader
+            .load_one(dir.path(), Arc::new(ToolSet::new()), Arc::new(StaticLlm))
+            .await;
+        assert!(matches!(result, Err(SkillLoadError::MissingSkillMd(_))));
+    }
+
+    #[tokio::test]
+    async fn load_one_missing_frontmatter() {
+        let dir = tempdir().unwrap();
+        let skill_dir = dir.path().join("demo");
+        std::fs::create_dir(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "# Demo\nbody").unwrap();
+
+        let loader = SkillLoader::new(dir.path());
+        let result = loader
+            .load_one(&skill_dir, Arc::new(ToolSet::new()), Arc::new(StaticLlm))
+            .await;
+        assert!(matches!(result, Err(SkillLoadError::MissingFrontmatter(_))));
+    }
+
+    #[tokio::test]
+    async fn load_all_skips_invalid_skill() {
+        let dir = tempdir().unwrap();
+
+        let valid = dir.path().join("valid");
+        std::fs::create_dir(&valid).unwrap();
+        std::fs::write(
+            valid.join("SKILL.md"),
+            "---\nname: valid\ndescription: Valid skill\n---\nUse this skill.",
+        )
+        .unwrap();
+
+        let invalid = dir.path().join("invalid");
+        std::fs::create_dir(&invalid).unwrap();
+        std::fs::write(invalid.join("SKILL.md"), "# Invalid").unwrap();
+
+        let loader = SkillLoader::new(dir.path());
+        let skills = loader
+            .load_all(Arc::new(ToolSet::new()), Arc::new(StaticLlm))
+            .await;
+
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].description().name, "skill:valid");
+    }
+}

--- a/crates/skill/src/tool.rs
+++ b/crates/skill/src/tool.rs
@@ -1,0 +1,388 @@
+//! Skill tool delegating work to a child control loop.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use lattice_core::{
+    Actor, EventFilter, EventPayload, ExecutionContext, ExecutionResult, LLMClient,
+    ToolDescription, ToolError, ToolExecutor, MAX_SKILL_DEPTH,
+};
+use lattice_runtime::ControlLoop;
+use lattice_tools::ToolSet;
+
+use crate::definition::{ParamSchema, SkillDefinition};
+use crate::tool_set::SkillToolSet;
+
+/// A tool that wraps a skill definition.
+pub struct SkillTool {
+    definition: SkillDefinition,
+    system_prompt: String,
+    parent_tools: Arc<ToolSet>,
+    llm: Arc<dyn LLMClient>,
+}
+
+impl SkillTool {
+    #[must_use]
+    pub fn new(
+        definition: SkillDefinition,
+        system_prompt: String,
+        parent_tools: Arc<ToolSet>,
+        llm: Arc<dyn LLMClient>,
+    ) -> Self {
+        Self {
+            definition,
+            system_prompt,
+            parent_tools,
+            llm,
+        }
+    }
+
+    fn tool_name(&self) -> String {
+        format!("skill:{}", self.definition.name)
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        if let Some(params) = self
+            .definition
+            .lattice
+            .as_ref()
+            .and_then(|lattice| lattice.params.as_ref())
+        {
+            let mut properties = serde_json::Map::new();
+            let mut required = Vec::new();
+
+            for (name, schema) in params {
+                properties.insert(name.clone(), schema_to_json(schema));
+                if schema.required.unwrap_or(false) {
+                    required.push(serde_json::Value::String(name.clone()));
+                }
+            }
+
+            let mut root = serde_json::Map::new();
+            root.insert("type".into(), serde_json::Value::String("object".into()));
+            root.insert("properties".into(), serde_json::Value::Object(properties));
+            root.insert("required".into(), serde_json::Value::Array(required));
+            return serde_json::Value::Object(root);
+        }
+
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "input": {
+                    "type": "string",
+                    "description": "Input to pass to the skill agent"
+                }
+            },
+            "required": ["input"]
+        })
+    }
+
+    fn child_input(&self, params: &serde_json::Value) -> Result<String, ToolError> {
+        if let Some(input) = params.get("input") {
+            return input
+                .as_str()
+                .map(ToOwned::to_owned)
+                .ok_or_else(|| ToolError::InvalidParams("'input' must be a string".into()));
+        }
+
+        if params.is_null() || params == &serde_json::json!({}) {
+            return Ok(String::new());
+        }
+
+        serde_json::to_string(params)
+            .map_err(|e| ToolError::InvalidParams(format!("failed to serialize params: {e}")))
+    }
+
+    fn excluded_parent_tools(&self) -> Vec<String> {
+        let Some(allowed) = self.definition.allowed_tools.as_ref() else {
+            return Vec::new();
+        };
+
+        let allowed: HashSet<_> = allowed.iter().cloned().collect();
+        self.parent_tools
+            .descriptions()
+            .into_iter()
+            .filter(|tool| !allowed.contains(&tool.name))
+            .map(|tool| tool.name)
+            .collect()
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for SkillTool {
+    fn description(&self) -> ToolDescription {
+        ToolDescription {
+            name: self.tool_name(),
+            description: self.definition.description.clone(),
+            parameters_schema: self.parameters_schema(),
+        }
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &ExecutionContext,
+    ) -> Result<ExecutionResult, ToolError> {
+        if ctx.depth >= MAX_SKILL_DEPTH {
+            return Err(ToolError::MaxDepthExceeded(MAX_SKILL_DEPTH));
+        }
+
+        let skill_name = self.definition.name.clone();
+        let (child_session_id, child_store) = ctx
+            .store
+            .create_child_session(ctx.session_id, &skill_name)
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
+
+        ctx.store
+            .append_event(
+                ctx.session_id,
+                EventPayload::SkillInvoked {
+                    skill_name: skill_name.clone(),
+                    child_session_id,
+                },
+                Actor::Harness,
+                Some(ctx.trigger_event_id),
+            )
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
+
+        let input = self.child_input(&params)?;
+        child_store
+            .append_event(
+                child_session_id,
+                EventPayload::UserMessage { content: input },
+                Actor::Harness,
+                None,
+            )
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
+
+        let skill_tool_set = SkillToolSet::build(
+            Arc::clone(&self.parent_tools),
+            Vec::new(),
+            self.excluded_parent_tools(),
+        );
+        let child_tools = Arc::new(
+            skill_tool_set
+                .into_tool_set()
+                .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?,
+        );
+
+        let child_loop = ControlLoop::builder()
+            .store(Arc::clone(&child_store))
+            .llm(Arc::clone(&self.llm))
+            .tools(child_tools)
+            .system_prompt(self.system_prompt.clone())
+            .depth(ctx.depth + 1)
+            .build();
+
+        child_loop
+            .run(child_session_id)
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
+
+        let events = child_store
+            .get_events(child_session_id, &EventFilter::default())
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
+        let answer = events
+            .iter()
+            .find_map(|event| match &event.payload {
+                EventPayload::FinalAnswer { answer } => Some(answer.clone()),
+                _ => None,
+            })
+            .ok_or_else(|| ToolError::ExecutionFailed("skill produced no FinalAnswer".into()))?;
+
+        ctx.store
+            .append_event(
+                ctx.session_id,
+                EventPayload::SkillCompleted {
+                    skill_name,
+                    child_session_id,
+                },
+                Actor::Harness,
+                Some(ctx.trigger_event_id),
+            )
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
+
+        Ok(ExecutionResult {
+            stdout: answer,
+            stderr: String::new(),
+            exit_code: 0,
+        })
+    }
+}
+
+fn schema_to_json(schema: &ParamSchema) -> serde_json::Value {
+    let mut object = serde_json::Map::new();
+    object.insert(
+        "type".into(),
+        serde_json::Value::String(schema.type_.clone()),
+    );
+    if let Some(description) = &schema.description {
+        object.insert(
+            "description".into(),
+            serde_json::Value::String(description.clone()),
+        );
+    }
+    if let Some(default) = &schema.default {
+        object.insert("default".into(), default.clone());
+    }
+    serde_json::Value::Object(object)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use lattice_core::{Decision, Event, LLMClient, LLMError, ToolDescription};
+    use lattice_store_memory::MemoryStore;
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct StaticLlm;
+
+    #[async_trait]
+    impl LLMClient for StaticLlm {
+        async fn decide(
+            &self,
+            _history: &[Event],
+            _available_tools: &[ToolDescription],
+            _system_prompt: &str,
+        ) -> Result<Decision, LLMError> {
+            Ok(Decision::FinalAnswer {
+                answer: "skill answer".into(),
+            })
+        }
+    }
+
+    fn definition() -> SkillDefinition {
+        SkillDefinition {
+            name: "web-research".into(),
+            description: "Research the web".into(),
+            compatibility: None,
+            allowed_tools: None,
+            metadata: None,
+            lattice: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn depth_limit_returns_error() {
+        let store: Arc<dyn lattice_core::SessionStore> = Arc::new(MemoryStore::new());
+        let session_id = store.create_session().await.unwrap();
+        let trigger_event_id = store
+            .append_event(
+                session_id,
+                EventPayload::ToolCallRequested {
+                    tool: "skill:web-research".into(),
+                    params: serde_json::json!({"input":"x"}),
+                },
+                Actor::LLM,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let tool = SkillTool::new(
+            definition(),
+            "You are a skill".into(),
+            Arc::new(ToolSet::new()),
+            Arc::new(StaticLlm),
+        );
+        let ctx = ExecutionContext {
+            session_id,
+            trigger_event_id,
+            store,
+            depth: MAX_SKILL_DEPTH,
+        };
+
+        let err = tool
+            .execute(serde_json::json!({"input":"hello"}), &ctx)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ToolError::MaxDepthExceeded(8)));
+    }
+
+    #[tokio::test]
+    async fn execute_records_parent_and_child_events() {
+        let parent_store: Arc<dyn lattice_core::SessionStore> = Arc::new(MemoryStore::new());
+        let parent_session_id = parent_store.create_session().await.unwrap();
+        let trigger_event_id = parent_store
+            .append_event(
+                parent_session_id,
+                EventPayload::ToolCallRequested {
+                    tool: "skill:web-research".into(),
+                    params: serde_json::json!({"input":"hello"}),
+                },
+                Actor::LLM,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let tool = SkillTool::new(
+            definition(),
+            "You are a skill".into(),
+            Arc::new(ToolSet::new()),
+            Arc::new(StaticLlm),
+        );
+        let ctx = ExecutionContext {
+            session_id: parent_session_id,
+            trigger_event_id,
+            store: Arc::clone(&parent_store),
+            depth: 0,
+        };
+
+        let result = tool
+            .execute(serde_json::json!({"input":"hello"}), &ctx)
+            .await
+            .unwrap();
+        assert_eq!(result.stdout, "skill answer");
+
+        let parent_events = parent_store
+            .get_events(parent_session_id, &EventFilter::default())
+            .await
+            .unwrap();
+        let child_session_id = parent_events
+            .iter()
+            .find_map(|event| match event.payload {
+                EventPayload::SkillInvoked {
+                    child_session_id, ..
+                } => Some(child_session_id),
+                _ => None,
+            })
+            .unwrap();
+
+        assert!(parent_events
+            .iter()
+            .any(|event| matches!(event.payload, EventPayload::SkillInvoked { .. })));
+        assert!(parent_events
+            .iter()
+            .any(|event| matches!(event.payload, EventPayload::SkillCompleted { .. })));
+
+        let children = parent_store
+            .child_sessions(parent_session_id)
+            .await
+            .unwrap();
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0].session_id, child_session_id);
+
+        let child_events = children[0]
+            .store
+            .get_events(child_session_id, &EventFilter::default())
+            .await
+            .unwrap();
+        assert!(child_events
+            .iter()
+            .any(|event| matches!(event.payload, EventPayload::UserMessage { .. })));
+        assert!(child_events
+            .iter()
+            .any(|event| matches!(event.payload, EventPayload::FinalAnswer { .. })));
+    }
+}

--- a/crates/skill/src/tool_set.rs
+++ b/crates/skill/src/tool_set.rs
@@ -1,0 +1,278 @@
+//! Skill tool set supporting inherit/exclude/override.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use lattice_core::{ExecutionContext, ExecutionResult, ToolDescription, ToolError, ToolExecutor};
+use lattice_tools::ToolSet;
+
+/// Tool set visible to a skill.
+pub struct SkillToolSet {
+    inherited: Arc<ToolSet>,
+    own: ToolSet,
+    excluded: HashSet<String>,
+}
+
+impl SkillToolSet {
+    #[must_use]
+    pub fn build(
+        parent: Arc<ToolSet>,
+        own_tools: Vec<Arc<dyn ToolExecutor>>,
+        exclude: Vec<String>,
+    ) -> Self {
+        let mut own = ToolSet::new();
+        for tool in own_tools {
+            own.register_arc(tool)
+                .expect("skill own tool name conflict should be prevented by caller");
+        }
+
+        Self {
+            inherited: parent,
+            own,
+            excluded: exclude.into_iter().collect(),
+        }
+    }
+
+    /// All tool descriptions visible to this skill.
+    #[must_use]
+    pub fn descriptions(&self) -> Vec<ToolDescription> {
+        let mut all: Vec<_> = self
+            .inherited
+            .descriptions()
+            .into_iter()
+            .filter(|d| !self.excluded.contains(&d.name) && !self.own.contains(&d.name))
+            .collect();
+        all.extend(self.own.descriptions());
+        all
+    }
+
+    pub async fn execute(
+        &self,
+        name: &str,
+        params: serde_json::Value,
+        ctx: &ExecutionContext,
+    ) -> Result<ExecutionResult, ToolError> {
+        if self.own.contains(name) {
+            self.own.execute(name, params, ctx).await
+        } else if !self.excluded.contains(name) {
+            self.inherited.execute(name, params, ctx).await
+        } else {
+            Err(ToolError::NotFound(name.to_string()))
+        }
+    }
+
+    /// Materialize the visible tools as a concrete `ToolSet`.
+    pub fn into_tool_set(self) -> Result<ToolSet, ToolError> {
+        let mut merged = ToolSet::new();
+
+        for desc in self.inherited.descriptions() {
+            if self.excluded.contains(&desc.name) || self.own.contains(&desc.name) {
+                continue;
+            }
+            let tool = self
+                .inherited
+                .tool(&desc.name)
+                .ok_or_else(|| ToolError::NotFound(desc.name.clone()))?;
+            merged.register_arc(tool)?;
+        }
+
+        for desc in self.own.descriptions() {
+            let tool = self
+                .own
+                .tool(&desc.name)
+                .ok_or_else(|| ToolError::NotFound(desc.name.clone()))?;
+            merged.register_arc(tool)?;
+        }
+
+        Ok(merged)
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.descriptions().len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use lattice_core::{
+        Actor, ChildSessionInfo, Event, EventFilter, EventPayload, ExecutionContext,
+        ExecutionResult, SessionId, SessionStore, StoreError, ToolDescription, ToolError,
+        ToolExecutor,
+    };
+
+    use super::SkillToolSet;
+    use lattice_tools::ToolSet;
+
+    struct MockStore;
+
+    #[async_trait]
+    impl SessionStore for MockStore {
+        async fn create_session(&self) -> Result<SessionId, StoreError> {
+            Ok(SessionId::new_v4())
+        }
+
+        async fn append_event(
+            &self,
+            _session_id: SessionId,
+            _payload: EventPayload,
+            _actor: Actor,
+            _parent_event_id: Option<lattice_core::EventId>,
+        ) -> Result<lattice_core::EventId, StoreError> {
+            Ok(lattice_core::EventId::new_v4())
+        }
+
+        async fn get_events(
+            &self,
+            _session_id: SessionId,
+            _filter: &EventFilter,
+        ) -> Result<Vec<Event>, StoreError> {
+            Ok(Vec::new())
+        }
+
+        async fn create_child_session(
+            &self,
+            _parent_session_id: SessionId,
+            _skill_name: &str,
+        ) -> Result<(SessionId, Arc<dyn SessionStore>), StoreError> {
+            Ok((SessionId::new_v4(), Arc::new(MockStore)))
+        }
+
+        async fn child_sessions(
+            &self,
+            _parent_session_id: SessionId,
+        ) -> Result<Vec<ChildSessionInfo>, StoreError> {
+            Ok(Vec::new())
+        }
+
+        async fn latest_event_id(
+            &self,
+            _session_id: SessionId,
+        ) -> Result<Option<lattice_core::EventId>, StoreError> {
+            Ok(None)
+        }
+    }
+
+    #[derive(Clone)]
+    struct StaticTool {
+        name: String,
+        output: String,
+    }
+
+    #[async_trait]
+    impl ToolExecutor for StaticTool {
+        fn description(&self) -> ToolDescription {
+            ToolDescription {
+                name: self.name.clone(),
+                description: "tool".into(),
+                parameters_schema: serde_json::json!({}),
+            }
+        }
+
+        async fn execute(
+            &self,
+            _params: serde_json::Value,
+            _ctx: &ExecutionContext,
+        ) -> Result<ExecutionResult, ToolError> {
+            Ok(ExecutionResult {
+                stdout: self.output.clone(),
+                stderr: String::new(),
+                exit_code: 0,
+            })
+        }
+    }
+
+    fn ctx() -> ExecutionContext {
+        ExecutionContext {
+            session_id: SessionId::new_v4(),
+            trigger_event_id: lattice_core::EventId::new_v4(),
+            store: Arc::new(MockStore),
+            depth: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn own_tool_overrides_parent() {
+        let mut parent = ToolSet::new();
+        parent
+            .register(StaticTool {
+                name: "echo".into(),
+                output: "parent".into(),
+            })
+            .unwrap();
+
+        let skill_set = SkillToolSet::build(
+            Arc::new(parent),
+            vec![Arc::new(StaticTool {
+                name: "echo".into(),
+                output: "own".into(),
+            })],
+            vec![],
+        );
+
+        let result = skill_set
+            .execute("echo", serde_json::json!({}), &ctx())
+            .await
+            .unwrap();
+        assert_eq!(result.stdout, "own");
+    }
+
+    #[tokio::test]
+    async fn excluded_tool_returns_not_found() {
+        let mut parent = ToolSet::new();
+        parent
+            .register(StaticTool {
+                name: "grep".into(),
+                output: "parent".into(),
+            })
+            .unwrap();
+
+        let skill_set = SkillToolSet::build(Arc::new(parent), vec![], vec!["grep".into()]);
+        let err = skill_set
+            .execute("grep", serde_json::json!({}), &ctx())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ToolError::NotFound(name) if name == "grep"));
+    }
+
+    #[test]
+    fn descriptions_hide_excluded_and_overridden_tools() {
+        let mut parent = ToolSet::new();
+        parent
+            .register(StaticTool {
+                name: "grep".into(),
+                output: "parent".into(),
+            })
+            .unwrap();
+        parent
+            .register(StaticTool {
+                name: "echo".into(),
+                output: "parent".into(),
+            })
+            .unwrap();
+
+        let skill_set = SkillToolSet::build(
+            Arc::new(parent),
+            vec![Arc::new(StaticTool {
+                name: "echo".into(),
+                output: "own".into(),
+            })],
+            vec!["grep".into()],
+        );
+
+        let names: Vec<_> = skill_set
+            .descriptions()
+            .into_iter()
+            .map(|d| d.name)
+            .collect();
+        assert_eq!(names, vec!["echo".to_string()]);
+    }
+}

--- a/crates/skill/src/tool_set.rs
+++ b/crates/skill/src/tool_set.rs
@@ -120,6 +120,10 @@ mod tests {
             Ok(SessionId::new_v4())
         }
 
+        async fn delete_session(&self, _session_id: SessionId) -> Result<(), StoreError> {
+            Ok(())
+        }
+
         async fn append_event(
             &self,
             _session_id: SessionId,

--- a/crates/store-memory/src/memory_store.rs
+++ b/crates/store-memory/src/memory_store.rs
@@ -1,8 +1,7 @@
 //! In-memory implementation of SessionStore.
 //!
-//! Uses `Arc<RwLock<HashMap<SessionId, Vec<Event>>>>` to support
-//! concurrent access. Data is not persisted — process restarts
-//! will lose all sessions.
+//! Uses `Arc<RwLock<Inner>>` to support concurrent access. Data is not persisted
+//! and process restarts will lose all sessions.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -10,16 +9,20 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use chrono::Utc;
 use lattice_core::{
-    error::StoreError, Actor, Event, EventFilter, EventId, EventPayload, SessionId, SessionStore,
+    error::StoreError, Actor, ChildSessionInfo, Event, EventFilter, EventId, EventPayload,
+    SessionId, SessionStore,
 };
 use tokio::sync::RwLock;
 
+/// Internal state of MemoryStore.
+struct Inner {
+    sessions: HashMap<SessionId, Vec<Event>>,
+    children: HashMap<SessionId, Vec<ChildSessionInfo>>,
+}
+
 /// In-memory session store for development and testing.
-///
-/// Not suitable for production — data is lost on process restart.
 pub struct MemoryStore {
-    /// Session id -> event log.
-    sessions: Arc<RwLock<HashMap<SessionId, Vec<Event>>>>,
+    inner: Arc<RwLock<Inner>>,
 }
 
 impl MemoryStore {
@@ -27,7 +30,18 @@ impl MemoryStore {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            sessions: Arc::new(RwLock::new(HashMap::new())),
+            inner: Arc::new(RwLock::new(Inner {
+                sessions: HashMap::new(),
+                children: HashMap::new(),
+            })),
+        }
+    }
+}
+
+impl Clone for MemoryStore {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
         }
     }
 }
@@ -51,14 +65,15 @@ impl SessionStore for MemoryStore {
             payload: EventPayload::SessionCreated,
             parent_event_id: None,
         };
-        let mut sessions = self.sessions.write().await;
-        sessions.insert(session_id, vec![event]);
+        let mut inner = self.inner.write().await;
+        inner.sessions.insert(session_id, vec![event]);
         Ok(session_id)
     }
 
     async fn delete_session(&self, session_id: SessionId) -> Result<(), StoreError> {
-        let mut sessions = self.sessions.write().await;
-        if sessions.remove(&session_id).is_some() {
+        let mut inner = self.inner.write().await;
+        if inner.sessions.remove(&session_id).is_some() {
+            inner.children.remove(&session_id);
             Ok(())
         } else {
             Err(StoreError::SessionNotFound(session_id))
@@ -82,8 +97,9 @@ impl SessionStore for MemoryStore {
             payload,
             parent_event_id,
         };
-        let mut sessions = self.sessions.write().await;
-        let events = sessions
+        let mut inner = self.inner.write().await;
+        let events = inner
+            .sessions
             .get_mut(&session_id)
             .ok_or(StoreError::SessionNotFound(session_id))?;
         events.push(event);
@@ -96,8 +112,9 @@ impl SessionStore for MemoryStore {
         session_id: SessionId,
         filter: &EventFilter,
     ) -> Result<Vec<Event>, StoreError> {
-        let sessions = self.sessions.read().await;
-        let events = sessions
+        let inner = self.inner.read().await;
+        let events = inner
+            .sessions
             .get(&session_id)
             .ok_or(StoreError::SessionNotFound(session_id))?;
 
@@ -140,10 +157,54 @@ impl SessionStore for MemoryStore {
         Ok(result)
     }
 
+    async fn create_child_session(
+        &self,
+        parent_session_id: SessionId,
+        skill_name: &str,
+    ) -> Result<(SessionId, Arc<dyn SessionStore>), StoreError> {
+        {
+            let inner = self.inner.read().await;
+            if !inner.sessions.contains_key(&parent_session_id) {
+                return Err(StoreError::SessionNotFound(parent_session_id));
+            }
+        }
+
+        let child_store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+        let child_session_id = child_store.create_session().await?;
+        let info = ChildSessionInfo {
+            session_id: child_session_id,
+            store: Arc::clone(&child_store),
+            skill_name: skill_name.to_string(),
+            created_at: Utc::now(),
+        };
+
+        let mut inner = self.inner.write().await;
+        inner
+            .children
+            .entry(parent_session_id)
+            .or_default()
+            .push(info);
+
+        Ok((child_session_id, child_store))
+    }
+
+    async fn child_sessions(
+        &self,
+        parent_session_id: SessionId,
+    ) -> Result<Vec<ChildSessionInfo>, StoreError> {
+        let inner = self.inner.read().await;
+        Ok(inner
+            .children
+            .get(&parent_session_id)
+            .cloned()
+            .unwrap_or_default())
+    }
+
     /// Returns the event id of the most recent event, if any.
     async fn latest_event_id(&self, session_id: SessionId) -> Result<Option<EventId>, StoreError> {
-        let sessions = self.sessions.read().await;
-        let events = sessions
+        let inner = self.inner.read().await;
+        let events = inner
+            .sessions
             .get(&session_id)
             .ok_or(StoreError::SessionNotFound(session_id))?;
         Ok(events.last().map(|e| e.event_id))
@@ -154,7 +215,6 @@ impl SessionStore for MemoryStore {
 mod tests {
     use super::*;
     use chrono::Duration;
-    use lattice_core::EventPayload;
 
     #[tokio::test]
     async fn test_create_session() {
@@ -382,8 +442,8 @@ mod tests {
 
         let base = Utc::now();
         {
-            let mut sessions = store.sessions.write().await;
-            let events = sessions.get_mut(&id).unwrap();
+            let mut inner = store.inner.write().await;
+            let events = inner.sessions.get_mut(&id).unwrap();
             events[0].timestamp = base;
             events[1].timestamp = base + Duration::seconds(10);
             events[2].timestamp = base + Duration::seconds(20);
@@ -410,40 +470,84 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_concurrent_read_write() {
+    async fn create_child_session_returns_independent_store() {
         let store = MemoryStore::new();
-        let id = store.create_session().await.unwrap();
+        let parent_id = store.create_session().await.unwrap();
 
-        // Spawn multiple writers and readers concurrently.
-        let sessions_clone = store.sessions.clone();
-        let handle = tokio::spawn(async move {
-            for _ in 0..10 {
-                let sessions = sessions_clone.read().await;
-                let _count = sessions.get(&id).map(|e| e.len());
-                drop(sessions);
-                tokio::task::yield_now().await;
-            }
-        });
+        let (child_id, child_store) = store
+            .create_child_session(parent_id, "web-research")
+            .await
+            .unwrap();
+
+        assert_ne!(child_id, parent_id);
+
+        child_store
+            .append_event(
+                child_id,
+                EventPayload::UserMessage {
+                    content: "child msg".into(),
+                },
+                Actor::Harness,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let parent_events = store
+            .get_events(parent_id, &EventFilter::default())
+            .await
+            .unwrap();
+        assert_eq!(parent_events.len(), 1);
+        assert!(matches!(
+            parent_events[0].payload,
+            EventPayload::SessionCreated
+        ));
+    }
+
+    #[tokio::test]
+    async fn child_sessions_returns_correct_info() {
+        let store = MemoryStore::new();
+        let parent_id = store.create_session().await.unwrap();
+
+        let (id1, _) = store
+            .create_child_session(parent_id, "skill-a")
+            .await
+            .unwrap();
+        let (id2, _) = store
+            .create_child_session(parent_id, "skill-b")
+            .await
+            .unwrap();
+
+        let children = store.child_sessions(parent_id).await.unwrap();
+        assert_eq!(children.len(), 2);
+        assert!(children.iter().any(|c| c.session_id == id1));
+        assert!(children.iter().any(|c| c.session_id == id2));
+        assert!(children.iter().any(|c| c.skill_name == "skill-a"));
+        assert!(children.iter().any(|c| c.skill_name == "skill-b"));
+    }
+
+    #[tokio::test]
+    async fn multiple_children_accumulated() {
+        let store = MemoryStore::new();
+        let parent_id = store.create_session().await.unwrap();
 
         for i in 0..5 {
             store
-                .append_event(
-                    id,
-                    EventPayload::UserMessage {
-                        content: format!("msg {i}"),
-                    },
-                    Actor::System,
-                    None,
-                )
+                .create_child_session(parent_id, &format!("skill-{i}"))
                 .await
                 .unwrap();
         }
 
-        handle.await.unwrap();
+        let children = store.child_sessions(parent_id).await.unwrap();
+        assert_eq!(children.len(), 5);
+    }
 
-        let events = store.get_events(id, &EventFilter::default()).await.unwrap();
-        // 1 session created + 5 appended
-        assert_eq!(events.len(), 6);
+    #[tokio::test]
+    async fn child_sessions_parent_not_found() {
+        let store = MemoryStore::new();
+        let fake = SessionId::new_v4();
+        let result = store.child_sessions(fake).await.unwrap();
+        assert!(result.is_empty());
     }
 
     #[tokio::test]
@@ -451,7 +555,6 @@ mod tests {
         let store = MemoryStore::new();
         let fake_id = SessionId::new_v4();
         let result = store.get_events(fake_id, &EventFilter::default()).await;
-        assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
             StoreError::SessionNotFound(_)

--- a/crates/tools/src/bash.rs
+++ b/crates/tools/src/bash.rs
@@ -3,7 +3,9 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use lattice_core::{ExecutionResult, Sandbox, ToolDescription, ToolError, ToolExecutor};
+use lattice_core::{
+    ExecutionContext, ExecutionResult, Sandbox, ToolDescription, ToolError, ToolExecutor,
+};
 
 /// Bash tool — delegates command execution to a Sandbox.
 ///
@@ -66,7 +68,11 @@ impl ToolExecutor for BashTool {
         }
     }
 
-    async fn execute(&self, params: serde_json::Value) -> Result<ExecutionResult, ToolError> {
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        _ctx: &ExecutionContext,
+    ) -> Result<ExecutionResult, ToolError> {
         let command = params
             .get("command")
             .and_then(|v| v.as_str())
@@ -89,7 +95,10 @@ mod tests {
     use std::sync::Arc;
 
     use async_trait::async_trait;
-    use lattice_core::{ExecutionResult, Sandbox, SandboxError, ToolError, ToolExecutor};
+    use lattice_core::{
+        Actor, ChildSessionInfo, Event, EventFilter, EventPayload, ExecutionContext,
+        ExecutionResult, Sandbox, SandboxError, SessionId, StoreError, ToolError, ToolExecutor,
+    };
 
     use crate::bash::BashTool;
 
@@ -115,6 +124,64 @@ mod tests {
         }
     }
 
+    struct MockStore;
+
+    #[async_trait]
+    impl lattice_core::SessionStore for MockStore {
+        async fn create_session(&self) -> Result<SessionId, StoreError> {
+            Ok(SessionId::new_v4())
+        }
+
+        async fn append_event(
+            &self,
+            _session_id: SessionId,
+            _payload: EventPayload,
+            _actor: Actor,
+            _parent_event_id: Option<lattice_core::EventId>,
+        ) -> Result<lattice_core::EventId, StoreError> {
+            Ok(lattice_core::EventId::new_v4())
+        }
+
+        async fn get_events(
+            &self,
+            _session_id: SessionId,
+            _filter: &EventFilter,
+        ) -> Result<Vec<Event>, StoreError> {
+            Ok(Vec::new())
+        }
+
+        async fn create_child_session(
+            &self,
+            _parent_session_id: SessionId,
+            _skill_name: &str,
+        ) -> Result<(SessionId, Arc<dyn lattice_core::SessionStore>), StoreError> {
+            Ok((SessionId::new_v4(), Arc::new(MockStore)))
+        }
+
+        async fn child_sessions(
+            &self,
+            _parent_session_id: SessionId,
+        ) -> Result<Vec<ChildSessionInfo>, StoreError> {
+            Ok(Vec::new())
+        }
+
+        async fn latest_event_id(
+            &self,
+            _session_id: SessionId,
+        ) -> Result<Option<lattice_core::EventId>, StoreError> {
+            Ok(None)
+        }
+    }
+
+    fn test_ctx() -> ExecutionContext {
+        ExecutionContext {
+            session_id: SessionId::new_v4(),
+            trigger_event_id: lattice_core::EventId::new_v4(),
+            store: Arc::new(MockStore),
+            depth: 0,
+        }
+    }
+
     #[tokio::test]
     async fn bash_tool_executes_via_sandbox() {
         let sandbox: Arc<dyn Sandbox> = Arc::new(MockSandbox::new(Ok(ExecutionResult {
@@ -125,7 +192,7 @@ mod tests {
         let tool = BashTool::new(sandbox);
 
         let result: ExecutionResult = tool
-            .execute(serde_json::json!({ "command": "echo hello" }))
+            .execute(serde_json::json!({ "command": "echo hello" }), &test_ctx())
             .await
             .unwrap();
         assert_eq!(result.stdout, "hello");
@@ -141,7 +208,7 @@ mod tests {
         })));
         let tool = BashTool::new(sandbox);
 
-        let result = tool.execute(serde_json::json!({})).await;
+        let result = tool.execute(serde_json::json!({}), &test_ctx()).await;
         let err = result.unwrap_err();
         assert!(matches!(err, ToolError::InvalidParams(_)));
         assert!(err.to_string().contains("command"));
@@ -156,7 +223,9 @@ mod tests {
         })));
         let tool = BashTool::new(sandbox);
 
-        let result = tool.execute(serde_json::json!({ "command": 123 })).await;
+        let result = tool
+            .execute(serde_json::json!({ "command": 123 }), &test_ctx())
+            .await;
         let err = result.unwrap_err();
         assert!(matches!(err, ToolError::InvalidParams(_)));
     }
@@ -169,7 +238,7 @@ mod tests {
         let tool = BashTool::new(sandbox);
 
         let result = tool
-            .execute(serde_json::json!({ "command": "sleep 10" }))
+            .execute(serde_json::json!({ "command": "sleep 10" }), &test_ctx())
             .await;
         let err = result.unwrap_err();
         assert!(matches!(err, ToolError::ExecutionFailed(_)));

--- a/crates/tools/src/bash.rs
+++ b/crates/tools/src/bash.rs
@@ -132,6 +132,10 @@ mod tests {
             Ok(SessionId::new_v4())
         }
 
+        async fn delete_session(&self, _session_id: SessionId) -> Result<(), StoreError> {
+            Ok(())
+        }
+
         async fn append_event(
             &self,
             _session_id: SessionId,

--- a/crates/tools/src/set.rs
+++ b/crates/tools/src/set.rs
@@ -176,6 +176,10 @@ mod tests {
             Ok(SessionId::new_v4())
         }
 
+        async fn delete_session(&self, _session_id: SessionId) -> Result<(), StoreError> {
+            Ok(())
+        }
+
         async fn append_event(
             &self,
             _session_id: SessionId,

--- a/crates/tools/src/set.rs
+++ b/crates/tools/src/set.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use lattice_core::{Sandbox, ToolDescription, ToolError, ToolExecutor};
+use lattice_core::{ExecutionContext, Sandbox, ToolDescription, ToolError, ToolExecutor};
 use tracing::instrument;
 
 /// A collection of tools available to the agent.
@@ -12,7 +12,7 @@ use tracing::instrument;
 /// 1. Provide tool descriptions to the LLM (via `descriptions()`)
 /// 2. Route tool calls to the correct executor (via `execute()`)
 pub struct ToolSet {
-    tools: HashMap<String, Box<dyn ToolExecutor>>,
+    tools: HashMap<String, Arc<dyn ToolExecutor>>,
 }
 
 impl Default for ToolSet {
@@ -53,13 +53,23 @@ impl ToolSet {
 
     /// Register a tool. Returns error if a tool with the same name already exists.
     pub fn register(&mut self, tool: impl ToolExecutor + 'static) -> Result<(), ToolError> {
+        self.register_arc(Arc::new(tool))
+    }
+
+    /// Register a boxed tool. Returns error if a tool with the same name already exists.
+    pub fn register_boxed(&mut self, tool: Box<dyn ToolExecutor>) -> Result<(), ToolError> {
+        self.register_arc(Arc::from(tool))
+    }
+
+    /// Register a shared tool instance. Returns error if a tool with the same name already exists.
+    pub fn register_arc(&mut self, tool: Arc<dyn ToolExecutor>) -> Result<(), ToolError> {
         let name = tool.description().name.clone();
         if self.tools.contains_key(&name) {
             return Err(ToolError::Other(format!(
                 "tool '{name}' is already registered"
             )));
         }
-        self.tools.insert(name, Box::new(tool));
+        self.tools.insert(name, tool);
         Ok(())
     }
 
@@ -75,12 +85,19 @@ impl ToolSet {
         &self,
         name: &str,
         params: serde_json::Value,
+        ctx: &ExecutionContext,
     ) -> Result<lattice_core::ExecutionResult, ToolError> {
         let executor = self
             .tools
             .get(name)
             .ok_or_else(|| ToolError::NotFound(name.to_string()))?;
-        executor.execute(params).await
+        executor.execute(params, ctx).await
+    }
+
+    /// Return a shared handle to a registered tool.
+    #[must_use]
+    pub fn tool(&self, name: &str) -> Option<Arc<dyn ToolExecutor>> {
+        self.tools.get(name).cloned()
     }
 
     /// Check if a tool is registered.
@@ -105,7 +122,12 @@ impl ToolSet {
 #[cfg(test)]
 mod tests {
     use async_trait::async_trait;
-    use lattice_core::{ExecutionResult, ToolDescription, ToolError, ToolExecutor};
+    use std::sync::Arc;
+
+    use lattice_core::{
+        Actor, ChildSessionInfo, Event, EventFilter, EventPayload, ExecutionContext,
+        ExecutionResult, SessionId, StoreError, ToolDescription, ToolError, ToolExecutor,
+    };
 
     use crate::ToolSet;
 
@@ -137,8 +159,70 @@ mod tests {
             }
         }
 
-        async fn execute(&self, _params: serde_json::Value) -> Result<ExecutionResult, ToolError> {
+        async fn execute(
+            &self,
+            _params: serde_json::Value,
+            _ctx: &ExecutionContext,
+        ) -> Result<ExecutionResult, ToolError> {
             self.result.clone()
+        }
+    }
+
+    struct MockStore;
+
+    #[async_trait]
+    impl lattice_core::SessionStore for MockStore {
+        async fn create_session(&self) -> Result<SessionId, StoreError> {
+            Ok(SessionId::new_v4())
+        }
+
+        async fn append_event(
+            &self,
+            _session_id: SessionId,
+            _payload: EventPayload,
+            _actor: Actor,
+            _parent_event_id: Option<lattice_core::EventId>,
+        ) -> Result<lattice_core::EventId, StoreError> {
+            Ok(lattice_core::EventId::new_v4())
+        }
+
+        async fn get_events(
+            &self,
+            _session_id: SessionId,
+            _filter: &EventFilter,
+        ) -> Result<Vec<Event>, StoreError> {
+            Ok(Vec::new())
+        }
+
+        async fn create_child_session(
+            &self,
+            _parent_session_id: SessionId,
+            _skill_name: &str,
+        ) -> Result<(SessionId, Arc<dyn lattice_core::SessionStore>), StoreError> {
+            Ok((SessionId::new_v4(), Arc::new(MockStore)))
+        }
+
+        async fn child_sessions(
+            &self,
+            _parent_session_id: SessionId,
+        ) -> Result<Vec<ChildSessionInfo>, StoreError> {
+            Ok(Vec::new())
+        }
+
+        async fn latest_event_id(
+            &self,
+            _session_id: SessionId,
+        ) -> Result<Option<lattice_core::EventId>, StoreError> {
+            Ok(None)
+        }
+    }
+
+    fn test_ctx() -> ExecutionContext {
+        ExecutionContext {
+            session_id: SessionId::new_v4(),
+            trigger_event_id: lattice_core::EventId::new_v4(),
+            store: Arc::new(MockStore),
+            depth: 0,
         }
     }
 
@@ -187,7 +271,8 @@ mod tests {
     fn execute_unknown_tool_returns_not_found() {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let set = ToolSet::new();
-        let result = rt.block_on(set.execute("nonexistent", serde_json::json!({})));
+        let ctx = test_ctx();
+        let result = rt.block_on(set.execute("nonexistent", serde_json::json!({}), &ctx));
         assert!(matches!(result, Err(ToolError::NotFound(_))));
     }
 
@@ -196,7 +281,7 @@ mod tests {
         let set = ToolSet::new();
         // No tools registered — execute returns NotFound.
         let result = set
-            .execute("bash", serde_json::json!({ "command": 123 }))
+            .execute("bash", serde_json::json!({ "command": 123 }), &test_ctx())
             .await;
         assert!(matches!(result, Err(ToolError::NotFound(_))));
     }
@@ -241,7 +326,11 @@ mod tests {
         let mut set = ToolSet::new();
         set.register(tool).unwrap();
 
-        let got = set.execute("success", serde_json::json!({})).await.unwrap();
+        let ctx = test_ctx();
+        let got = set
+            .execute("success", serde_json::json!({}), &ctx)
+            .await
+            .unwrap();
         assert_eq!(got.stdout, "hello world");
         assert_eq!(got.stderr, "err output");
         assert_eq!(got.exit_code, 42);

--- a/examples/real-agent/src/main.rs
+++ b/examples/real-agent/src/main.rs
@@ -213,6 +213,18 @@ async fn run(task: String) -> Result<()> {
             EventPayload::FinalAnswer { answer } => {
                 format!("FinalAnswer: {}", truncate(answer, 80))
             }
+            EventPayload::SkillInvoked {
+                skill_name,
+                child_session_id,
+            } => {
+                format!("SkillInvoked: {skill_name} child={child_session_id}")
+            }
+            EventPayload::SkillCompleted {
+                skill_name,
+                child_session_id,
+            } => {
+                format!("SkillCompleted: {skill_name} child={child_session_id}")
+            }
             EventPayload::StateChange { from, to } => {
                 format!("StateChange: {from} → {to}")
             }


### PR DESCRIPTION
## 背景

这是 PR #71 的 rebase 版本，已解决与最新 main 的冲突。

原 PR #71 因与 main 产生冲突而关闭，本 PR 在最新 main（包含 MCP 集成）基础上重新整合了完整的 skill 系统实现。

## 改动

### 新增 `crates/skill/` 完整实现

- **SkillDefinition**：解析 SKILL.md frontmatter 并做基础校验
- **SkillToolSet**：支持继承/排除/覆盖父工具集
- **SkillTool**：实现 depth 检查、子 session、子 ControlLoop 执行、结果回传、父 session 生命周期事件记录
- **SkillLoader**：从技能目录动态加载，单 skill 失败仅 warn，不会 panic

### 扩展 core/runtime/store/tools

- 新增 `ExecutionContext` 和 `MAX_SKILL_DEPTH = 8`
- `ToolExecutor::execute` 增加运行时上下文参数（破坏性变更）
- `SessionStore` / `MemoryStore` 支持 child session
- `ControlLoopBuilder` 支持 depth 透传
- 新增 `SkillInvoked` / `SkillCompleted` 事件

### 兼容最新 main

- 适配 MCP 工具桥接（`McpToolAdapter` 支持 `ExecutionContext`）
- 适配 SSE 事件流（`NotifyingStore` 支持 child session）
- skill 生命周期事件不会进入 LLM 对话历史
- server / real-agent 能识别新的事件类型

## 设计原则

- `allowed_tools` 的语义按白名单处理：skill 只能看到声明允许的父工具，其余父工具会被排除
- 参考了 OpenHarness 在 skill 加载、注册和子代理调用上的思路，但实现按 Lattice 当前 Rust 架构落地

## 验证

本地已通过：
- ✅ `cargo fmt --all --check`
- ✅ `cargo check --workspace`
- ✅ `cargo test --workspace` - 所有测试通过
- ✅ `cargo clippy --workspace --all-targets --all-features -- -D warnings`

## 关联 Issues

- Closes #51 (20-1: core 层扩展)
- Closes #52 (20-2: SessionStore 树形扩展)
- Closes #53 (20-3: ToolSet + 已有工具适配新签名)
- Closes #54 (20-4: ControlLoop 构造 ExecutionContext)
- Closes #55 (20-5: lattice-skill crate)

## 说明

这次 rebase 没有改变原 PR #71 的核心实现，只是修复了与最新 main 的兼容性问题：
- 修复 `MemoryStore::delete_session` 字段访问
- 为所有 `ToolExecutor` 实现添加 `ExecutionContext` 参数
- 为 `NotifyingStore` 添加 child session 支持
- 为所有测试 MockStore 添加 `delete_session` 方法

🤖 Generated with [Claude Code](https://claude.com/claude-code)