### PR TITLE
feat: add configurable HTTP timeout for LLM clients

### DIFF
--- a/crates/llm-anthropic/src/client.rs
+++ b/crates/llm-anthropic/src/client.rs
@@ -67,6 +67,19 @@ impl AnthropicClient {
         self
     }
 
+    /// Set HTTP request timeout.
+    ///
+    /// Default is 120 seconds. For complex reasoning tasks (e.g., extended thinking),
+    /// you may want to increase this to 180-300 seconds.
+    #[must_use]
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.http = reqwest::Client::builder()
+            .timeout(timeout)
+            .build()
+            .expect("failed to build HTTP client");
+        self
+    }
+
     /// Convert protocol messages to Anthropic format.
     fn to_anthropic_messages(&self, messages: &[Message]) -> Vec<AnthropicMessage> {
         messages

--- a/crates/llm-openai/src/client.rs
+++ b/crates/llm-openai/src/client.rs
@@ -64,6 +64,19 @@ impl OpenAIClient {
         self
     }
 
+    /// Set HTTP request timeout.
+    ///
+    /// Default is 120 seconds. For complex reasoning tasks or slower models,
+    /// you may want to increase this to 180-300 seconds.
+    #[must_use]
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.http = reqwest::Client::builder()
+            .timeout(timeout)
+            .build()
+            .expect("failed to build HTTP client");
+        self
+    }
+
     /// Convert protocol messages to OpenAI format.
     fn to_openai_messages(&self, messages: &[Message], system_prompt: &str) -> Vec<OpenAIMessage> {
         let mut result = Vec::new();


### PR DESCRIPTION
## 问题

LLM 客户端的 HTTP 请求超时硬编码为 120 秒：
- `AnthropicClient` - 120 秒
- `OpenAIClient` - 120 秒

这对某些场景不够灵活：
- 复杂推理任务（如 extended thinking）可能需要 2-3 分钟
- 快速失败场景可能希望更短的超时

## 解决方案

为两个 LLM 客户端添加 `with_timeout()` builder 方法：

```rust
let client = AnthropicClient::new(api_key, model)
    .with_timeout(Duration::from_secs(180));
```

## 改动

- 为 `AnthropicClient` 添加 `with_timeout()` 方法
- 为 `OpenAIClient` 添加 `with_timeout()` 方法
- 默认超时保持 120 秒（向后兼容）
- 添加文档说明使用场景

## 验证

- ✅ `cargo check -p lattice-llm-anthropic -p lattice-llm-openai` 通过
- ✅ `cargo clippy` 零警告
- ✅ 向后兼容（默认值不变）

## 关联 Issue

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)