### PR TITLE
fix: skip Thinking events in LLM conversation history

### DIFF
--- a/crates/llm-protocol/src/convert.rs
+++ b/crates/llm-protocol/src/convert.rs
@@ -18,10 +18,10 @@ pub fn events_to_messages(events: &[Event]) -> Vec<Message> {
             EventPayload::UserMessage { content } => {
                 messages.push(Message::text(Role::User, content.clone()));
             }
-            EventPayload::Thinking { reasoning } => {
-                // Thinking is emitted as assistant text so the LLM can see
-                // its own prior reasoning chain.
-                messages.push(Message::text(Role::Assistant, reasoning.clone()));
+            EventPayload::Thinking { .. } => {
+                // Internal reasoning — do not include in LLM messages.
+                // The event is preserved in the store for debugging/audit,
+                // but the LLM does not need to see its own prior reasoning.
             }
             EventPayload::ToolCallRequested { tool, params } => {
                 let id = event.event_id.to_string();
@@ -304,6 +304,31 @@ mod tests {
                 assert_eq!(tool_use_id, &second_tool_event_id.to_string());
             }
             _ => panic!("expected second tool result block"),
+        }
+    }
+
+    #[test]
+    fn test_thinking_events_skipped() {
+        let events = vec![
+            make_event(EventPayload::UserMessage {
+                content: "What is 2+2?".into(),
+            }),
+            make_event(EventPayload::Thinking {
+                reasoning: "I need to calculate 2+2. The answer is 4.".into(),
+            }),
+            make_event(EventPayload::FinalAnswer { answer: "4".into() }),
+        ];
+        let messages = events_to_messages(&events);
+
+        // Should only have UserMessage and FinalAnswer, Thinking is skipped
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].role, Role::User);
+        assert_eq!(messages[1].role, Role::Assistant);
+
+        // Verify the assistant message is the FinalAnswer, not the Thinking
+        match &messages[1].content[0] {
+            ContentBlock::Text { text } => assert_eq!(text, "4"),
+            _ => panic!("expected text block"),
         }
     }
 


### PR DESCRIPTION
## 问题

`Thinking` 事件被转换成 assistant 消息并发送回 LLM，导致：

1. **对话污染** - LLM 看到自己的内部推理，就像之前的回复一样
2. **Token 浪费** - 推理文本膨胀对话历史，但对下一次决策没有价值
3. **行为漂移** - LLM 可能尝试继续或引用自己的推理，导致输出混乱

### 当前行为

事件日志：
```
[System] SessionCreated
[System] UserMessage: "What is 2+2?"
[LLM]    Thinking: "I need to calculate 2+2. The answer is 4."
[LLM]    FinalAnswer: "4"
```

转换成消息：
```
User: "What is 2+2?"
Assistant: "I need to calculate 2+2. The answer is 4."  ← thinking 泄漏
Assistant: "4"
```

LLM 现在看到两条连续的 assistant 消息，第一条是从未向用户显示的内部推理。

## 修复

在 `events_to_messages()` 中跳过 `Thinking` 事件：

```rust
EventPayload::Thinking { .. } => {
    // Internal reasoning — do not include in LLM messages.
    // The event is preserved in the store for debugging/audit,
    // but the LLM does not need to see its own prior reasoning.
}
```

这是安全的，因为：
- Thinking 事件仍然保存在 store 中用于调试/审计
- LLM 不需要看到自己之前的推理来做下一次决策
- 现代 LLM（如 Claude extended thinking）在内部处理推理链

## 改动

- `crates/llm-protocol/src/convert.rs` - 跳过 Thinking 事件转换
- 添加测试验证 Thinking 事件被正确跳过

## 验证

- ✅ `cargo test -p lattice-llm-protocol` 通过（22 个测试）
- ✅ 新增测试 `test_thinking_events_skipped` 通过
- ✅ `cargo clippy -- -D warnings` 通过

## 关联 Issue

Fixes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)