### PR TITLE
docs: sync architecture docs with current code state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ crates/
 ├── llm-anthropic/    # LLMClient 的 Anthropic Claude 实现
 ├── llm-openai/       # LLMClient 的 OpenAI 兼容实现
 ├── tools/            # 标准工具库（bash, file, glob, grep, http）
-├── skill/            # Skill 系统（SkillTool、SkillToolSet、SkillLoader）
+├── mcp/              # MCP 客户端（McpClientManager、McpToolAdapter）
 ├── server/           # HTTP API 服务（axum），平台服务入口
 
 # Facade crate（根目录 src/lib.rs）
@@ -52,9 +52,12 @@ lattice               # 通过 feature flags 重导出所有子 crate
 
 | Crate | CLAUDE.md |
 |-------|-----------|
+| `core` | [crates/core/CLAUDE.md](crates/core/CLAUDE.md) |
 | `runtime` | [crates/runtime/CLAUDE.md](crates/runtime/CLAUDE.md) |
+| `store-memory` | [crates/store-memory/CLAUDE.md](crates/store-memory/CLAUDE.md) |
+| `sandbox-local` | [crates/sandbox-local/CLAUDE.md](crates/sandbox-local/CLAUDE.md) |
 | `tools` | [crates/tools/CLAUDE.md](crates/tools/CLAUDE.md) |
-| `skill` | [crates/skill/CLAUDE.md](crates/skill/CLAUDE.md) |
+| `mcp` | [crates/mcp/CLAUDE.md](crates/mcp/CLAUDE.md) |
 | `llm-protocol` | [crates/llm-protocol/CLAUDE.md](crates/llm-protocol/CLAUDE.md) |
 | `llm-anthropic` | [crates/llm-anthropic/CLAUDE.md](crates/llm-anthropic/CLAUDE.md) |
 | `llm-openai` | [crates/llm-openai/CLAUDE.md](crates/llm-openai/CLAUDE.md) |

--- a/crates/core/CLAUDE.md
+++ b/crates/core/CLAUDE.md
@@ -1,0 +1,43 @@
+# lattice-core
+
+## Purpose
+
+Pure interface layer for Lattice. Defines all core traits and types with zero external dependencies beyond standard Rust crates (serde, uuid, chrono, async-trait). No feature flags — always compiled in full.
+
+## Key Types
+
+### Traits
+- `SessionStore` — event log persistence. Methods: `create_session`, `delete_session`, `append_event`, `get_events`, `latest_event_id`
+- `LLMClient` — decision making. Single method: `decide(history, available_tools, system_prompt) -> Decision`
+- `Sandbox` — isolated tool execution. Single method: `execute(command, params) -> ExecutionResult`
+- `ToolExecutor` — individual tool implementation. Methods: `description() -> ToolDescription`, `execute(params) -> ExecutionResult`
+
+### Enums
+- `EventPayload` — all event variants: `SessionCreated`, `UserMessage`, `Thinking`, `ToolCallRequested`, `ToolCallResult`, `ToolCallError`, `FinalAnswer`, `StateChange`
+- `Decision` — LLM decision variants: `Thinking`, `ToolCall`, `ThinkingToolCall`, `MultiToolCall`, `FinalAnswer`
+- `Actor` — event producer: `System`, `LLM`, `Harness`, `Sandbox`
+- `ToolErrorKind` — structured tool failure categories: `NotFound`, `InvalidParams`, `ExecutionFailed`, `Timeout`, `Other`
+
+### Structs
+- `Event` — immutable append-only record: `event_id`, `session_id`, `timestamp`, `actor`, `payload`, `parent_event_id`
+- `ToolDescription` — LLM-facing tool spec: `name`, `description`, `parameters_schema`
+- `ToolCallRequest` — single call within a `MultiToolCall`: `id`, `tool`, `params`
+- `ExecutionResult` — tool output: `stdout`, `stderr`, `exit_code`
+- `EventFilter` — query filter for `get_events` (time range, payload type filters)
+
+### Error Types
+- `StoreError` — SessionStore failures
+- `LLMError` — LLMClient failures
+- `SandboxError` — Sandbox failures
+- `ToolError` — ToolExecutor failures
+
+## Design Decisions
+
+- Zero feature flags: core is always fully compiled; optional functionality lives in implementation crates.
+- `ToolErrorKind` is embedded in `EventPayload::ToolCallError` to preserve structured failure information in the event log.
+- `Thinking` in `EventPayload` carries an optional `signature` field for LLM providers (e.g. Anthropic extended thinking) that require round-trip opaque tokens.
+
+## Dependencies
+
+- Depends on: `serde`, `uuid`, `chrono`, `async-trait`
+- Depended on by: all other Lattice crates

