### PR TITLE
fix: preserve structured tool error kinds in events

### DIFF
--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -4,7 +4,7 @@
 
 use thiserror::Error;
 
-use crate::event::SessionId;
+use crate::event::{SessionId, ToolErrorKind};
 
 /// Error from the session store.
 #[derive(Debug, Clone, Error)]
@@ -75,10 +75,24 @@ pub enum ToolError {
     Other(String),
 }
 
+impl ToolError {
+    #[must_use]
+    pub fn kind(&self) -> ToolErrorKind {
+        match self {
+            Self::NotFound(_) => ToolErrorKind::NotFound,
+            Self::InvalidParams(_) => ToolErrorKind::InvalidParams,
+            Self::ExecutionFailed(_) => ToolErrorKind::ExecutionFailed,
+            Self::Timeout { .. } => ToolErrorKind::Timeout,
+            Self::Other(_) => ToolErrorKind::Other,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::StoreError;
     use super::{LLMError, SandboxError, ToolError};
+    use crate::ToolErrorKind;
 
     #[test]
     fn test_store_error_display() {
@@ -139,5 +153,29 @@ mod tests {
 
         let err = ToolError::Other("misc".to_string());
         assert_eq!(err.to_string(), "tool error: misc");
+    }
+
+    #[test]
+    fn test_tool_error_kind_mapping() {
+        assert_eq!(
+            ToolError::NotFound("bash".to_string()).kind(),
+            ToolErrorKind::NotFound
+        );
+        assert_eq!(
+            ToolError::InvalidParams("missing key".to_string()).kind(),
+            ToolErrorKind::InvalidParams
+        );
+        assert_eq!(
+            ToolError::ExecutionFailed("segfault".to_string()).kind(),
+            ToolErrorKind::ExecutionFailed
+        );
+        assert_eq!(
+            ToolError::Timeout { timeout_secs: 60 }.kind(),
+            ToolErrorKind::Timeout
+        );
+        assert_eq!(
+            ToolError::Other("misc".to_string()).kind(),
+            ToolErrorKind::Other
+        );
     }
 }

--- a/crates/core/src/event.rs
+++ b/crates/core/src/event.rs
@@ -27,7 +27,36 @@ pub enum Actor {
     Sandbox,
 }
 
-/// Event payload — all possible events in the system.
+/// Structured category for tool execution failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolErrorKind {
+    /// Tool name was not found in the registry.
+    NotFound,
+    /// Tool parameters failed validation.
+    InvalidParams,
+    /// Tool execution failed after starting.
+    ExecutionFailed,
+    /// Tool execution exceeded a timeout.
+    Timeout,
+    /// Fallback for uncategorized errors.
+    Other,
+}
+
+impl ToolErrorKind {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NotFound => "not_found",
+            Self::InvalidParams => "invalid_params",
+            Self::ExecutionFailed => "execution_failed",
+            Self::Timeout => "timeout",
+            Self::Other => "other",
+        }
+    }
+}
+
+/// Event payload - all possible events in the system.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum EventPayload {
@@ -49,7 +78,10 @@ pub enum EventPayload {
         exit_code: i32,
     },
     /// Tool call failed.
-    ToolCallError { error: String },
+    ToolCallError {
+        error: String,
+        error_kind: ToolErrorKind,
+    },
     /// LLM gave a final answer.
     FinalAnswer { answer: String },
     /// Session state changed.
