### PR TITLE
feat: add graceful shutdown to server

### DIFF
--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -35,12 +35,40 @@ async fn main() -> anyhow::Result<()> {
     // Print startup banner.
     print_banner(addr);
 
-    // Start the server.
+    // Start the server with graceful shutdown.
     let listener = tokio::net::TcpListener::bind(addr).await?;
     info!(%addr, "server listening");
-    axum::serve(listener, app).await?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
 
+    info!("server shut down gracefully");
     Ok(())
+}
+
+/// Waits for a shutdown signal (Ctrl-C on all platforms, SIGTERM on Unix).
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl-C handler");
+    };
+
+    #[cfg(unix)]
+    let sigterm = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let sigterm = std::future::pending::<()>();
+
+    tokio::select! {
+        () = ctrl_c => { info!("received SIGINT, shutting down"); }
+        () = sigterm => { info!("received SIGTERM, shutting down"); }
+    }
 }
 
 fn print_banner(addr: SocketAddr) {


### PR DESCRIPTION
## 问题

Server 没有处理关闭信号，收到 SIGTERM 或 SIGINT 时：
- 活跃的 HTTP 连接被强制断开
- 正在运行的 ControlLoop 任务被直接 kill
- 没有机会刷新日志或清理状态

## 修复

使用 `axum::serve().with_graceful_shutdown()` 添加优雅关闭支持：

- **Ctrl-C (SIGINT)**: 所有平台支持
- **SIGTERM**: Unix 平台支持（Windows 使用 `pending()` 占位）

```rust
axum::serve(listener, app)
    .with_graceful_shutdown(shutdown_signal())
    .await?;
```

## 跨平台处理

```rust
#[cfg(unix)]
let sigterm = async { /* tokio::signal::unix */ };

#[cfg(not(unix))]
let sigterm = std::future::pending::<()>();  // Windows 不支持 SIGTERM
```

## 改动

- `crates/server/src/main.rs` — 添加 `shutdown_signal()` 函数，更新 `axum::serve` 调用

## 验证

- ✅ `cargo check -p lattice-server` 通过（Windows + Linux）
- ✅ `cargo clippy -- -D warnings` 通过
- ✅ 跨平台兼容（`#[cfg(unix)]` / `#[cfg(not(unix))]`）

## 关联 Issue

Fixes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)