--- a/crates/mcp/CLAUDE.md
+++ b/crates/mcp/CLAUDE.md
@@ -1,0 +1,35 @@
+# lattice-mcp
+
+## Purpose
+
+MCP (Model Context Protocol) client integration for Lattice. Provides a multi-server stdio client manager and a `ToolExecutor` adapter that bridges MCP tools into Lattice's tool system.
+
+## Key Types
+
+- `McpClientManager` — manages connections to multiple MCP servers. Spawns stdio subprocesses, tracks connection state, and multiplexes tool calls.
+- `McpToolCallOutput` — result of an MCP tool invocation.
+- `McpToolAdapter` — implements `ToolExecutor`, wrapping a single MCP tool so it can be registered in a `ToolSet`.
+- `ListMcpResourcesTool` / `ReadMcpResourceTool` — `ToolExecutor` implementations for listing and reading MCP resources.
+
+### Config Types
+- `McpJsonConfig` — top-level config (maps server name → `McpServerConfig`)
+- `McpServerConfig` — enum: `Stdio(McpStdioServerConfig)`, `Http(McpHttpServerConfig)`, `WebSocket(McpWebSocketServerConfig)`
+- `McpStdioServerConfig` — command + args + optional env for stdio servers
+- `McpConnectionStatus` / `McpConnectionSnapshot` — observable connection state
+
+### Integration Helpers
+- `load_mcp_server_configs_from_env` / `load_mcp_server_configs_from_path` — load config from `LATTICE_MCP_CONFIG` env var or a JSON file path
+- `load_mcp_manager_from_env` — convenience: load config + construct `McpClientManager`
+- `register_mcp_tools` — register all connected MCP server tools into a `ToolSet`
+- `mcp_tool_name` — canonical tool name used when registering MCP tools (`<server>__<tool>`)
+- `LATTICE_MCP_CONFIG_ENV` — env var name constant (`"LATTICE_MCP_CONFIG"`)
+
+## Design Decisions
+
+- MCP tools are a Layer 3 injection: the application calls `register_mcp_tools` to populate a `ToolSet`, then passes the set to `ControlLoop`. The control loop treats MCP tools identically to built-in tools.
+- Tool names are namespaced as `<server_name>__<tool_name>` to avoid collisions when multiple MCP servers expose tools with the same name.
+
+## Dependencies
+
+- Depends on: `tokio`, `lattice-core` (via `ToolExecutor`)
+- Depended on by: `lattice-server` (optional), application layer