@@ -107,6 +139,7 @@ mod tests {
             },
             EventPayload::ToolCallError {
                 error: "not found".to_string(),
+                error_kind: ToolErrorKind::NotFound,
             },
             EventPayload::FinalAnswer {
                 answer: "the answer".to_string(),
@@ -150,7 +183,7 @@ mod tests {
             content: "hello".to_string(),
         };
         let json = serde_json::to_string(&payload).unwrap();
-        assert!(json.contains(r#""type":"userMessage"#));
+        assert!(json.contains(r#""type":"userMessage""#));
         assert!(json.contains(r#""content":"hello""#));
     }
 
@@ -176,6 +209,18 @@ mod tests {
         assert!(json.contains(r#""type":"toolCallResult""#));
         assert!(json.contains(r#""stdout":"output""#));
         assert!(json.contains(r#""exit_code":0"#));
+    }
+
+    #[test]
+    fn test_tool_call_error_kind_tagged_format() {
+        let payload = EventPayload::ToolCallError {
+            error: "missing command".to_string(),
+            error_kind: ToolErrorKind::InvalidParams,
+        };
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(json.contains(r#""type":"toolCallError""#));
+        assert!(json.contains(r#""error":"missing command""#));
+        assert!(json.contains(r#""error_kind":"invalid_params""#));
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -27,7 +27,7 @@ pub mod filter {
 
 // Re-exports for convenience.
 pub use error::{LLMError, SandboxError, StoreError, ToolError};
-pub use event::{Actor, Event, EventId, EventPayload, SessionId, Timestamp};
+pub use event::{Actor, Event, EventId, EventPayload, SessionId, Timestamp, ToolErrorKind};
 pub use filter::EventFilter;
 pub use llm::{Decision, LLMClient};
 pub use sandbox::{ExecutionResult, Sandbox};

--- a/crates/llm-protocol/src/convert.rs
+++ b/crates/llm-protocol/src/convert.rs
@@ -50,13 +50,13 @@ pub fn events_to_messages(events: &[Event]) -> Vec<Message> {
                     }],
                 });
             }
-            EventPayload::ToolCallError { error } => {
+            EventPayload::ToolCallError { error, error_kind } => {
                 let tool_use_id = tool_use_id_from_parent(event);
                 messages.push(Message {
                     role: Role::Tool,
                     content: vec![ContentBlock::ToolResult {
                         tool_use_id,
-                        content: error.clone(),
+                        content: format_tool_error(error_kind.as_str(), error),
                         is_error: true,
                     }],
                 });
@@ -102,6 +102,10 @@ fn format_tool_result(stdout: &str, stderr: &str, exit_code: i32) -> String {
     }
     parts.push(format!("exit_code: {exit_code}"));
     parts.join("\n")
+}
+
+fn format_tool_error(error_kind: &str, error: &str) -> String {
+    format!("error_kind: {error_kind}\nmessage: {error}")
 }
 
 #[cfg(test)]
@@ -225,6 +229,7 @@ mod tests {
             make_event_with_parent(
                 EventPayload::ToolCallError {
                     error: "command not found".into(),
+                    error_kind: lattice_core::ToolErrorKind::NotFound,
                 },
                 Some(tool_event_id),
             ),
@@ -238,7 +243,7 @@ mod tests {
                 is_error,
             } => {
                 assert_eq!(tool_use_id, &tool_event_id.to_string());
-                assert_eq!(content, "command not found");
+                assert_eq!(content, "error_kind: not_found\nmessage: command not found");
                 assert!(is_error);
             }
             _ => panic!("expected tool result block"),

--- a/crates/runtime/src/control_loop.rs
+++ b/crates/runtime/src/control_loop.rs
@@ -185,12 +185,14 @@ impl ControlLoop {
                         Err(e) => {
                             warn!("tool execution failed: {}", e);
                             let error_str = e.to_string();
+                            let error_kind = e.kind();
                             let error_event_id = self
                                 .store
                                 .append_event(
                                     session_id,
                                     EventPayload::ToolCallError {
                                         error: error_str.clone(),
+                                        error_kind,
                                     },
                                     Actor::Sandbox,
                                     Some(req_event_id),
@@ -204,7 +206,10 @@ impl ControlLoop {
                                 session_id,
                                 timestamp: chrono::Utc::now(),
                                 actor: Actor::Sandbox,
-                                payload: EventPayload::ToolCallError { error: error_str },
+                                payload: EventPayload::ToolCallError {
+                                    error: error_str,
+                                    error_kind,
+                                },
                                 parent_event_id: Some(req_event_id),
                             });
                         }
@@ -285,12 +290,14 @@ impl ControlLoop {
                             Err(e) => {
                                 warn!("tool execution failed: {}", e);
                                 let error_str = e.to_string();
+                                let error_kind = e.kind();
                                 let error_event_id = self
                                     .store
                                     .append_event(
                                         session_id,
                                         EventPayload::ToolCallError {
                                             error: error_str.clone(),
+                                            error_kind,
                                         },
                                         Actor::Sandbox,
                                         Some(req_event_id),
@@ -303,7 +310,10 @@ impl ControlLoop {
                                     session_id,
                                     timestamp: chrono::Utc::now(),
                                     actor: Actor::Sandbox,
-                                    payload: EventPayload::ToolCallError { error: error_str },
+                                    payload: EventPayload::ToolCallError {
+                                        error: error_str,
+                                        error_kind,
+                                    },
                                     parent_event_id: Some(req_event_id),
                                 });
                             }
@@ -729,12 +739,18 @@ mod tests {
             .get_events(session_id, &EventFilter::default())
             .await
             .unwrap();
-        let has_error = events
-            .iter()
-            .any(|e| matches!(e.payload, EventPayload::ToolCallError { .. }));
+        let error_event = events.iter().find(|e| {
+            matches!(
+                e.payload,
+                EventPayload::ToolCallError {
+                    error_kind: lattice_core::ToolErrorKind::NotFound,
+                    ..
+                }
+            )
+        });
         assert!(
-            has_error,
-            "expected ToolCallError in event log, got: {:?}",
+            error_event.is_some(),
+            "expected ToolCallError(NotFound) in event log, got: {:?}",
             events
         );
     }

--- a/examples/real-agent/src/main.rs
+++ b/examples/real-agent/src/main.rs
@@ -149,8 +149,12 @@ async fn run(task: String) -> Result<()> {
                     truncate(stderr, 40)
                 )
             }
-            EventPayload::ToolCallError { error } => {
-                format!("ToolError: {}", truncate(error, 80))
+            EventPayload::ToolCallError { error, error_kind } => {
+                format!(
+                    "ToolError: kind={} message={}",
+                    error_kind.as_str(),
+                    truncate(error, 80)
+                )
             }
             EventPayload::FinalAnswer { answer } => {
                 format!("FinalAnswer: {}", truncate(answer, 80))


### PR DESCRIPTION
﻿## Summary
- add structured `ToolErrorKind` metadata to `EventPayload::ToolCallError`
- preserve the original human-readable error message while recording the error kind in runtime events
- include the structured error kind when converting tool failures back into LLM-visible tool results

## Problem
Issue #32 points out that tool failures were flattened to plain strings when recorded as `ToolCallError` events. That discarded the distinction between not-found, invalid-params, execution-failed, timeout, and other error classes.

## Fix
- added `ToolErrorKind` to `lattice-core` and exposed `ToolError::kind()` for consistent mapping
- changed `EventPayload::ToolCallError` to carry both `error` and `error_kind`
- updated `ControlLoop` to record structured error kinds for both single-tool and multi-tool failures
- updated `llm-protocol` formatting so LLM-visible tool errors include both `error_kind` and `message`
- updated the real-agent example output and tests accordingly

## Verification
- `cargo test -p lattice-core -q`
- `cargo test -p lattice-llm-protocol -q`
- `cargo test -p lattice-runtime -q`
- `cargo test --workspace -q`

Closes #32
