### PR TITLE
fix: decouple lattice-tools bash feature from local sandbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -979,7 +979,6 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "lattice-core",
- "lattice-sandbox-local",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -8,11 +8,10 @@ rust-version.workspace = true
 
 [features]
 default = ["bash"]
-bash = ["lattice-sandbox-local"]
+bash = []
 
 [dependencies]
 lattice-core = { path = "../core" }
-lattice-sandbox-local = { path = "../sandbox-local", optional = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/tools/src/set.rs
+++ b/crates/tools/src/set.rs
@@ -36,7 +36,15 @@ impl ToolSet {
     /// - `BashTool` (if the `bash` feature is enabled)
     #[must_use]
     pub fn with_defaults(sandbox: Arc<dyn Sandbox>) -> Self {
+        #[cfg(feature = "bash")]
         let mut set = Self::new();
+
+        #[cfg(not(feature = "bash"))]
+        let set = {
+            let _ = sandbox;
+            Self::new()
+        };
+
         #[cfg(feature = "bash")]
         set.register(crate::bash::BashTool::new(sandbox))
             .expect("bash tool registration should not fail");


### PR DESCRIPTION
﻿## Summary
- decouple the `bash` feature in `lattice-tools` from `lattice-sandbox-local`
- remove the unused direct dependency on `lattice-sandbox-local` from `lattice-tools`
- keep `ToolSet::with_defaults()` warning-free when `bash` is not compiled

## Problem
Issue #36 points out that `BashTool` already depends on the `Sandbox` trait, but the crate manifest still forced `bash` to pull in `lattice-sandbox-local` at compile time. That made the abstraction misleading and blocked reuse with alternative sandbox implementations.

## Verification
- `cargo test -p lattice-tools -q`
- `cargo check -p lattice-tools --no-default-features -q`
- `cargo test --workspace -q`

Closes #36