--- a/crates/store-memory/CLAUDE.md
+++ b/crates/store-memory/CLAUDE.md
@@ -1,0 +1,27 @@
+# lattice-store-memory
+
+## Purpose
+
+In-memory implementation of `SessionStore`. Intended for development and testing only — all data is lost on process restart.
+
+## Key Types
+
+- `MemoryStore` — implements `SessionStore` using `Arc<RwLock<HashMap<SessionId, Vec<Event>>>>` for concurrent access.
+
+## Behavior
+
+- `create_session`: allocates a new UUID session and appends an initial `SessionCreated` event.
+- `delete_session`: removes the session and all its events from the map.
+- `append_event`: acquires a write lock and pushes an `Event` with a new UUID and current timestamp.
+- `get_events`: acquires a read lock and applies `EventFilter` in memory.
+- `latest_event_id`: returns the `event_id` of the last event in the session's vec, or `None` if empty.
+
+## Design Decisions
+
+- `Arc<RwLock<...>>` allows `MemoryStore` to be cloned cheaply — all clones share the same underlying map. This is intentional: the server crate creates one store and shares it across request handlers via `Arc`.
+- Not suitable for production. Use a persistent backend (e.g. SQLite, Postgres) for anything that must survive restarts.
+
+## Dependencies
+
+- Depends on: `lattice-core`, `tokio` (RwLock), `chrono`, `uuid`, `async-trait`
+- Depended on by: `lattice-runtime` (tests), `lattice-server`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,28 +57,28 @@ Lattice 的架构灵感来自 Anthropic 的 Managed Agents 博客（*Scaling Man
 
 ```rust
 /// 事件负载
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum EventPayload {
     SessionCreated,
 
     UserMessage { content: String },
 
-    Thinking { reasoning: String },
+    Thinking {
+        reasoning: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        signature: Option<String>,
+    },
 
     ToolCallRequested { tool: String, params: serde_json::Value },
 
     ToolCallResult { stdout: String, stderr: String, exit_code: i32 },
 
-    ToolCallError { error: String },
+    ToolCallError { error: String, error_kind: ToolErrorKind },
 
     FinalAnswer { answer: String },
 
     StateChange { from: String, to: String },
-
-    // — Skill 系统扩展 —
-    SkillInvoked { skill_name: String, child_session_id: SessionId },
-    SkillCompleted { skill_name: String, child_session_id: SessionId },
 }
 
 /// 一个不可变事件
@@ -100,6 +100,8 @@ pub struct Event {
 pub trait SessionStore: Send + Sync {
     async fn create_session(&self) -> Result<SessionId, StoreError>;
 
+    async fn delete_session(&self, session_id: SessionId) -> Result<(), StoreError>;
+
     async fn append_event(
         &self,
         session_id: SessionId,
@@ -115,31 +117,12 @@ pub trait SessionStore: Send + Sync {
     ) -> Result<Vec<Event>, StoreError>;
 
     async fn latest_event_id(&self, session_id: SessionId) -> Result<Option<EventId>, StoreError>;
-
-    // — Skill 系统扩展 —
-    async fn create_child_session(
-        &self,
-        parent_session_id: SessionId,
-        skill_name: &str,
-    ) -> Result<(SessionId, Arc<dyn SessionStore>), StoreError>;
-
-    async fn child_sessions(
-        &self,
-        parent_session_id: SessionId,
-    ) -> Result<Vec<ChildSessionInfo>, StoreError>;
 }
 ```
 
 ### Session Tree（Skill 系统）
 
-Session 支持树形扩展：父 session 调用 skill 时创建子 session，子 session 拥有独立的 SessionStore。父 session 的事件日志记录 `SkillInvoked`/`SkillCompleted` 事件，携带子 session ID，供可观测性查询。
-
-```
-Root SessionStore
-├── session-001 (meta agent)
-│   └── SkillInvoked → session-002 (skill: web-research, 独立 MemoryStore)
-└── session-003 (另一个 meta agent)
-```
+Session 支持树形扩展（规划中）：父 session 调用 skill 时创建子 session，子 session 拥有独立的 SessionStore。
 
 ---
 
@@ -162,7 +145,7 @@ loop {
     4. match 决策:
        - FinalAnswer → 记录结果，退出循环
        - Thinking   → 继续循环
-       - ToolCall   → 构造 ExecutionContext，ToolSet.execute()，记录结果/错误，继续循环
+       - ToolCall   → ToolSet.execute()，记录结果/错误，继续循环
 }
 ```
 
@@ -184,23 +167,24 @@ pub trait LLMClient: Send + Sync {
 pub enum Decision {
     Thinking { reasoning: String },
     ToolCall { tool: String, params: serde_json::Value },
+    /// Thinking text returned alongside a tool call in the same response.
+    /// Used by models like DeepSeek that attach reasoning to tool-call responses.
+    ThinkingToolCall {
+        reasoning: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        signature: Option<String>,
+        tool: String,
+        params: serde_json::Value,
+    },
+    /// Multiple tools to invoke sequentially.
+    MultiToolCall { calls: Vec<ToolCallRequest> },
     FinalAnswer { answer: String },
 }
-```
 
