### PR TITLE
feat(store): add time-range event filters

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -13,15 +13,23 @@ pub mod tool;
 pub mod filter {
     //! Event filtering types.
 
-    use crate::event::Actor;
+    use crate::event::{Actor, EventId, Timestamp};
 
     /// Filter for querying events from a SessionStore.
     #[derive(Debug, Clone, Default)]
     pub struct EventFilter {
         /// Filter by actor type.
         pub actor: Option<Actor>,
-        /// Filter by event payload variant name (e.g. "ToolCallRequested").
+        /// Filter by event payload variant name (e.g. "toolCallRequested").
         pub payload_type: Option<&'static str>,
+        /// Return events after this event id.
+        pub after_event_id: Option<EventId>,
+        /// Return events at or after this timestamp.
+        pub since: Option<Timestamp>,
+        /// Return events at or before this timestamp.
+        pub until: Option<Timestamp>,
+        /// Maximum number of events to return.
+        pub limit: Option<usize>,
     }
 }
 

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -29,6 +29,10 @@ pub struct EventQuery {
     pub event_type: Option<String>,
     /// Return events after this event id (cursor-based pagination).
     pub after: Option<EventId>,
+    /// Return events at or after this timestamp.
+    pub since: Option<chrono::DateTime<chrono::Utc>>,
+    /// Return events at or before this timestamp.
+    pub until: Option<chrono::DateTime<chrono::Utc>>,
     /// Maximum number of events to return (default 100).
     #[serde(default = "default_limit")]
     pub limit: usize,
@@ -226,60 +230,37 @@ async fn get_events(
         }
     }
 
-    // Build the store filter (actor only — payload_type/after/limit are post-filtered in memory).
-    let mut filter = EventFilter::default();
-    if let Some(actor) = query.actor {
-        filter.actor = Some(actor);
+    let payload_type = query
+        .event_type
+        .as_deref()
+        .and_then(payload_type_from_query);
+    if query.event_type.is_some() && payload_type.is_none() {
+        return Ok(Json(EventListResponse {
+            events: Vec::new(),
+            has_more: false,
+        }));
     }
+    let filter = EventFilter {
+        actor: query.actor,
+        payload_type,
+        after_event_id: query.after,
+        since: query.since,
+        until: query.until,
+        limit: Some(query.limit.saturating_add(1)),
+    };
 
-    let all_events = state
+    let events = state
         .store
         .get_events(session_id, &filter)
         .await
         .map_err(|e| AppError::InternalError(e.to_string()))?;
 
-    // Post-filter by event type (payload_type is not in EventFilter yet).
-    // The serialized tag matches serde's rename_all = "camelCase" on the enum.
-    let all_events = if let Some(ref et) = query.event_type {
-        all_events
-            .into_iter()
-            .filter(|e| {
-                let type_name = match &e.payload {
-                    lattice_core::EventPayload::SessionCreated => "sessionCreated",
-                    lattice_core::EventPayload::UserMessage { .. } => "userMessage",
-                    lattice_core::EventPayload::Thinking { .. } => "thinking",
-                    lattice_core::EventPayload::ToolCallRequested { .. } => "toolCallRequested",
-                    lattice_core::EventPayload::ToolCallResult { .. } => "toolCallResult",
-                    lattice_core::EventPayload::ToolCallError { .. } => "toolCallError",
-                    lattice_core::EventPayload::FinalAnswer { .. } => "finalAnswer",
-                    lattice_core::EventPayload::StateChange { .. } => "stateChange",
-                };
-                type_name == et
-            })
-            .collect::<Vec<_>>()
-    } else {
-        all_events
-    };
-
-    // Post-filter by `after` cursor.
-    let events: Vec<EventResponse> = if let Some(after_id) = query.after {
-        all_events
-            .into_iter()
-            .skip_while(|e| e.event_id != after_id)
-            .skip(1) // skip the `after` event itself
-            .take(query.limit + 1)
-            .map(EventResponse::from)
-            .collect()
-    } else {
-        all_events
-            .into_iter()
-            .take(query.limit + 1)
-            .map(EventResponse::from)
-            .collect()
-    };
-
     let has_more = events.len() > query.limit;
-    let events = events.into_iter().take(query.limit).collect::<Vec<_>>();
+    let events = events
+        .into_iter()
+        .take(query.limit)
+        .map(EventResponse::from)
+        .collect::<Vec<_>>();
 
     Ok(Json(EventListResponse { events, has_more }))
 }
