### PR TITLE
chore: align local coverage validation with CI

### DIFF
--- a/scripts/check.ps1
+++ b/scripts/check.ps1
@@ -10,11 +10,20 @@ cargo clippy --workspace --all-targets --all-features -- -D warnings
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 Write-Host "Running cargo test..." -ForegroundColor Cyan
-cargo test --workspace
+cargo test --workspace --all-targets --all-features
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
+if (Get-Command cargo-llvm-cov -ErrorAction SilentlyContinue) {
+    Write-Host "Running cargo llvm-cov..." -ForegroundColor Cyan
+    cargo llvm-cov test --workspace --all-features --lcov --output-path lcov.info -- --nocapture
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    Write-Host "Coverage report: lcov.info" -ForegroundColor Green
+} else {
+    Write-Host "Skipping local coverage validation because cargo-llvm-cov is not installed." -ForegroundColor Yellow
+}
+
 Write-Host "Running cargo doc..." -ForegroundColor Cyan
-cargo doc --workspace --no-deps --document-private-items
+cargo doc --no-deps --all-features
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 Write-Host "All checks passed!" -ForegroundColor Green

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -19,8 +19,12 @@ cargo test --workspace --all-targets --all-features
 if command -v cargo-llvm-cov &> /dev/null; then
     echo ""
     echo "=== 3.5/4 Coverage ==="
-    cargo llvm-cov test --workspace --all-features -- --nocapture
-    cargo llvm-cov report --lcov
+    cargo llvm-cov test --workspace --all-features --lcov --output-path lcov.info -- --nocapture
+    echo "Coverage report: lcov.info"
+else
+    echo ""
+    echo "=== 3.5/4 Coverage skipped ==="
+    echo "cargo-llvm-cov not installed; skipping local coverage validation."
 fi
 
 echo ""


### PR DESCRIPTION
﻿## Summary
- align local coverage validation with the CI coverage job output format
- teach `scripts/check.ps1` to run optional `cargo llvm-cov` validation and emit `lcov.info`
- make `scripts/check.sh` use the same single-step `cargo llvm-cov ... --lcov --output-path lcov.info` flow as CI

## Problem
Issue #35 calls out that the coverage pipeline required repeated CI-only fixes. The local check scripts did not fully mirror the coverage flow used in CI:
- PowerShell had no local coverage validation at all
- the Unix script generated coverage in a different way from CI and did not produce the same `lcov.info` artifact directly

## Verification
- `cargo test --workspace --all-targets --all-features -q`
- `cargo doc --no-deps --all-features -q`
- `cargo llvm-cov test --workspace --all-features --lcov --output-path lcov.info -- --nocapture`

Closes #35