-### ExecutionContext
-
-```rust
-/// Maximum allowed skill nesting depth. A meta agent has depth=0;
-/// its direct skill children have depth=1, and so on.
-pub const MAX_SKILL_DEPTH: u32 = 8;
-
-/// Execution context passed to every tool invocation.
-pub struct ExecutionContext {
-    pub session_id: SessionId,
-    pub trigger_event_id: EventId,
-    pub store: Arc<dyn SessionStore>,
-    pub depth: u32,
+pub struct ToolCallRequest {
+    pub id: String,
+    pub tool: String,
+    pub params: serde_json::Value,
 }
 ```
 
@@ -251,7 +235,6 @@ pub trait ToolExecutor: Send + Sync {
     async fn execute(
         &self,
         params: serde_json::Value,
-        ctx: &ExecutionContext,
     ) -> Result<ExecutionResult, ToolError>;
 }
 ```
@@ -280,7 +263,6 @@ impl ToolSet {
         &self,
         name: &str,
         params: serde_json::Value,
-        ctx: &ExecutionContext,
     ) -> Result<ExecutionResult, ToolError> { ... }
 }
 ```
@@ -370,24 +352,23 @@ llm-protocol = ["dep:lattice-llm-protocol"]
 llm-anthropic = ["llm-protocol", "dep:lattice-llm-anthropic"]
 llm-openai = ["llm-protocol", "dep:lattice-llm-openai"]
 llm-all = ["llm-anthropic", "llm-openai"]
-skill = ["dep:lattice-skill", "tools"]        # Skill 系统
-full = ["runtime", "store-memory", "sandbox-local", "llm-all", "tools", "skill"]
+full = ["runtime", "store-memory", "sandbox-local", "llm-all", "tools"]
 ```
 
 ### Crate 结构
 
 ```
 crates/
-├── core/             # 纯接口：SessionStore, LLMClient, Sandbox, ToolExecutor, ExecutionContext
+├── core/             # 纯接口：SessionStore, LLMClient, Sandbox, ToolExecutor 等所有 trait 和核心类型
 ├── runtime/          # ControlLoop 实现
 ├── store-memory/     # MemoryStore 实现
-├── sandbox-local/   # LocalSandbox 实现（跨平台 shell）
-├── tools/           # ToolSet + 标准工具（BashTool 等）
-├── skill/           # Skill 系统（SkillDefinition, SkillTool, SkillLoader）  # 规划中
-├── llm-protocol/    # LLM 通用协议层
-├── llm-anthropic/   # Anthropic Claude 后端
-├── llm-openai/      # OpenAI 兼容后端
-└── server/          # HTTP API 服务（axum）
+├── sandbox-local/    # LocalSandbox 实现（跨平台 shell）
+├── tools/            # ToolSet + 标准工具（BashTool 等）
+├── mcp/              # MCP 客户端（McpClientManager, McpToolAdapter）
+├── llm-protocol/     # LLM 通用协议层
+├── llm-anthropic/    # Anthropic Claude 后端
+├── llm-openai/       # OpenAI 兼容后端
+└── server/           # HTTP API 服务（axum）
 ```
 
 ---


### PR DESCRIPTION
- Fix EventPayload: add ToolErrorKind to ToolCallError, add signature field to Thinking, remove unimplemented SkillInvoked/SkillCompleted
- Fix SessionStore trait: add delete_session, remove planned Skill extension methods (create_child_session, child_sessions)
- Fix Decision enum: add ThinkingToolCall and MultiToolCall variants, add ToolCallRequest struct
- Remove ExecutionContext section (not yet implemented)
- Fix ToolExecutor/ToolSet::execute signatures: remove ctx param
- Fix feature flags: remove unimplemented skill feature
- Fix crate structure: remove skill crate, add mcp crate
- Add CLAUDE.md for core, store-memory, and mcp crates
- Update root CLAUDE.md crate table: add core, store-memory, mcp, sandbox-local; remove skill