@@ -718,6 +699,20 @@ fn done_event(session_id: SessionId) -> SseEvent {
         "status": "completed",
     });
     SseEvent::default().event("done").data(data.to_string())
+}
+
+fn payload_type_from_query(event_type: &str) -> Option<&'static str> {
+    match event_type {
+        "sessionCreated" => Some("sessionCreated"),
+        "userMessage" => Some("userMessage"),
+        "thinking" => Some("thinking"),
+        "toolCallRequested" => Some("toolCallRequested"),
+        "toolCallResult" => Some("toolCallResult"),
+        "toolCallError" => Some("toolCallError"),
+        "finalAnswer" => Some("finalAnswer"),
+        "stateChange" => Some("stateChange"),
+        _ => None,
+    }
 }
 
 async fn session_has_terminal_event(

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -329,8 +329,13 @@ mod tests {
     use async_trait::async_trait;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
-    use lattice_core::{Decision, Event, LLMError, ToolDescription};
+    use chrono::{Duration, SecondsFormat, Timelike};
+    use lattice_core::{
+        Actor, Decision, Event, EventFilter, EventId, EventPayload, LLMError, SessionId,
+        StoreError, ToolDescription,
+    };
     use std::sync::Mutex;
+    use tokio::sync::RwLock;
     use tower::ServiceExt;
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -338,6 +343,102 @@ mod tests {
     fn make_app() -> Router {
         let store = Arc::new(lattice_store_memory::MemoryStore::new());
         router(new_state(store))
+    }
+
+    struct FixedStore {
+        session_id: SessionId,
+        events: Vec<Event>,
+        last_filter: RwLock<Option<EventFilter>>,
+    }
+
+    impl FixedStore {
+        fn new(session_id: SessionId, events: Vec<Event>) -> Self {
+            Self {
+                session_id,
+                events,
+                last_filter: RwLock::new(None),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl lattice_core::SessionStore for FixedStore {
+        async fn create_session(&self) -> Result<SessionId, StoreError> {
+            Ok(self.session_id)
+        }
+
+        async fn delete_session(&self, session_id: SessionId) -> Result<(), StoreError> {
+            if session_id == self.session_id {
+                Ok(())
+            } else {
+                Err(StoreError::SessionNotFound(session_id))
+            }
+        }
+
+        async fn append_event(
+            &self,
+            _session_id: SessionId,
+            _payload: EventPayload,
+            _actor: Actor,
+            _parent_event_id: Option<EventId>,
+        ) -> Result<EventId, StoreError> {
+            panic!("append_event not used in this test")
+        }
+
+        async fn get_events(
+            &self,
+            session_id: SessionId,
+            filter: &EventFilter,
+        ) -> Result<Vec<Event>, StoreError> {
+            if session_id != self.session_id {
+                return Err(StoreError::SessionNotFound(session_id));
+            }
+
+            *self.last_filter.write().await = Some(filter.clone());
+
+            let mut events = self.events.clone();
+            if let Some(actor) = filter.actor {
+                events.retain(|event| event.actor == actor);
+            }
+            if let Some(payload_type) = filter.payload_type {
+                events.retain(|event| {
+                    let json = serde_json::to_value(&event.payload).ok();
+                    json.as_ref()
+                        .and_then(|value| value.get("type"))
+                        .and_then(|value| value.as_str())
+                        .is_some_and(|value| value == payload_type)
+                });
+            }
+            if let Some(after_event_id) = filter.after_event_id {
+                events = events
+                    .into_iter()
+                    .skip_while(|event| event.event_id != after_event_id)
+                    .skip(1)
+                    .collect();
+            }
+            if let Some(since) = filter.since {
+                events.retain(|event| event.timestamp >= since);
+            }
+            if let Some(until) = filter.until {
+                events.retain(|event| event.timestamp <= until);
+            }
+            if let Some(limit) = filter.limit {
+                events.truncate(limit);
+            }
+
+            Ok(events)
+        }
+
+        async fn latest_event_id(
+            &self,
+            session_id: SessionId,
+        ) -> Result<Option<EventId>, StoreError> {
+            if session_id != self.session_id {
+                return Err(StoreError::SessionNotFound(session_id));
+            }
+
+            Ok(self.events.last().map(|event| event.event_id))
+        }
     }
 
     struct TestLlm {
@@ -1095,5 +1196,112 @@ mod tests {
         let evts: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert!(evts["events"].as_array().unwrap().is_empty());
         assert!(!evts["hasMore"].as_bool().unwrap());
+    }
+
+    #[tokio::test]
+    async fn get_events_with_time_range_filters() {
+        let base = Utc::now().with_nanosecond(0).unwrap();
+        let session_id = SessionId::new_v4();
+        let after_event_id = EventId::new_v4();
+        let store = Arc::new(FixedStore::new(
+            session_id,
+            vec![
+                Event {
+                    event_id: EventId::new_v4(),
+                    session_id,
+                    timestamp: base,
+                    actor: Actor::System,
+                    payload: EventPayload::SessionCreated,
+                    parent_event_id: None,
+                },
+                Event {
+                    event_id: after_event_id,
+                    session_id,
+                    timestamp: base + Duration::seconds(10),
+                    actor: Actor::Harness,
+                    payload: EventPayload::UserMessage {
+                        content: "first".into(),
+                    },
+                    parent_event_id: None,
+                },
+                Event {
+                    event_id: EventId::new_v4(),
+                    session_id,
+                    timestamp: base + Duration::seconds(20),
+                    actor: Actor::LLM,
+                    payload: EventPayload::Thinking {
+                        reasoning: "second".into(),
+                    },
+                    parent_event_id: None,
+                },
+                Event {
+                    event_id: EventId::new_v4(),
+                    session_id,
+                    timestamp: base + Duration::seconds(30),
+                    actor: Actor::LLM,
+                    payload: EventPayload::FinalAnswer {
+                        answer: "third".into(),
+                    },
+                    parent_event_id: None,
+                },
+            ],
+        ));
+        let state = new_state(store.clone());
+        state.sessions.write().await.push(SessionInfo {
+            session_id,
+            created_at: base,
+            metadata: None,
+        });
+        let app = router(state);
+        let since = (base + Duration::seconds(15)).to_rfc3339_opts(SecondsFormat::Secs, true);
+        let until = (base + Duration::seconds(25)).to_rfc3339_opts(SecondsFormat::Secs, true);
+
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/v1/sessions/{session_id}/events?after={after_event_id}&since={since}&until={until}"
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();
+        let evts: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let events = evts["events"].as_array().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0]["payload"]["type"], "thinking");
+        assert!(!evts["hasMore"].as_bool().unwrap());
+        let first_filter = store.last_filter.read().await.clone().unwrap();
+        assert_eq!(first_filter.after_event_id, Some(after_event_id));
+        assert_eq!(first_filter.since, Some(base + Duration::seconds(15)));
+        assert_eq!(first_filter.until, Some(base + Duration::seconds(25)));
+        assert_eq!(first_filter.limit, Some(101));
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/v1/sessions/{session_id}/events?since={since}&until={until}"
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();
+        let evts: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let events = evts["events"].as_array().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0]["payload"]["type"], "thinking");
+        let second_filter = store.last_filter.read().await.clone().unwrap();
+        assert_eq!(second_filter.after_event_id, None);
+        assert_eq!(second_filter.since, Some(base + Duration::seconds(15)));
+        assert_eq!(second_filter.until, Some(base + Duration::seconds(25)));
+        assert_eq!(second_filter.limit, Some(101));
     }
 }

--- a/crates/store-memory/src/memory_store.rs
+++ b/crates/store-memory/src/memory_store.rs
@@ -117,6 +117,26 @@ impl SessionStore for MemoryStore {
             });
         }
 
+        if let Some(after_event_id) = filter.after_event_id {
+            result = result
+                .into_iter()
+                .skip_while(|e| e.event_id != after_event_id)
+                .skip(1)
+                .collect();
+        }
+
+        if let Some(since) = filter.since {
+            result.retain(|e| e.timestamp >= since);
+        }
+
+        if let Some(until) = filter.until {
+            result.retain(|e| e.timestamp <= until);
+        }
+
+        if let Some(limit) = filter.limit {
+            result.truncate(limit);
+        }
+
         Ok(result)
     }
 
@@ -133,6 +153,7 @@ impl SessionStore for MemoryStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Duration;
     use lattice_core::EventPayload;
 
     #[tokio::test]
@@ -234,6 +255,10 @@ mod tests {
                 &EventFilter {
                     actor: Some(Actor::LLM),
                     payload_type: None,
+                    after_event_id: None,
+                    since: None,
+                    until: None,
+                    limit: None,
                 },
             )
             .await
@@ -286,6 +311,10 @@ mod tests {
                 &EventFilter {
                     actor: None,
                     payload_type: Some("thinking"),
+                    after_event_id: None,
+                    since: None,
+                    until: None,
+                    limit: None,
                 },
             )
             .await
@@ -298,11 +327,83 @@ mod tests {
                 &EventFilter {
                     actor: None,
                     payload_type: Some("toolCallRequested"),
+                    after_event_id: None,
+                    since: None,
+                    until: None,
+                    limit: None,
                 },
             )
             .await
             .unwrap();
         assert_eq!(tool_events.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_filter_by_time_range_after_and_limit() {
+        let store = MemoryStore::new();
+        let id = store.create_session().await.unwrap();
+
+        let first_id = store
+            .append_event(
+                id,
+                EventPayload::UserMessage {
+                    content: "first".to_string(),
+                },
+                Actor::Harness,
+                None,
+            )
+            .await
+            .unwrap();
+        store
+            .append_event(
+                id,
+                EventPayload::Thinking {
+                    reasoning: "second".to_string(),
+                },
+                Actor::LLM,
+                None,
+            )
+            .await
+            .unwrap();
+        store
+            .append_event(
+                id,
+                EventPayload::FinalAnswer {
+                    answer: "third".to_string(),
+                },
+                Actor::LLM,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let base = Utc::now();
+        {
+            let mut sessions = store.sessions.write().await;
+            let events = sessions.get_mut(&id).unwrap();
+            events[0].timestamp = base;
+            events[1].timestamp = base + Duration::seconds(10);
+            events[2].timestamp = base + Duration::seconds(20);
+            events[3].timestamp = base + Duration::seconds(30);
+        }
+
+        let filtered = store
+            .get_events(
+                id,
+                &EventFilter {
+                    actor: None,
+                    payload_type: None,
+                    after_event_id: Some(first_id),
+                    since: Some(base + Duration::seconds(15)),
+                    until: Some(base + Duration::seconds(30)),
+                    limit: Some(1),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(filtered.len(), 1);
+        assert!(matches!(filtered[0].payload, EventPayload::Thinking { .. }));
     }
 
     #[tokio::test]


### PR DESCRIPTION
﻿## Summary
- extend `EventFilter` with `after_event_id`, `since`, `until`, and `limit`
- move event pagination and time-range filtering into `MemoryStore`
- simplify the session events handler to translate query params into store filters
- add store and server tests covering cursor + time-range behavior

## Verification
- cargo test -p lattice-store-memory -q
- cargo test -p lattice-server -q
- cargo test --workspace -q

Closes #39
